### PR TITLE
fix(obstacle_avoidance_planner): change behavior when optimization fails

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -471,8 +471,13 @@ std::vector<TrajectoryPoint> MPTOptimizer::optimizeTrajectory(
 
   const auto get_prev_optimized_traj_points = [&]() {
     if (prev_optimized_traj_points_ptr_) {
+      RCLCPP_WARN(logger_, "return the previous optimized_trajectory as exceptional behavior.");
       return *prev_optimized_traj_points_ptr_;
     }
+    RCLCPP_WARN(
+      logger_,
+      "Try to return the previous optimized_trajectory as exceptional behavior, "
+      "but this failure also. Then retrun path_smoother output.");
     return smoothed_points;
   };
 
@@ -499,8 +504,7 @@ std::vector<TrajectoryPoint> MPTOptimizer::optimizeTrajectory(
   // 6. optimize steer angles
   const auto optimized_variables = calcOptimizedSteerAngles(ref_points, obj_mat, const_mat);
   if (!optimized_variables) {
-    RCLCPP_INFO_EXPRESSION(
-      logger_, enable_debug_info_, "return std::nullopt since could not solve qp");
+    RCLCPP_WARN(logger_, "return std::nullopt since could not solve qp");
     return get_prev_optimized_traj_points();
   }
 
@@ -508,7 +512,7 @@ std::vector<TrajectoryPoint> MPTOptimizer::optimizeTrajectory(
   const auto mpt_traj_points = calcMPTPoints(ref_points, *optimized_variables, mpt_mat);
   if (!mpt_traj_points) {
     RCLCPP_WARN(logger_, "return std::nullopt since lateral or yaw error is too large.");
-    return get_prev_optimized_traj_points();
+    return smoothed_points;
   }
 
   // 8. publish trajectories for debug

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -477,7 +477,7 @@ std::vector<TrajectoryPoint> MPTOptimizer::optimizeTrajectory(
     RCLCPP_WARN(
       logger_,
       "Try to return the previous optimized_trajectory as exceptional behavior, "
-      "but this failure also. Then retrun path_smoother output.");
+      "but this failure also. Then return path_smoother output.");
     return smoothed_points;
   };
 

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -505,14 +505,14 @@ std::vector<TrajectoryPoint> MPTOptimizer::optimizeTrajectory(
   const auto optimized_variables = calcOptimizedSteerAngles(ref_points, obj_mat, const_mat);
   if (!optimized_variables) {
     RCLCPP_WARN(logger_, "return std::nullopt since could not solve qp");
-    return get_prev_optimized_traj_points();
+    return smoothed_points;
   }
 
   // 7. convert to points with validation
   const auto mpt_traj_points = calcMPTPoints(ref_points, *optimized_variables, mpt_mat);
   if (!mpt_traj_points) {
     RCLCPP_WARN(logger_, "return std::nullopt since lateral or yaw error is too large.");
-    return smoothed_points;
+    return get_prev_optimized_traj_points();
   }
 
   // 8. publish trajectories for debug


### PR DESCRIPTION
## Description
https://tier4.atlassian.net/browse/RT0-33698
https://star4.slack.com/archives/CRUE57C30/p1727746662736939
への暫定対応PRです。

path_optimizer (X2 v2.3.3においてはobstacle_avoidance_planner) で計算に失敗した際の振る舞いを変更し、
前回の最適化経路を出力するようになっていたところを、前段のモジュールの経路を出力するように変更しました。

path_optimizerにより経路を大きく変更しながら走行している際には、それなりに急にハンドルを切る可能性があります。（vehicle_cmd_gateあるいはMPCのパラメータ次第です）

また、今後類似問題が発生した際に発生事象を絞り込めるように、例外発生時のエラーメッセージを増やす対応を行いました。

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
