### PR TITLE
feat: use mrm in any operation mode

### DIFF
--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -135,7 +135,7 @@ private:
 
   // Heartbeat
   rclcpp::Time stamp_operation_mode_availability_;
-  std::optional<rclcpp::Time> stamp_autonomous_become_unavailable_ = std::nullopt;
+  std::optional<rclcpp::Time> stamp_current_operation_mode_become_unavailable_ = std::nullopt;
   bool is_operation_mode_availability_timeout;
   void checkOperationModeAvailabilityTimeout();
 
@@ -148,13 +148,14 @@ private:
   void handleFailedRequest();
   autoware_adapi_v1_msgs::msg::MrmState::_behavior_type getCurrentMrmBehavior();
   bool isStopped();
-  bool isEmergency() const;
+  bool isEmergency();
   bool isControlModeAutonomous();
-  bool isOperationModeAutonomous();
   bool isPullOverStatusAvailable();
   bool isComfortableStopStatusAvailable();
   bool isEmergencyStopStatusAvailable();
   bool isArrivedAtGoal();
+  bool isAvailableCurrentOperationMode();
+  autoware_adapi_v1_msgs::msg::OperationModeState::_mode_type getCurrentOperationMode();
 };
 
 #endif  // MRM_HANDLER__MRM_HANDLER_CORE_HPP_

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -83,8 +83,7 @@ void MrmHandler::onOperationModeAvailability(
 {
   stamp_operation_mode_availability_ = this->now();
   operation_mode_availability_ = msg;
-  const bool skip_emergency_holding_check =
-    !param_.use_emergency_holding || is_emergency_holding_;
+  const bool skip_emergency_holding_check = !param_.use_emergency_holding || is_emergency_holding_;
 
   if (skip_emergency_holding_check) {
     return;
@@ -97,9 +96,10 @@ void MrmHandler::onOperationModeAvailability(
 
   // If no timestamp is available, the ego autonomous mode just became unavailable and the current
   // time is recorded.
-  stamp_current_operation_mode_become_unavailable_ = (!stamp_current_operation_mode_become_unavailable_.has_value())
-                                           ? this->now()
-                                           : stamp_current_operation_mode_become_unavailable_;
+  stamp_current_operation_mode_become_unavailable_ =
+    (!stamp_current_operation_mode_become_unavailable_.has_value())
+      ? this->now()
+      : stamp_current_operation_mode_become_unavailable_;
 
   // Check if autonomous mode unavailable time is larger than timeout threshold.
   const auto emergency_duration =

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -84,26 +84,26 @@ void MrmHandler::onOperationModeAvailability(
   stamp_operation_mode_availability_ = this->now();
   operation_mode_availability_ = msg;
   const bool skip_emergency_holding_check =
-    !param_.use_emergency_holding || is_emergency_holding_ || !isOperationModeAutonomous();
+    !param_.use_emergency_holding || is_emergency_holding_;
 
   if (skip_emergency_holding_check) {
     return;
   }
 
-  if (msg->autonomous) {
-    stamp_autonomous_become_unavailable_.reset();
+  if (isAvailableCurrentOperationMode()) {
+    stamp_current_operation_mode_become_unavailable_.reset();
     return;
   }
 
   // If no timestamp is available, the ego autonomous mode just became unavailable and the current
   // time is recorded.
-  stamp_autonomous_become_unavailable_ = (!stamp_autonomous_become_unavailable_.has_value())
+  stamp_current_operation_mode_become_unavailable_ = (!stamp_current_operation_mode_become_unavailable_.has_value())
                                            ? this->now()
-                                           : stamp_autonomous_become_unavailable_;
+                                           : stamp_current_operation_mode_become_unavailable_;
 
   // Check if autonomous mode unavailable time is larger than timeout threshold.
   const auto emergency_duration =
-    (this->now() - stamp_autonomous_become_unavailable_.value()).seconds();
+    (this->now() - stamp_current_operation_mode_become_unavailable_.value()).seconds();
   is_emergency_holding_ = (emergency_duration > param_.timeout_emergency_recovery);
 }
 
@@ -399,12 +399,11 @@ void MrmHandler::updateMrmState()
 
   // Get mode
   const bool is_control_mode_autonomous = isControlModeAutonomous();
-  const bool is_operation_mode_autonomous = isOperationModeAutonomous();
 
   // State Machine
   switch (mrm_state_.state) {
     case MrmState::NORMAL:
-      if (is_control_mode_autonomous && is_operation_mode_autonomous) {
+      if (is_control_mode_autonomous) {
         transitionTo(MrmState::MRM_OPERATING);
       }
       return;
@@ -526,9 +525,9 @@ bool MrmHandler::isStopped()
   return (std::abs(odom->twist.twist.linear.x) < th_stopped_velocity);
 }
 
-bool MrmHandler::isEmergency() const
+bool MrmHandler::isEmergency()
 {
-  return !operation_mode_availability_->autonomous || is_emergency_holding_ ||
+  return !isAvailableCurrentOperationMode() || is_emergency_holding_ ||
          is_operation_mode_availability_timeout;
 }
 
@@ -575,6 +574,33 @@ bool MrmHandler::isArrivedAtGoal()
   auto state = sub_operation_mode_state_.takeData();
   if (state == nullptr) return false;
   return state->mode == OperationModeState::STOP;
+}
+
+bool MrmHandler::isAvailableCurrentOperationMode()
+{
+  auto operation_mode = getCurrentOperationMode();
+  switch (operation_mode) {
+    case autoware_adapi_v1_msgs::msg::OperationModeState::UNKNOWN:
+      return false;
+    case autoware_adapi_v1_msgs::msg::OperationModeState::STOP:
+      return operation_mode_availability_->stop;
+    case autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS:
+      return operation_mode_availability_->autonomous;
+    case autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL:
+      return operation_mode_availability_->local;
+    case autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE:
+      return operation_mode_availability_->remote;
+    default:
+      RCLCPP_WARN(this->get_logger(), "invalid operation mode: %d", operation_mode);
+      return false;
+  }
+}
+
+autoware_adapi_v1_msgs::msg::OperationModeState::_mode_type MrmHandler::getCurrentOperationMode()
+{
+  auto state = sub_operation_mode_state_.takeData();
+  if (state == nullptr) return autoware_adapi_v1_msgs::msg::OperationModeState::UNKNOWN;
+  return state->mode;
 }
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -539,14 +539,6 @@ bool MrmHandler::isControlModeAutonomous()
   return mode->mode == ControlModeReport::AUTONOMOUS;
 }
 
-bool MrmHandler::isOperationModeAutonomous()
-{
-  using autoware_adapi_v1_msgs::msg::OperationModeState;
-  auto state = sub_operation_mode_state_.takeData();
-  if (state == nullptr) return false;
-  return state->mode == OperationModeState::AUTONOMOUS;
-}
-
 bool MrmHandler::isPullOverStatusAvailable()
 {
   auto status = sub_mrm_pull_over_status_.takeData();


### PR DESCRIPTION
## Description
This PR changed that  mrm can be used in all operation mode state,

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C4P0NSMB5/p1741932283537309?thread_ts=1741750397.876449&cid=C4P0NSMB5)

## How was this PR tested?

1. prepare for [pilot-auto.s1](https://github.com/tier4/pilot-auto.s1/tree/beta/v0.39.0)
2. cherry-pick this PR commit to autoware.universe
3. conlcon build
4. launch psim
5. Set Autonomous operation mode
6. Set Autonomous Availability false
7. Comfirm that transition to MRM
8. clear
9. Set Local operation mode
10. Set Local Availability false
11. Comfirm that transition to MRM

[Screencast from 2025年03月18日 14時29分01秒.webm](https://github.com/user-attachments/assets/5613c1db-4b8f-4872-99fd-f7fa51011769)

Comfirm that transition to Routing in setting initial pose.

[Screencast from 2025年03月18日 14時55分35秒.webm](https://github.com/user-attachments/assets/2f00b5d2-8f9f-4c5f-a038-6c61812ccc7c)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

When current operation mode state (all) is not available, Autoware executes MRM.
