### PR TITLE
feat(command_mode_decider): command mode decider change

### DIFF
--- a/system/autoware_command_mode_decider/CMakeLists.txt
+++ b/system/autoware_command_mode_decider/CMakeLists.txt
@@ -9,12 +9,19 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/command_mode_status.cpp"
   "src/command_mode_decider_base.cpp"
   "src/command_mode_decider.cpp"
+  "src/command_mode_decider_redundancy.cpp"
 )
 target_include_directories(${PROJECT_NAME} PRIVATE "src")
 
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::command_mode_decider::CommandModeDecider"
   EXECUTABLE "command_mode_decider_node"
+  EXECUTOR MultiThreadedExecutor
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::command_mode_decider::CommandModeDeciderRedundancy"
+  EXECUTABLE "command_mode_decider_redundancy_node"
   EXECUTOR MultiThreadedExecutor
 )
 

--- a/system/autoware_command_mode_decider/launch/decider.launch.xml
+++ b/system/autoware_command_mode_decider/launch/decider.launch.xml
@@ -1,11 +1,14 @@
 <launch>
   <arg name="is_redundant" default="false"/>
   <arg name="config" default="$(find-pkg-share autoware_command_mode_decider)/config/default.param.yaml"/>
+  <arg name="is_main_ecu" default="false"/>
+  <let name="status_topic_name" value="/system/command_mode/status" if="$(var is_main_ecu)"/>
+  <let name="status_topic_name" value="/sub/system/command_mode/status" unless="$(var is_main_ecu)"/>
 
   <group if="$(var is_redundant)">
     <node pkg="autoware_command_mode_decider" exec="command_mode_decider_redundancy_node">
       <param from="$(var config)"/>
-      <remap from="~/command_mode/status" to="/system/command_mode/status"/>
+      <remap from="~/command_mode/status" to="$(var status_topic_name)"/>
       <remap from="~/command_mode/request" to="/system/command_mode/request"/>
       <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
       <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>

--- a/system/autoware_command_mode_decider/launch/decider.launch.xml
+++ b/system/autoware_command_mode_decider/launch/decider.launch.xml
@@ -12,6 +12,7 @@
       <remap from="~/command_mode/request" to="/system/command_mode/request"/>
       <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
       <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>
+      <remap from="~/operation_mode/change_autoware_control" to="/system/operation_mode/change_autoware_control"/>
       <remap from="~/mrm/state" to="/system/fail_safe/mrm_state"/>
       <remap from="~/mrm/request" to="/system/fail_safe/mrm_request"/>
     </node>
@@ -24,6 +25,7 @@
       <remap from="~/command_mode/request" to="/system/command_mode/request"/>
       <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
       <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>
+      <remap from="~/operation_mode/change_autoware_control" to="/system/operation_mode/change_autoware_control"/>
       <remap from="~/mrm/state" to="/system/fail_safe/mrm_state"/>
       <remap from="~/mrm/request" to="/system/fail_safe/mrm_request"/>
     </node>

--- a/system/autoware_command_mode_decider/launch/decider.launch.xml
+++ b/system/autoware_command_mode_decider/launch/decider.launch.xml
@@ -1,13 +1,28 @@
 <launch>
+  <arg name="is_redundant" default="false"/>
   <arg name="config" default="$(find-pkg-share autoware_command_mode_decider)/config/default.param.yaml"/>
-  <node pkg="autoware_command_mode_decider" exec="command_mode_decider_node">
-    <param from="$(var config)"/>
-    <remap from="~/command_mode/status" to="/system/command_mode/status"/>
-    <remap from="~/command_mode/request" to="/system/command_mode/request"/>
-    <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
-    <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>
-    <remap from="~/operation_mode/change_autoware_control" to="/system/operation_mode/change_autoware_control"/>
-    <remap from="~/mrm/state" to="/system/fail_safe/mrm_state"/>
-    <remap from="~/mrm/request" to="/system/fail_safe/mrm_request"/>
-  </node>
+
+  <group if="$(var is_redundant)">
+    <node pkg="autoware_command_mode_decider" exec="command_mode_decider_redundancy_node">
+      <param from="$(var config)"/>
+      <remap from="~/command_mode/status" to="/system/command_mode/status"/>
+      <remap from="~/command_mode/request" to="/system/command_mode/request"/>
+      <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
+      <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>
+      <remap from="~/mrm/state" to="/system/fail_safe/mrm_state"/>
+      <remap from="~/mrm/request" to="/system/fail_safe/mrm_request"/>
+    </node>
+  </group>
+
+  <group unless="$(var is_redundant)">
+    <node pkg="autoware_command_mode_decider" exec="command_mode_decider_node">
+      <param from="$(var config)"/>
+      <remap from="~/command_mode/status" to="/system/command_mode/status"/>
+      <remap from="~/command_mode/request" to="/system/command_mode/request"/>
+      <remap from="~/operation_mode/state" to="/system/operation_mode/state"/>
+      <remap from="~/operation_mode/change_operation_mode" to="/system/operation_mode/change_operation_mode"/>
+      <remap from="~/mrm/state" to="/system/fail_safe/mrm_state"/>
+      <remap from="~/mrm/request" to="/system/fail_safe/mrm_request"/>
+    </node>
+  </group>
 </launch>

--- a/system/autoware_command_mode_decider/src/command_mode_conversion.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_conversion.cpp
@@ -57,6 +57,10 @@ uint32_t command_to_mrm_behavior(const std::string & text)
   if (text == "emergency_stop")   return MrmState::EMERGENCY_STOP;
   if (text == "comfortable_stop") return MrmState::COMFORTABLE_STOP;
   if (text == "pull_over")        return MrmState::PULL_OVER;
+
+  // tmp mapping
+  if (text == "main_ecu_in_lane_stop_0_4g") return MrmState::PULL_OVER;
+  if (text == "main_ecu_in_lane_stop_0_6g") return MrmState::EMERGENCY_STOP;
   // clang-format on
   return MrmState::NONE;
 }

--- a/system/autoware_command_mode_decider/src/command_mode_conversion.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_conversion.cpp
@@ -59,7 +59,7 @@ uint32_t command_to_mrm_behavior(const std::string & text)
   if (text == "pull_over")        return MrmState::PULL_OVER;
 
   // tmp mapping
-  if (text == "main_ecu_in_lane_stop_0_4g") return MrmState::PULL_OVER;
+  if (text == "main_ecu_in_lane_stop_0_3g") return MrmState::PULL_OVER;
   if (text == "main_ecu_in_lane_stop_0_6g") return MrmState::EMERGENCY_STOP;
   // clang-format on
   return MrmState::NONE;

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
@@ -1,0 +1,80 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "command_mode_decider_redundancy.hpp"
+
+#include <string>
+
+namespace autoware::command_mode_decider
+{
+
+  CommandModeDeciderRedundancy::CommandModeDeciderRedundancy(const rclcpp::NodeOptions & options)
+: CommandModeDeciderBase(options)
+{
+}
+
+std::string CommandModeDeciderRedundancy::decide_command_mode()
+{
+  const auto command_mode_status = get_command_mode_status();
+  const auto request_mode_status = get_request_mode_status();
+
+  // Use the requested MRM if available.
+  {
+    const auto status = command_mode_status.get(request_mode_status.mrm);
+    if (status.available) {
+      return request_mode_status.mrm;
+    }
+  }
+
+  // Use the specified operation mode if available.
+  {
+    const auto status = command_mode_status.get(request_mode_status.operation_mode);
+    if (status.available) {
+      return request_mode_status.operation_mode;
+    }
+  }
+
+  // TODO(Takagi, Isamu): Use the available MRM according to the state transitions at the
+  // following.
+  // https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/fail-safe/#behavior
+  const auto comfortable_stop = "comfortable_stop";
+  const auto main_ecu_in_lane_stop_0_4g = "main_ecu_in_lane_stop_0_4g";
+  const auto main_ecu_in_lane_stop_0_6g = "main_ecu_in_lane_stop_0_6g";
+  const auto sub_ecu_in_lane_stop_0_4g = "sub_ecu_in_lane_stop_0_4g";
+
+  // TODO(Takagi, Isamu): check command_modes parameter
+  if (command_mode_status.get(comfortable_stop).available /*&& use_comfortable_stop_*/) {
+    return comfortable_stop;
+  }
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).available /*&& use_main_ecu_in_lane_stop_0_4g_*/) {
+    return main_ecu_in_lane_stop_0_4g;
+  }
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).available /*&& use_main_ecu_in_lane_stop_0_6g_*/) {
+    return main_ecu_in_lane_stop_0_6g;
+  }
+  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).available /*&& use_sub_ecu_in_lane_stop_0_4g_*/) {
+    return sub_ecu_in_lane_stop_0_4g;
+  }
+  // FIXME(TetsuKawa): How to handle the case where no MRM is available.
+
+  // Use an empty string to delegate to switcher node.
+  RCLCPP_WARN_THROTTLE(
+    get_logger(), *get_clock(), 5000, "no mrm available: delegate to switcher node");
+  return std::string();
+}
+
+}  // namespace autoware::command_mode_decider
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::command_mode_decider::CommandModeDeciderRedundancy)

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
@@ -53,22 +53,22 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   // following.
   // https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/fail-safe/#behavior
   const auto comfortable_stop = "comfortable_stop";
-  const auto main_ecu_in_lane_stop_0_4g = "main_ecu_in_lane_stop_0_4g";
+  const auto main_ecu_in_lane_stop_0_3g = "main_ecu_in_lane_stop_0_3g";
   const auto main_ecu_in_lane_stop_0_6g = "main_ecu_in_lane_stop_0_6g";
-  const auto sub_ecu_in_lane_stop_0_4g = "sub_ecu_in_lane_stop_0_4g";
+  const auto sub_ecu_in_lane_stop_0_3g = "sub_ecu_in_lane_stop_0_3g";
 
   // TODO(Takagi, Isamu): check command_modes parameter
   if (command_mode_status.get(comfortable_stop).mode_available) {
     return comfortable_stop;
   }
-  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).mode_available) {
-    return main_ecu_in_lane_stop_0_4g;
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_3g).mode_available) {
+    return main_ecu_in_lane_stop_0_3g;
   }
   if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).mode_available) {
     return main_ecu_in_lane_stop_0_6g;
   }
-  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).mode_available) {
-    return sub_ecu_in_lane_stop_0_4g;
+  if (command_mode_status.get(sub_ecu_in_lane_stop_0_3g).mode_available) {
+    return sub_ecu_in_lane_stop_0_3g;
   }
   // FIXME(TetsuKawa): How to handle the case where no MRM is available.
 

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
@@ -19,7 +19,7 @@
 namespace autoware::command_mode_decider
 {
 
-  CommandModeDeciderRedundancy::CommandModeDeciderRedundancy(const rclcpp::NodeOptions & options)
+CommandModeDeciderRedundancy::CommandModeDeciderRedundancy(const rclcpp::NodeOptions & options)
 : CommandModeDeciderBase(options)
 {
 }

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
@@ -28,11 +28,15 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
 {
   const auto command_mode_status = get_command_mode_status();
   const auto request_mode_status = get_request_mode_status();
+  const auto background = !request_mode_status.autoware_control;
+  const auto is_available = [background](const auto & status) {
+    return status.mode_available && (status.transition_available || background);
+  };
 
   // Use the requested MRM if available.
   {
     const auto status = command_mode_status.get(request_mode_status.mrm);
-    if (status.mode_available) {
+    if (is_available(status)) {
       return request_mode_status.mrm;
     }
   }
@@ -40,7 +44,7 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   // Use the specified operation mode if available.
   {
     const auto status = command_mode_status.get(request_mode_status.operation_mode);
-    if (status.mode_available) {
+    if (is_available(status)) {
       return request_mode_status.operation_mode;
     }
   }
@@ -54,16 +58,16 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   const auto sub_ecu_in_lane_stop_0_4g = "sub_ecu_in_lane_stop_0_4g";
 
   // TODO(Takagi, Isamu): check command_modes parameter
-  if (command_mode_status.get(comfortable_stop).mode_available /*&& use_comfortable_stop_*/) {
+  if (command_mode_status.get(comfortable_stop).mode_available) {
     return comfortable_stop;
   }
-  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).mode_available /*&& use_main_ecu_in_lane_stop_0_4g_*/) {
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).mode_available) {
     return main_ecu_in_lane_stop_0_4g;
   }
-  if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).mode_available /*&& use_main_ecu_in_lane_stop_0_6g_*/) {
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).mode_available) {
     return main_ecu_in_lane_stop_0_6g;
   }
-  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).mode_available /*&& use_sub_ecu_in_lane_stop_0_4g_*/) {
+  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).mode_available) {
     return sub_ecu_in_lane_stop_0_4g;
   }
   // FIXME(TetsuKawa): How to handle the case where no MRM is available.

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.cpp
@@ -32,7 +32,7 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   // Use the requested MRM if available.
   {
     const auto status = command_mode_status.get(request_mode_status.mrm);
-    if (status.available) {
+    if (status.mode_available) {
       return request_mode_status.mrm;
     }
   }
@@ -40,7 +40,7 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   // Use the specified operation mode if available.
   {
     const auto status = command_mode_status.get(request_mode_status.operation_mode);
-    if (status.available) {
+    if (status.mode_available) {
       return request_mode_status.operation_mode;
     }
   }
@@ -54,16 +54,16 @@ std::string CommandModeDeciderRedundancy::decide_command_mode()
   const auto sub_ecu_in_lane_stop_0_4g = "sub_ecu_in_lane_stop_0_4g";
 
   // TODO(Takagi, Isamu): check command_modes parameter
-  if (command_mode_status.get(comfortable_stop).available /*&& use_comfortable_stop_*/) {
+  if (command_mode_status.get(comfortable_stop).mode_available /*&& use_comfortable_stop_*/) {
     return comfortable_stop;
   }
-  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).available /*&& use_main_ecu_in_lane_stop_0_4g_*/) {
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_4g).mode_available /*&& use_main_ecu_in_lane_stop_0_4g_*/) {
     return main_ecu_in_lane_stop_0_4g;
   }
-  if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).available /*&& use_main_ecu_in_lane_stop_0_6g_*/) {
+  if (command_mode_status.get(main_ecu_in_lane_stop_0_6g).mode_available /*&& use_main_ecu_in_lane_stop_0_6g_*/) {
     return main_ecu_in_lane_stop_0_6g;
   }
-  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).available /*&& use_sub_ecu_in_lane_stop_0_4g_*/) {
+  if (command_mode_status.get(sub_ecu_in_lane_stop_0_4g).mode_available /*&& use_sub_ecu_in_lane_stop_0_4g_*/) {
     return sub_ecu_in_lane_stop_0_4g;
   }
   // FIXME(TetsuKawa): How to handle the case where no MRM is available.

--- a/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.hpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_redundancy.hpp
@@ -1,0 +1,40 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef COMMAND_MODE_DECIDER_REDUNDANCY_HPP_
+#define COMMAND_MODE_DECIDER_REDUNDANCY_HPP_
+
+#include "command_mode_decider_base.hpp"
+
+#include <string>
+
+namespace autoware::command_mode_decider
+{
+
+class CommandModeDeciderRedundancy : public CommandModeDeciderBase
+{
+public:
+  explicit CommandModeDeciderRedundancy(const rclcpp::NodeOptions & options);
+
+protected:
+  std::string decide_command_mode() override;
+
+private:
+  bool use_pull_over_;
+  bool use_comfortable_stop_;
+};
+
+}  // namespace autoware::command_mode_decider
+
+#endif  // COMMAND_MODE_DECIDER_REDUNDANCY_HPP_

--- a/system/autoware_command_mode_switcher/launch/switcher.launch.xml
+++ b/system/autoware_command_mode_switcher/launch/switcher.launch.xml
@@ -1,10 +1,13 @@
 <launch>
   <arg name="config" default="$(find-pkg-share autoware_command_mode_switcher)/config/default.param.yaml"/>
+  <arg name="is_main_ecu" default="false"/>
+  <let name="status_topic_name" value="/system/command_mode/status" if="$(var is_main_ecu)"/>
+  <let name="status_topic_name" value="/sub/system/command_mode/status" unless="$(var is_main_ecu)"/>
 
   <node pkg="autoware_command_mode_switcher" exec="command_mode_switcher_node">
     <param from="$(var config)"/>
     <remap from="~/command_mode/availability" to="/system/command_mode/availability"/>
-    <remap from="~/command_mode/status" to="/system/command_mode/status"/>
+    <remap from="~/command_mode/status" to="$(var status_topic_name)"/>
     <remap from="~/command_mode/request" to="/system/command_mode/request"/>
     <remap from="~/command_mode/transition/available" to="/system/command_mode/transition/available"/>
     <remap from="~/command_mode/transition/completed" to="/system/command_mode/transition/completed"/>
@@ -12,9 +15,5 @@
     <remap from="~/source/select" to="/control/control_command_gate/source/select"/>
     <remap from="~/control_mode/report" to="/vehicle/status/control_mode"/>
     <remap from="~/control_mode/request" to="/control/control_mode_request"/>
-  </node>
-  <node pkg="autoware_command_mode_switcher" exec="availability_converter_node">
-    <remap from="~/command_mode/availability" to="/system/command_mode/availability"/>
-    <remap from="~/operation_mode/availability" to="/system/operation_mode/availability"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description
Adds command mode decider redundancy for mrmv0.7.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
