### PR TITLE
feat: add command mode param path

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -48,6 +48,8 @@
   <!-- temporary: control_command_gate migration -->
   <arg name="use_control_command_gate" default="false"/>
   <arg name="control_command_gate_param_path" if="$(var use_control_command_gate)"/>
+  <let name="operation_mode_transition_manager_plugin" value="FlagNode" if="$(var use_control_command_gate)"/>
+  <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
 
   <group>
     <push-ros-namespace namespace="control"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -47,14 +47,15 @@
 
   <!-- temporary: control_command_gate migration -->
   <arg name="use_control_command_gate" default="false"/>
-  <let name="operation_mode_transition_manager_plugin" value="FlagNode" if="$(var use_control_command_gate)"/>
-  <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
+  <arg name="control_command_gate_param_path" if="$(var use_control_command_gate)"/>
 
   <group>
     <push-ros-namespace namespace="control"/>
 
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml"/>
+      <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
+        <arg name="config" value="$(var control_command_gate_param_path)"/>
+      </include>
     </group>
     <group if="$(var use_control_command_gate)">
       <include file="$(find-pkg-share autoware_stop_mode_operator)/launch/stop_mode_operator.launch.xml"/>

--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -36,15 +36,21 @@
 
   <!-- temporary: control_command_gate migration -->
   <arg name="use_control_command_gate" default="false"/>
+  <arg name="command_mode_switcher_param_path" if="$(var use_control_command_gate)"/>
+  <arg name="command_mode_decider_param_path" if="$(var use_control_command_gate)"/>
 
   <group>
     <push-ros-namespace namespace="/system"/>
 
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_command_mode_switcher)/launch/switcher.launch.xml"/>
+      <include file="$(find-pkg-share autoware_command_mode_switcher)/launch/switcher.launch.xml">
+        <arg name="config" value="$(var command_mode_switcher_param_path)"/>
+      </include>
     </group>
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_command_mode_decider)/launch/decider.launch.xml"/>
+      <include file="$(find-pkg-share autoware_command_mode_decider)/launch/decider.launch.xml">
+        <arg name="config" value="$(var command_mode_decider_param_path)"/>
+      </include>
     </group>
 
     <!-- System Monitor -->


### PR DESCRIPTION
## Description
Adds param path of control command gate, command mode switcher, and command mode decider to launch file.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
