### PR TITLE
fix(autoware_static_centerline_generator): cherry-pick changes to support modifications made to autoware.core

### DIFF
--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -164,10 +164,14 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
       virtual_ego_pose};
     const auto optimized_traj_points = mpt_optimizer_ptr->optimizeTrajectory(planner_data);
 
+    if (!optimized_traj_points) {
+      return whole_optimized_traj_points;
+    }
+
     // connect the previously and currently optimized trajectory points
     for (size_t j = 0; j < whole_optimized_traj_points.size(); ++j) {
       const double dist = autoware::universe_utils::calcDistance2d(
-        whole_optimized_traj_points.at(j), optimized_traj_points.front());
+        whole_optimized_traj_points.at(j), optimized_traj_points->front());
       if (dist < 0.5) {
         const std::vector<TrajectoryPoint> extracted_whole_optimized_traj_points{
           whole_optimized_traj_points.begin(),
@@ -176,8 +180,8 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
         break;
       }
     }
-    for (size_t j = 0; j < optimized_traj_points.size(); ++j) {
-      whole_optimized_traj_points.push_back(optimized_traj_points.at(j));
+    for (size_t j = 0; j < optimized_traj_points->size(); ++j) {
+      whole_optimized_traj_points.push_back(optimized_traj_points->at(j));
     }
   }
 


### PR DESCRIPTION
## Description

This PR will cherry-pick the PR submitted to autoware_tools. Since the old version of `autoware_static_centerline_generator` exists in autoware.universe, not in autoware_tools, I created this PR again.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_tools/pull/225

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Evaluator build OK.
https://evaluation.tier4.jp/evaluation/reports/bd3988c8-9c66-5248-8e3c-449f4c8ce368?project_id=x2_dev

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
