### PR TITLE
feat(detection_area)!: suppression of giving up stopping (backport #1631)

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
@@ -58,6 +58,8 @@ public:
     double dead_line_margin;
     bool use_pass_judge_line;
     double state_clear_time;
+    double distance_to_judge_over_stop_line;
+    bool suppress_pass_judge_when_stopping;
   };
 
 public:
@@ -82,7 +84,8 @@ private:
 
   bool isOverLine(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose) const;
+    const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose,
+    const double margin) const;
 
   bool hasEnoughBrakingDistance(
     const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose) const;

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -69,6 +69,10 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
   planner_param_.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 5.0);
   planner_param_.use_pass_judge_line = node.declare_parameter(ns + ".use_pass_judge_line", false);
   planner_param_.state_clear_time = node.declare_parameter(ns + ".state_clear_time", 2.0);
+  planner_param_.distance_to_judge_over_stop_line =
+    node.declare_parameter(ns + ".distance_to_judge_over_stop_line", 0.0);
+  planner_param_.suppress_pass_judge_when_stopping =
+    node.declare_parameter(ns + ".suppress_pass_judge_when_stopping", false);
 }
 
 void DetectionAreaModuleManager::launchNewModules(


### PR DESCRIPTION
## Description

 backport #1631 

## Related links

[管理チケット](https://tier4.atlassian.net/browse/AEAP-2368)

## How was this PR tested?

backport PR のため不要

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
