### PR TITLE
fix(start_planner): fix segmentation fault when generating backward path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -54,6 +54,11 @@ PathWithLaneId getBackwardPath(
     // forward center line path
     backward_path = route_handler.getCenterLinePath(shoulder_lanes, s_start, s_end, true);
 
+    // If the returned path is empty, return an empty path
+    if (backward_path.points.empty()) {
+      return backward_path;
+    }
+
     // backward center line path
     std::reverse(backward_path.points.begin(), backward_path.points.end());
     for (auto & p : backward_path.points) {


### PR DESCRIPTION
## Description
cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/10393

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
