### PR TITLE
fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -2142,6 +2142,38 @@ size_t findFirstNearestIndexWithSoftConstraints(
     }
   }
 
+  {  // with yaw threshold
+    double min_squared_dist = std::numeric_limits<double>::max();
+    size_t min_idx = 0;
+    bool is_within_constraints = false;
+    for (size_t i = 0; i < points.size(); ++i) {
+      const auto yaw = autoware::universe_utils::calcYawDeviation(
+        autoware::universe_utils::getPose(points.at(i)), pose);  
+      const auto squared_dist =
+        autoware::universe_utils::calcSquaredDistance2d(points.at(i), pose.position);
+
+      if (yaw_threshold < std::abs(yaw)) {
+        if (is_within_constraints) {
+          break;
+        }
+        continue;
+      }
+
+      if (min_squared_dist <= squared_dist) {
+        continue;
+      }
+
+      min_squared_dist = squared_dist;
+      min_idx = i;
+      is_within_constraints = true;
+    }
+
+    // nearest index is found
+    if (is_within_constraints) {
+      return min_idx;
+    }
+  }
+
   // without any threshold
   return findNearestIndex(points, pose.position);
 }

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -2148,7 +2148,7 @@ size_t findFirstNearestIndexWithSoftConstraints(
     bool is_within_constraints = false;
     for (size_t i = 0; i < points.size(); ++i) {
       const auto yaw = autoware::universe_utils::calcYawDeviation(
-        autoware::universe_utils::getPose(points.at(i)), pose);  
+        autoware::universe_utils::getPose(points.at(i)), pose);
       const auto squared_dist =
         autoware::universe_utils::calcSquaredDistance2d(points.at(i), pose.position);
 

--- a/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -4774,11 +4774,11 @@ TEST(trajectory, findFirstNearestIndexWithSoftConstraints)
       EXPECT_EQ(
         findFirstNearestIndexWithSoftConstraints(
           poses, createPose(-2.1, 0.1, 0.0, 0.0, 0.0, pi), 0.0, 0.4),
-        1U);
+        5U);
       EXPECT_EQ(
         findFirstNearestSegmentIndexWithSoftConstraints(
           poses, createPose(-2.1, 0.1, 0.0, 0.0, 0.0, pi), 0.0, 0.4),
-        0U);
+        5U);
 
       // Yaw is out of range
       EXPECT_EQ(

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -1648,6 +1648,7 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::calcMPTPoints(
   const Eigen::VectorXd steer_angles = optimized_variables.segment(N_x, N_u);
   const Eigen::VectorXd slack_variables = optimized_variables.segment(N_x + N_u, N_ref * N_slack);
 
+
   // calculate trajectory points from optimization result
   std::vector<TrajectoryPoint> traj_points;
   for (size_t i = 0; i < N_ref; ++i) {

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -1648,7 +1648,6 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::calcMPTPoints(
   const Eigen::VectorXd steer_angles = optimized_variables.segment(N_x, N_u);
   const Eigen::VectorXd slack_variables = optimized_variables.segment(N_x + N_u, N_ref * N_slack);
 
-
   // calculate trajectory points from optimization result
   std::vector<TrajectoryPoint> traj_points;
   for (size_t i = 0; i < N_ref; ++i) {

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -398,9 +398,10 @@ void PathOptimizer::applyInputVelocity(
 
     // trim to ego-pose
     const size_t ego_seg_idx_output_traj =
-    trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
-    
-    output_traj_points = std::vector<TrajectoryPoint>(output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
+      trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
+
+    output_traj_points = std::vector<TrajectoryPoint>(
+      output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
 
     const auto cropped_points = autoware::motion_utils::cropForwardPoints(
       input_traj_points, ego_pose.position, ego_seg_idx,
@@ -411,7 +412,7 @@ void PathOptimizer::applyInputVelocity(
     }
     return cropped_points;
   }();
-  
+
   // update velocity
   const auto segment_length_vec = calcSegmentLengthVector(forward_cropped_input_traj_points);
   const double mpt_delta_arc_length = mpt_optimizer_ptr_->getDeltaArcLength();

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -395,6 +395,13 @@ void PathOptimizer::applyInputVelocity(
 
     const size_t ego_seg_idx =
       trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
+
+    // trim to ego-pose
+    const size_t ego_seg_idx_output_traj =
+    trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
+    
+    output_traj_points = std::vector<TrajectoryPoint>(output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
+
     const auto cropped_points = autoware::motion_utils::cropForwardPoints(
       input_traj_points, ego_pose.position, ego_seg_idx,
       optimized_traj_length + margin_traj_length);
@@ -404,7 +411,7 @@ void PathOptimizer::applyInputVelocity(
     }
     return cropped_points;
   }();
-
+  
   // update velocity
   const auto segment_length_vec = calcSegmentLengthVector(forward_cropped_input_traj_points);
   const double mpt_delta_arc_length = mpt_optimizer_ptr_->getDeltaArcLength();

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -388,6 +388,13 @@ void PathOptimizer::applyInputVelocity(
 {
   autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
+  // trim to ego-pose
+  const size_t ego_seg_idx_output_traj =
+    trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
+  output_traj_points = autoware::motion_utils::cropBackwardPoints(
+    output_traj_points, ego_pose.position, ego_seg_idx_output_traj,
+    traj_param_.output_backward_traj_length);
+
   // crop forward for faster calculation
   const auto forward_cropped_input_traj_points = [&]() {
     const double optimized_traj_length = mpt_optimizer_ptr_->getTrajectoryLength();

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -403,13 +403,6 @@ void PathOptimizer::applyInputVelocity(
     const size_t ego_seg_idx =
       trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
 
-    // trim to ego-pose
-    const size_t ego_seg_idx_output_traj =
-      trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
-
-    output_traj_points = std::vector<TrajectoryPoint>(
-      output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
-
     const auto cropped_points = autoware::motion_utils::cropForwardPoints(
       input_traj_points, ego_pose.position, ego_seg_idx,
       optimized_traj_length + margin_traj_length);

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -13,8 +13,8 @@
       use_lane_type: "opposite_direction_lane"
       # drivable area setting
       use_intersection_areas: true
-      use_hatched_road_markings: true
-      use_freespace_areas: true
+      use_hatched_road_markings: false
+      use_freespace_areas: false
 
       # avoidance is performed for the object type with true
       target_object:


### PR DESCRIPTION
## Description
When applying the input velocity to the output of MPT, the initial pose of the output of MPT is used to trim the input trajectory. In certain cases when  there is a sharp U-turn, depending on the width of the adjacent, opposing lane into which Ego is turning into, the initial pose of the output trajectory may be mapped to a point in the opposing lane - leading to incorrect input velocity application.

This PR adds a yaw-thresholded closest-distance point search step to ensure that this doesn't occur and also trims the output of MPT to start from the current ego pose so that the initial pose of the MPT output will always map to a point within the current lane.
## Related links

**Parent Issue:**
https://tier4.atlassian.net/browse/RT0-35764

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Results in Ticket.

Evaluator Result:

Evaluator results borrowed from:
https://github.com/autowarefoundation/autoware_universe/pull/10403

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
