### PR TITLE
fix: add manual mode but not push commands_

### DIFF
--- a/system/autoware_command_mode_switcher/src/command_mode_switcher.cpp
+++ b/system/autoware_command_mode_switcher/src/command_mode_switcher.cpp
@@ -32,11 +32,13 @@ CommandModeSwitcher::CommandModeSwitcher(const rclcpp::NodeOptions & options)
   vehicle_gate_interface_(*this, [this]() { update(); })
 {
   // Create vehicle gate switcher.
-  if (this->declare_parameter<bool>("is_main_ecu", true)) {
+  {
     const auto command = std::make_shared<Command>(std::make_shared<ManualCommand>());
     manual_command_ = command;
-    platform_commands_[command->plugin->mode_name()] = command;
-    commands_.push_back(command);
+    if (this->declare_parameter<bool>("is_main_ecu", true)) {
+      platform_commands_[command->plugin->mode_name()] = command;
+      commands_.push_back(command);
+    }
   }
 
   // Create control gate switcher.


### PR DESCRIPTION
## Description
Add manual mode but not push commands_.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
