### PR TITLE
hotdix: limit control mode request to once

### DIFF
--- a/system/autoware_command_mode_switcher/src/command_mode_switcher.cpp
+++ b/system/autoware_command_mode_switcher/src/command_mode_switcher.cpp
@@ -185,17 +185,14 @@ void CommandModeSwitcher::detect_override()
 void CommandModeSwitcher::update_status()
 {
   // NOTE: Update the source state first since the source group state depends on it.
-  const auto to_tri_state = [](bool state) {
-    return state ? TriState::Enabled : TriState::Disabled;
-  };
   for (const auto & command : commands_) {
     auto & status = command->status;
     auto & plugin = command->plugin;
     status.mrm = plugin->update_mrm_state();
     status.source_state =
       plugin->update_source_state(status.request_phase != GateType::NotSelected);
-    status.control_gate_state = to_tri_state(control_gate_interface_.is_selected(*plugin));
-    status.vehicle_gate_state = to_tri_state(vehicle_gate_interface_.is_selected(*plugin));
+    status.control_gate_state = control_gate_interface_.is_selected(*plugin);
+    status.vehicle_gate_state = vehicle_gate_interface_.is_selected(*plugin);
     status.mode_continuable = plugin->get_mode_continuable();
     status.mode_available = plugin->get_mode_available();
     status.transition_available = plugin->get_transition_available();

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.hpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.hpp
@@ -36,7 +36,7 @@ class ControlGateInterface
 public:
   using Callback = std::function<void()>;
   ControlGateInterface(rclcpp::Node & node, Callback callback);
-  bool is_selected(const CommandPlugin & plugin) const;
+  TriState is_selected(const CommandPlugin & plugin) const;
   bool is_in_transition() const;
   bool request(const CommandPlugin & plugin, bool transition);
 
@@ -50,6 +50,7 @@ private:
   rclcpp::Subscription<CommandSourceStatus>::SharedPtr sub_source_status_;
 
   bool requesting_ = false;
+  std::string last_request_mode_;
   Callback notification_callback_;
   CommandSourceStatus status_;
 };
@@ -59,7 +60,7 @@ class VehicleGateInterface
 public:
   using Callback = std::function<void()>;
   VehicleGateInterface(rclcpp::Node & node, Callback callback);
-  bool is_selected(const CommandPlugin & plugin) const;
+  TriState is_selected(const CommandPlugin & plugin) const;
   bool is_autoware_control() const;
   bool request(const CommandPlugin & plugin);
 
@@ -73,6 +74,7 @@ private:
   rclcpp::Subscription<ControlModeReport>::SharedPtr sub_control_mode_;
 
   bool requesting_ = false;
+  std::string last_request_mode_;
   Callback notification_callback_;
   ControlModeReport status_;
 };


### PR DESCRIPTION
## Description

Limit control mode request to once.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C07DMS06H6U/p1744622356720249?thread_ts=1744596070.731779&cid=C07DMS06H6U)

## How was this PR tested?

Launch control_mode_switcher with control_mode service that is not update control_mode status.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
