### PR TITLE
ci: update build_depends.repos to match pilot-auto beta/v0.41

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -31,7 +31,7 @@ repositories:
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: v0.41.0
+    version: beta/v0.41
   universe/external/mussp:
     type: git
     url: https://github.com/tier4/muSSP.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -44,10 +44,6 @@ repositories:
     type: git
     url: https://github.com/tier4/glog.git
     version: ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30
-  v2x/vehicle2infrastructure:
-    type: git
-    url: git@github.com:tier4/vehicle2infrastructure.git
-    version: 4d97f6bff72541357cbe490f5731036c0ed85286
   # middleware
   # TODO(TIER IV): During the transition period of Agnocast introduction,
   # the Agnocast ROS packages are provided as a source build.

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,10 +1,8 @@
 repositories:
-  # core
-  # TODO(youtalk): Remove autoware_common when https://github.com/autowarefoundation/autoware/issues/4911 is closed
-  core/autoware_common:
+  core/autoware.core:
     type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: remove-autoware-cmake-utils
+    url: https://github.com/tier4/autoware.core.git
+    version: fa227e6b6e7123a3fe36d42d2c29eb413d520009
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
@@ -12,15 +10,11 @@ repositories:
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 1.1.0
+    version: 1.2.0
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.6.1
-  core/autoware.core:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.core.git
-    version: main
+    version: 0.6.2
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -28,36 +22,28 @@ repositories:
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: beta/1.7.0
+    version: e62ea6fdb9ee50e49c7642c77e85250cb15b8e80
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.5.0
+    version: 1.6.0
   # universe
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
+    version: v0.41.0
   universe/external/mussp:
     type: git
     url: https://github.com/tier4/muSSP.git
-    version: tier4/main
-  universe/external/ndt_omp:
-    type: git
-    url: https://github.com/tier4/ndt_omp.git
-    version: tier4/main
+    version: c79e98fd5e658f4f90c06d93472faa977bc873b9
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
-    version: main
+    version: e2e75fc1603a9798773e467a679edf68b448e705
   universe/external/glog:  # TODO: to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git
-    version: v0.6.0_t4-ros
-  universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
-    type: git
-    url: https://github.com/autowarefoundation/ament_cmake.git
-    version: feat/faster_ament_libraries_deduplicate
+    version: ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30
   # middleware
   # TODO(TIER IV): During the transition period of Agnocast introduction,
   # the Agnocast ROS packages are provided as a source build.

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -44,6 +44,10 @@ repositories:
     type: git
     url: https://github.com/tier4/glog.git
     version: ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30
+  v2x/vehicle2infrastructure:
+    type: git
+    url: git@github.com:tier4/vehicle2infrastructure.git
+    version: 4d97f6bff72541357cbe490f5731036c0ed85286
   # middleware
   # TODO(TIER IV): During the transition period of Agnocast introduction,
   # the Agnocast ROS packages are provided as a source build.


### PR DESCRIPTION
## Description
I updated `build_depends.repos` to match `autoware.repos` in [pilot-auto beta/v0.41 ](https://github.com/tier4/pilot-auto/blob/beta/v0.41/autoware.repos) to pass build on CI check.

## Related links

[internal discuttion](https://star4.slack.com/archives/C07K1PPNPTR/p1744718842220209?thread_ts=1744718776.361219&cid=C07K1PPNPTR)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
