### PR TITLE
feat(control_validator, tier4_diagnostics): sync upstream

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -64,3 +64,5 @@ The input trajectory is detected as invalid if the index exceeds the following t
 | `thresholds.over_velocity_offset`    | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
 | `thresholds.over_velocity_ratio`     | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
 | `thresholds.overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
+| `thresholds.acc_error_offset`        | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
+| `thresholds.acc_error_scale`         | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |

--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -13,6 +13,7 @@ The listed features below does not always correspond to the latest implementatio
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | :---------------------------------------------------: |
 | Inverse velocity: Measured velocity has a different sign from the target velocity. | measured velocity $v$, target velocity $\hat{v}$, and velocity parameter $c$                    |      $v \hat{v} < 0, \quad \lvert v \rvert > c$       |
 | Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, ratio parameter $r$, and offset parameter $c$ | $\lvert v \rvert > (1 + r) \lvert \hat{v} \rvert + c$ |
+| Overrun estimation: estimate overrun even if decelerate by assumed rate.           | assumed deceleration, assumed delay                                                             |                                                       |
 
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
 
@@ -57,12 +58,15 @@ The following parameters can be set for the `control_validator`:
 
 The input trajectory is detected as invalid if the index exceeds the following thresholds.
 
-| Name                                 | Type   | Description                                                                                                 | Default value |
-| :----------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
-| `thresholds.max_distance_deviation`  | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
-| `thresholds.rolling_back_velocity`   | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
-| `thresholds.over_velocity_offset`    | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
-| `thresholds.over_velocity_ratio`     | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
-| `thresholds.overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
-| `thresholds.acc_error_offset`        | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
-| `thresholds.acc_error_scale`         | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |
+| Name                                      | Type   | Description                                                                                                 | Default value |
+| :---------------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
+| `thresholds.max_distance_deviation`       | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| `thresholds.rolling_back_velocity`        | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
+| `thresholds.over_velocity_offset`         | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
+| `thresholds.over_velocity_ratio`          | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
+| `thresholds.overrun_stop_point_dist`      | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
+| `thresholds.acc_error_offset`             | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
+| `thresholds.acc_error_scale`              | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |
+| `thresholds.will_overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 1.0           |
+| `thresholds.assumed_limit_acc`            | double | assumed acceleration for over run estimation [m]                                                            | 5.0           |
+| `thresholds.assumed_delay_time`           | double | assumed delay for over run estimation [m]                                                                   | 0.2           |

--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -57,9 +57,10 @@ The following parameters can be set for the `control_validator`:
 
 The input trajectory is detected as invalid if the index exceeds the following thresholds.
 
-| Name                                | Type   | Description                                                                                                 | Default value |
-| :---------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
-| `thresholds.max_distance_deviation` | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
-| `thresholds.rolling_back_velocity`  | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
-| `thresholds.over_velocity_offset`   | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
-| `thresholds.over_velocity_ratio`    | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
+| Name                                 | Type   | Description                                                                                                 | Default value |
+| :----------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
+| `thresholds.max_distance_deviation`  | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| `thresholds.rolling_back_velocity`   | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
+| `thresholds.over_velocity_offset`    | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
+| `thresholds.over_velocity_ratio`     | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
+| `thresholds.overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 0.8           |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -1,19 +1,22 @@
 /**:
   ros__parameters:
-    # If the number of consecutive invalid trajectory exceeds this threshold, the Diag will be set to ERROR.
-    # (For example, threshold = 1 means, even if the trajectory is invalid, Diag will not be ERROR if
-    #  the next trajectory is valid.)
+    # If the number of consecutive invalid predicted_path exceeds this threshold, the Diag will be set to ERROR.
+    # (For example, threshold = 1 means, even if the predicted_path is invalid, Diag will not be ERROR if
+    #  the next predicted_path is valid.)
     diag_error_count_threshold: 0
 
     display_on_terminal: false # show error msg on terminal
 
     thresholds:
       max_distance_deviation: 1.0
+      acc_error_offset: 0.8
+      acc_error_scale: 0.2
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
       nominal_latency: 0.01
 
+    acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33
     hold_velocity_error_until_stop: true

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -12,6 +12,7 @@
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
+      overrun_stop_point_dist: 0.8
       nominal_latency: 0.01
 
     vel_lpf_gain: 0.9 # Time constant 0.33

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -15,6 +15,9 @@
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
+      will_overrun_stop_point_dist: 1.0
+      assumed_limit_acc: 5.0
+      assumed_delay_time: 0.2
       nominal_latency: 0.01
 
     acc_lpf_gain: 0.97 # Time constant 1.11s

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -12,6 +12,7 @@
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
+      nominal_latency: 0.01
 
     vel_lpf_gain: 0.9 # Time constant 0.33
     hold_velocity_error_until_stop: true

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -190,9 +190,9 @@ private:
 
   // Subscribers and publishers
   rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_traj_;
   autoware_utils::InterProcessPollingSubscriber<Odometry>::SharedPtr sub_kinematics_;
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr sub_reference_traj_;
+  autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr sub_predicted_traj_;
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
     sub_measured_acc_;
   rclcpp::Publisher<ControlValidatorStatus>::SharedPtr pub_status_;

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -156,6 +156,12 @@ public:
   explicit OverrunValidator(rclcpp::Node & node)
   : overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
       node, "thresholds.overrun_stop_point_dist")},
+    will_overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
+      node, "thresholds.will_overrun_stop_point_dist")},
+    assumed_limit_acc{
+      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_limit_acc")},
+    assumed_delay_time{
+      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_delay_time")},
     vehicle_vel_lpf{autoware_utils::get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
 
   void validate(
@@ -164,6 +170,9 @@ public:
 
 private:
   const double overrun_stop_point_dist_th;
+  const double will_overrun_stop_point_dist_th;
+  const double assumed_limit_acc;
+  const double assumed_delay_time;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
 };
 

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -39,6 +39,8 @@
 #include <tuple>
 #include <utility>
 
+class AccelerationValidatorTest;
+
 namespace autoware::control_validator
 {
 using autoware_control_msgs::msg::Control;
@@ -67,6 +69,7 @@ struct ValidationParams
 class AccelerationValidator
 {
 public:
+  friend class ::AccelerationValidatorTest;
   explicit AccelerationValidator(rclcpp::Node & node)
   {
     e_offset =
@@ -83,6 +86,7 @@ public:
     const AccelWithCovarianceStamped & loc_acc);
 
 private:
+  bool is_in_error_range() const;
   double e_offset;
   double e_scale;
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf{0.0};

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -53,6 +53,7 @@ struct ValidationParams
   double rolling_back_velocity;
   double over_velocity_ratio;
   double over_velocity_offset;
+  double overrun_stop_point_dist;
   double nominal_latency_threshold;
 };
 
@@ -93,6 +94,14 @@ public:
     const Trajectory & predicted_trajectory, const Trajectory & reference_trajectory) const;
 
   void calc_velocity_deviation_status(
+    const Trajectory & reference_trajectory, const Odometry & kinematics);
+
+  /**
+   * @brief Calculate whether the vehicle has overrun a stop point in the trajectory.
+   * @param reference_trajectory Reference trajectory
+   * @param kinematics Current vehicle odometry including pose and twist
+   */
+  void calc_stop_point_overrun_status(
     const Trajectory & reference_trajectory, const Odometry & kinematics);
 
 private:

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -25,6 +25,7 @@
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -38,6 +39,7 @@
 
 namespace autoware::control_validator
 {
+using autoware_control_msgs::msg::Control;
 using autoware_control_validator::msg::ControlValidatorStatus;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
@@ -51,6 +53,7 @@ struct ValidationParams
   double rolling_back_velocity;
   double over_velocity_ratio;
   double over_velocity_offset;
+  double nominal_latency_threshold;
 };
 
 /**
@@ -66,6 +69,12 @@ public:
    * @param options Node options
    */
   explicit ControlValidator(const rclcpp::NodeOptions & options);
+
+  /**
+   * @brief Callback function for the control component output.
+   * @param msg Control message
+   */
+  void on_control_cmd(const Control::ConstSharedPtr msg);
 
   /**
    * @brief Callback function for the predicted trajectory.
@@ -134,6 +143,7 @@ private:
     DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const;
 
   // Subscribers and publishers
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_traj_;
   autoware_utils::InterProcessPollingSubscriber<Odometry>::SharedPtr sub_kinematics_;
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr sub_reference_traj_;

--- a/control/autoware_control_validator/launch/control_validator.launch.xml
+++ b/control/autoware_control_validator/launch/control_validator.launch.xml
@@ -8,9 +8,11 @@
     <param from="$(var control_validator_param_path)"/>
 
     <!-- remap topic name -->
+    <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
+    <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
+    <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
     <remap from="~/input/reference_trajectory" to="$(var input_reference_trajectory)"/>
     <remap from="~/input/predicted_trajectory" to="$(var input_predicted_trajectory)"/>
-    <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
     <remap from="~/output/validation_status" to="~/validation_status"/>
   </node>
 </launch>

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -2,6 +2,7 @@ builtin_interfaces/Time stamp
 
 # states
 bool is_valid_max_distance_deviation
+bool is_valid_acc
 bool is_rolling_back
 bool is_over_velocity
 bool has_overrun_stop_point
@@ -9,6 +10,8 @@ bool is_valid_latency
 
 # values
 float64 max_distance_deviation
+float64 desired_acc
+float64 measured_acc
 float64 target_vel
 float64 vehicle_vel
 float64 dist_to_stop

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -6,6 +6,7 @@ bool is_valid_acc
 bool is_rolling_back
 bool is_over_velocity
 bool has_overrun_stop_point
+bool will_overrun_stop_point
 bool is_valid_latency
 
 # values
@@ -15,6 +16,7 @@ float64 measured_acc
 float64 target_vel
 float64 vehicle_vel
 float64 dist_to_stop
+float64 pred_dist_to_stop
 float64 nearest_trajectory_vel
 float64 latency
 

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -4,12 +4,15 @@ builtin_interfaces/Time stamp
 bool is_valid_max_distance_deviation
 bool is_rolling_back
 bool is_over_velocity
+bool has_overrun_stop_point
 bool is_valid_latency
 
 # values
 float64 max_distance_deviation
 float64 target_vel
 float64 vehicle_vel
+float64 dist_to_stop
+float64 nearest_trajectory_vel
 float64 latency
 
 int64 invalid_count

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -4,10 +4,12 @@ builtin_interfaces/Time stamp
 bool is_valid_max_distance_deviation
 bool is_rolling_back
 bool is_over_velocity
+bool is_valid_latency
 
 # values
 float64 max_distance_deviation
 float64 target_vel
 float64 vehicle_vel
+float64 latency
 
 int64 invalid_count

--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_signal_processing</depend>

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -122,11 +122,27 @@ void OverrunValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps;
 
+  /*
+  res.dist_to_stop: distance to stop according to the trajectory.
+  v_vel * assumed_delay_time : distance ego will travel before starting the limit deceleration.
+  v_vel * v_vel / (2.0 * assumed_limit_acc): distance to stop assuming we apply the limit
+  deceleration.
+  if res.pred_dist_to_stop is negative, it means that we predict we will stop after the stop point
+  contained in the trajectory.
+  */
   const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
+  res.pred_dist_to_stop =
+    res.dist_to_stop - v_vel * assumed_delay_time - v_vel * v_vel / (2.0 * assumed_limit_acc);
 
   // NOTE: the same velocity threshold as autoware::motion_utils::searchZeroVelocity
-  res.has_overrun_stop_point = res.dist_to_stop < -overrun_stop_point_dist_th &&
-                               res.nearest_trajectory_vel < 1e-3 && v_vel > 1e-3;
+  if (v_vel < 1e-3) {
+    res.has_overrun_stop_point = false;
+    res.will_overrun_stop_point = false;
+    return;
+  }
+  res.has_overrun_stop_point =
+    res.dist_to_stop < -overrun_stop_point_dist_th && res.nearest_trajectory_vel < 1e-3;
+  res.will_overrun_stop_point = res.pred_dist_to_stop < -will_overrun_stop_point_dist_th;
 }
 
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
@@ -227,6 +243,12 @@ void ControlValidator::setup_diag()
       stat, !validation_status_.has_overrun_stop_point,
       "The vehicle has overrun the front stop point on the trajectory.");
   });
+  d.add(ns + "will_overrun_stop_point", [&](auto & stat) {
+    set_status(
+      stat, !validation_status_.will_overrun_stop_point,
+      "In a few seconds ago, the vehicle will overrun the front stop point on the trajectory.");
+  });
+
   d.add(ns + "latency", [&](auto & stat) {
     set_status(
       stat, validation_status_.is_valid_latency, "The latency is larger than expected value.");
@@ -318,7 +340,7 @@ void ControlValidator::publish_debug_info(const geometry_msgs::msg::Pose & ego_p
 bool ControlValidator::is_all_valid(const ControlValidatorStatus & s)
 {
   return s.is_valid_max_distance_deviation && s.is_valid_acc && !s.is_rolling_back &&
-         !s.is_over_velocity && !s.has_overrun_stop_point;
+         !s.is_over_velocity && !s.has_overrun_stop_point && !s.will_overrun_stop_point;
 }
 
 void ControlValidator::display_status()

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -63,15 +63,15 @@ ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
 
   sub_control_cmd_ = create_subscription<Control>(
     "~/input/control_cmd", 1, std::bind(&ControlValidator::on_control_cmd, this, _1));
-  sub_predicted_traj_ = create_subscription<Trajectory>(
-    "~/input/predicted_trajectory", 1,
-    std::bind(&ControlValidator::on_predicted_trajectory, this, _1));
   sub_kinematics_ =
     autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>::create_subscription(
       this, "~/input/kinematics", 1);
   sub_reference_traj_ =
     autoware_utils::InterProcessPollingSubscriber<Trajectory>::create_subscription(
       this, "~/input/reference_trajectory", 1);
+  sub_predicted_traj_ =
+    autoware_utils::InterProcessPollingSubscriber<Trajectory>::create_subscription(
+      this, "~/input/predicted_trajectory", 1);
   sub_measured_acc_ =
     autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::create_subscription(
       this, "~/input/measured_acceleration", 1);
@@ -191,7 +191,7 @@ bool ControlValidator::is_data_ready()
     return waiting(sub_reference_traj_->subscriber()->get_topic_name());
   }
   if (!current_predicted_trajectory_) {
-    return waiting(sub_predicted_traj_->get_topic_name());
+    return waiting(sub_reference_traj_->subscriber()->get_topic_name());
   }
   if (!acceleration_msg_) {
     return waiting(sub_measured_acc_->subscriber()->get_topic_name());
@@ -204,21 +204,10 @@ bool ControlValidator::is_data_ready()
 
 void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
 {
-  control_cmd_msg_ = msg;
-
-  validation_status_.latency = (this->now() - msg->stamp).seconds();
-  validation_status_.is_valid_latency =
-    validation_status_.latency < validation_params_.nominal_latency_threshold;
-
-  validation_status_.invalid_count =
-    is_all_valid(validation_status_) ? 0 : validation_status_.invalid_count + 1;
-}
-
-void ControlValidator::on_predicted_trajectory(const Trajectory::ConstSharedPtr msg)
-{
   stop_watch.tic();
 
-  current_predicted_trajectory_ = msg;
+  control_cmd_msg_ = msg;
+  current_predicted_trajectory_ = sub_predicted_traj_->take_data();
   current_reference_trajectory_ = sub_reference_traj_->take_data();
   current_kinematics_ = sub_kinematics_->take_data();
   acceleration_msg_ = sub_measured_acc_->take_data();
@@ -226,6 +215,10 @@ void ControlValidator::on_predicted_trajectory(const Trajectory::ConstSharedPtr 
   if (!is_data_ready()) return;
 
   debug_pose_publisher_->clear_markers();
+
+  validation_status_.latency = (this->now() - msg->stamp).seconds();
+  validation_status_.is_valid_latency =
+    validation_status_.latency < validation_params_.nominal_latency_threshold;
 
   validate(
     *current_predicted_trajectory_, *current_reference_trajectory_, *current_kinematics_,

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -16,10 +16,12 @@
 
 #include "autoware/control_validator/utils.hpp"
 #include "autoware/motion_utils/trajectory/interpolation.hpp"
+#include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -72,6 +74,7 @@ void ControlValidator::setup_parameters()
     p.rolling_back_velocity = declare_parameter<double>(t + "rolling_back_velocity");
     p.over_velocity_offset = declare_parameter<double>(t + "over_velocity_offset");
     p.over_velocity_ratio = declare_parameter<double>(t + "over_velocity_ratio");
+    p.overrun_stop_point_dist = declare_parameter<double>(t + "overrun_stop_point_dist");
     p.nominal_latency_threshold = declare_parameter<double>(t + "nominal_latency");
   }
   const auto lpf_gain = declare_parameter<double>("vel_lpf_gain");
@@ -128,6 +131,11 @@ void ControlValidator::setup_diag()
     set_status(
       stat, !validation_status_.is_over_velocity,
       "The vehicle is over-speeding against the target.");
+  });
+  d.add(ns + "overrun_stop_point", [&](auto & stat) {
+    set_status(
+      stat, !validation_status_.has_overrun_stop_point,
+      "The vehicle has overrun the front stop point on the trajectory.");
   });
   d.add(ns + "latency", [&](auto & stat) {
     set_status(
@@ -219,12 +227,14 @@ void ControlValidator::validate(
   }
 
   validation_status_.stamp = get_clock()->now();
+  validation_status_.vehicle_vel = vehicle_vel_.filter(kinematics.twist.twist.linear.x);
 
   std::tie(
     validation_status_.max_distance_deviation, validation_status_.is_valid_max_distance_deviation) =
     calc_lateral_deviation_status(predicted_trajectory, *current_reference_trajectory_);
 
   calc_velocity_deviation_status(*current_reference_trajectory_, kinematics);
+  calc_stop_point_overrun_status(*current_reference_trajectory_, kinematics);
 
   validation_status_.invalid_count =
     is_all_valid(validation_status_) ? 0 : validation_status_.invalid_count + 1;
@@ -245,7 +255,6 @@ void ControlValidator::calc_velocity_deviation_status(
 {
   auto & status = validation_status_;
   const auto & params = validation_params_;
-  status.vehicle_vel = vehicle_vel_.filter(kinematics.twist.twist.linear.x);
   status.target_vel = target_vel_.filter(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
@@ -268,10 +277,41 @@ void ControlValidator::calc_velocity_deviation_status(
   }
 }
 
+void ControlValidator::calc_stop_point_overrun_status(
+  const Trajectory & reference_trajectory, const Odometry & kinematics)
+{
+  auto & status = validation_status_;
+  const auto & params = validation_params_;
+
+  status.dist_to_stop = [](const Trajectory & traj, const geometry_msgs::msg::Pose & pose) {
+    const auto stop_idx_opt = autoware::motion_utils::searchZeroVelocityIndex(traj.points);
+
+    const size_t end_idx = stop_idx_opt ? *stop_idx_opt : traj.points.size() - 1;
+    const size_t seg_idx =
+      autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(traj.points, pose);
+    const double signed_length_on_traj = autoware::motion_utils::calcSignedArcLength(
+      traj.points, pose.position, seg_idx, traj.points.at(end_idx).pose.position,
+      std::min(end_idx, traj.points.size() - 2));
+
+    if (std::isnan(signed_length_on_traj)) {
+      return 0.0;
+    }
+    return signed_length_on_traj;
+  }(reference_trajectory, kinematics.pose.pose);
+
+  status.nearest_trajectory_vel =
+    autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
+      .longitudinal_velocity_mps;
+
+  // NOTE: the same velocity threshold as autoware::motion_utils::searchZeroVelocity
+  status.has_overrun_stop_point = status.dist_to_stop < -params.overrun_stop_point_dist &&
+                                  status.nearest_trajectory_vel < 1e-3 && status.vehicle_vel > 1e-3;
+}
+
 bool ControlValidator::is_all_valid(const ControlValidatorStatus & s)
 {
   return s.is_valid_max_distance_deviation && !s.is_rolling_back && !s.is_over_velocity &&
-         s.is_valid_latency;
+         !s.has_overrun_stop_point;
 }
 
 void ControlValidator::display_status()

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -72,9 +72,19 @@ TrajectoryPoint make_trajectory_point(double x, double y)
   return point;
 }
 
-class TrajectoryDeviationTest
+namespace autoware::control_validator
+{
+class TrajectoryValidatorTest
 : public ::testing::TestWithParam<std::tuple<Trajectory, Trajectory, double, bool>>
 {
+public:
+  void validate(
+    ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
+    const Trajectory & reference_trajectory)
+  {
+    return trajectory_validator_->validate(res, predicted_trajectory, reference_trajectory);
+  }
+
 protected:
   void SetUp() override
   {
@@ -88,27 +98,28 @@ protected:
        ament_index_cpp::get_package_share_directory("autoware_test_utils") +
          "/config/test_vehicle_info.param.yaml"});
 
-    node = std::make_shared<autoware::control_validator::ControlValidator>(options);
+    node_ = std::make_shared<ControlValidator>(options);
+    trajectory_validator_ = std::make_shared<TrajectoryValidator>(*node_);
   }
-
   void TearDown() override { rclcpp::shutdown(); }
 
-  std::shared_ptr<autoware::control_validator::ControlValidator> node;
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<TrajectoryValidator> trajectory_validator_;
 };
 
-TEST_P(TrajectoryDeviationTest, test_calc_lateral_deviation_status)
+TEST_P(TrajectoryValidatorTest, test_calc_lateral_deviation_status)
 {
   auto [reference_trajectory, predicted_trajectory, expected_deviation, expected_condition] =
     GetParam();
-  auto [deviation, is_valid] =
-    node->calc_lateral_deviation_status(predicted_trajectory, reference_trajectory);
+  ControlValidatorStatus res;
+  validate(res, predicted_trajectory, reference_trajectory);
 
-  EXPECT_EQ(is_valid, expected_condition);
-  EXPECT_NEAR(deviation, expected_deviation, 1e-5);
+  EXPECT_EQ(res.is_valid_max_distance_deviation, expected_condition);
+  EXPECT_NEAR(res.max_distance_deviation, expected_deviation, 1e-5);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  TrajectoryDeviationTests, TrajectoryDeviationTest,
+  TrajectoryDeviationTests, TrajectoryValidatorTest,
   ::testing::Values(
 
     std::make_tuple(
@@ -190,14 +201,13 @@ protected:
        ament_index_cpp::get_package_share_directory("autoware_test_utils") +
          "/config/test_vehicle_info.param.yaml"});
 
-    node_ = std::make_shared<autoware::control_validator::ControlValidator>(options);
-    acceleration_validator_ =
-      std::make_shared<autoware::control_validator::AccelerationValidator>(*node_);
+    node_ = std::make_shared<ControlValidator>(options);
+    acceleration_validator_ = std::make_shared<AccelerationValidator>(*node_);
   }
   void TearDown() override { rclcpp::shutdown(); }
 
   std::shared_ptr<rclcpp::Node> node_;
-  std::shared_ptr<autoware::control_validator::AccelerationValidator> acceleration_validator_;
+  std::shared_ptr<AccelerationValidator> acceleration_validator_;
 };
 
 TEST_P(AccelerationValidatorTest, test_is_in_error_range)
@@ -217,3 +227,5 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(false, 1.0, 5.0), std::make_tuple(false, 1.0, -5.0),
     std::make_tuple(true, -1.0, -1.0), std::make_tuple(false, -1.0, -5.0),
     std::make_tuple(false, -1.0, 5.0)));
+
+}  // namespace autoware::control_validator

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -203,6 +203,7 @@
           <composable_node pkg="autoware_control_validator" plugin="autoware::control_validator::ControlValidator" name="control_validator">
             <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
             <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
+            <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
             <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <remap from="~/output/validation_status" to="~/validation_status"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -201,6 +201,7 @@
       <group if="$(var launch_control_validator)">
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_control_validator" plugin="autoware::control_validator::ControlValidator" name="control_validator">
+            <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
             <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
             <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>


### PR DESCRIPTION
## Description
beta/v0.41のcontrol_validator関係の設定をv0.41からv0.44相当に更新する変更です。
リファクタリングを含みますので、変更自体はそこそこの大きさがありますが、パイプラインからは独立しているモジュールですので、影響は限定的かと想定しています。

## How was this PR tested?
psimにおいて、以下を確認しました。
- /diagnosticsの内容がv0.44相当のものになっていること
- 坂道で走らせても、誤検知が発生しないこと
- シミュレータの車両モデルを意図的壊すとそれらしいMRM停止ができること  

## Related links
launch: https://github.com/tier4/autoware_launch/pull/838

## Notes for reviewers
None.

## Interface changes

None.



## Effects on system behavior

None.
