### PR TITLE
feat: should be using NvInferRuntime.h (#10399)

### DIFF
--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -19,7 +19,7 @@
 
 #include <NvInfer.h>
 #include <NvInferPlugin.h>
-#include <NvInferRuntimeBase.h>
+#include <NvInferRuntime.h>
 #include <dlfcn.h>
 
 #include <cmath>


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/10399

This would allow autoware_universe working on TensorRT 8.5.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
