### PR TITLE
fix(autoware_system_monitor): quick fix by cherry-picking 677447f

### DIFF
--- a/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
@@ -567,7 +567,11 @@ bool ProcessMonitor::getCommandLineFromPid(const std::string & pid, std::string 
   // Leave the last 0x00 (end-of-C-string) intact.
   std::replace(buffer.begin(), (buffer.end() - 1), '\0', ' ');
   // Make sure the last character is a null terminator.
-  *(buffer.end() - 1) = '\0';
+
+  // Although buffer.back() is safer and more idiomatic,
+  // using it here causes a compile error with -Werror=stringop-overflow.
+  // Therefore, we safely access the last element by index.
+  buffer[buffer.size() - 1] = '\0';
   try {
     std::string cmdline = std::string(buffer.begin(), (buffer.end() - 1));
     // Remove trailing spaces


### PR DESCRIPTION
## Description

Cherry pick https://github.com/tier4/autoware_universe/commit/677447fae09f196b293f76240986da5572cf6076 to fix the `-Wno-stringop-overflow` error.

## Related links

None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Local build succeeded.

## Notes for reviewers

None.

## Interface changes

None

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
Expected to fix the building error of autoware_system_monitor