### PR TITLE
feat(blind_spot): extend attention area to straight lanelet

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_util.cpp
@@ -239,7 +239,7 @@ TEST_F(TestWithAdjLaneData, generateBlindSpotLanelets_left)
     route_handler, autoware::behavior_velocity_planner::TurnDirection::LEFT, {2000, 2010},
     param.ignore_width_from_center_line, param.adjacent_extend_width,
     param.opposite_adjacent_extend_width);
-  EXPECT_EQ(blind_spot_lanelets.size(), 2);
+  EXPECT_EQ(blind_spot_lanelets.size(), 3);
 
 #ifdef EXPORT_TEST_PLOT_FIGURE
   py::gil_scoped_acquire acquire;
@@ -406,7 +406,7 @@ TEST_F(TestWithShoulderData, generateBlindSpotLaneletsShoulder_left)
     route_handler, autoware::behavior_velocity_planner::TurnDirection::LEFT, {1000, 1010},
     param.ignore_width_from_center_line, param.adjacent_extend_width,
     param.opposite_adjacent_extend_width);
-  EXPECT_EQ(blind_spot_lanelets.size(), 2);
+  EXPECT_EQ(blind_spot_lanelets.size(), 3);
 
 #ifdef EXPORT_TEST_PLOT_FIGURE
   py::gil_scoped_acquire acquire;


### PR DESCRIPTION
## Description

Cherry pick of the following PR.

https://github.com/autowarefoundation/autoware_universe/pull/10450

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
