### PR TITLE
fix(mvp_run_out): set proper target package name when exporting plugin

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
@@ -3,7 +3,7 @@ project(autoware_motion_velocity_run_out_module)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
-pluginlib_export_plugin_description_file(autoware_motion_velocity_planner plugins.xml)
+pluginlib_export_plugin_description_file(autoware_motion_velocity_planner_node_universe plugins.xml)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src


### PR DESCRIPTION
## Description

The target when exporting the plugin (`autoware_motion_velocity_planner`) cannot be found.
This PR fixes the issue by renaming it to `autoware_motion_velocity_planner_node_universe`.

## Related links

https://github.com/tier4/autoware_universe/pull/1997

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
