### PR TITLE
fix(autoware_motion_velocity): fix for mishandling lateral-distance #452

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -284,7 +284,7 @@ ObstacleSlowDownModule::convert_point_cloud_to_slow_down_points(
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
 
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
         continue;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -284,7 +284,7 @@ ObstacleSlowDownModule::convert_point_cloud_to_slow_down_points(
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m / 2;
 
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
         continue;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -301,7 +301,7 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
 
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
         continue;
@@ -485,7 +485,10 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
     const auto lat_dist_from_obstacle_to_traj =
       autoware::motion_utils::calcLateralOffset(traj_points, itr->collision_point);
     const auto min_lat_dist_to_traj_poly =
-      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
+      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
+
+    std::cout << "min_lat_dist_to_traj_poly: " << min_lat_dist_to_traj_poly << std::endl;
+    std::cout << "obstacle_filtering_param_.max_lat_margin: " << obstacle_filtering_param_.max_lat_margin << std::endl;
 
     if (min_lat_dist_to_traj_poly < obstacle_filtering_param_.max_lat_margin) {
       auto stop_obstacle = *itr;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -301,7 +301,7 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m / 2;
 
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
         continue;
@@ -485,10 +485,11 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
     const auto lat_dist_from_obstacle_to_traj =
       autoware::motion_utils::calcLateralOffset(traj_points, itr->collision_point);
     const auto min_lat_dist_to_traj_poly =
-      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m/2;
+      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m / 2;
 
     std::cout << "min_lat_dist_to_traj_poly: " << min_lat_dist_to_traj_poly << std::endl;
-    std::cout << "obstacle_filtering_param_.max_lat_margin: " << obstacle_filtering_param_.max_lat_margin << std::endl;
+    std::cout << "obstacle_filtering_param_.max_lat_margin: "
+              << obstacle_filtering_param_.max_lat_margin << std::endl;
 
     if (min_lat_dist_to_traj_poly < obstacle_filtering_param_.max_lat_margin) {
       auto stop_obstacle = *itr;


### PR DESCRIPTION
## Description
pointcloud clusters too far from the footprint of the vehicle are considered to be obstructive and slow-down and stop modules are triggered unnecessarily.
This PR is for the universe changes.

## Related links

**Parent Issue:**

https://tier4.atlassian.net/browse/RT1-10023

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
