### PR TITLE
fix(autoware_crosswalk_traffic_light_estimator): add process that guard access to empty elements (#10281)

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -300,7 +300,11 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
         output_traffic_signal_element.color = color;
         output_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
         output_traffic_signal_element.confidence = 1.0;
-        output.traffic_light_groups[idx].elements[0] = output_traffic_signal_element;
+        if (output.traffic_light_groups[idx].elements.empty()) {
+          output.traffic_light_groups[idx].elements.push_back(output_traffic_signal_element);
+        } else {
+          output.traffic_light_groups[idx].elements[0] = output_traffic_signal_element;
+        }
         continue;
       }
       updateFlashingState(signal);  // check if it is flashing
@@ -322,6 +326,10 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
 bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
   const TrafficSignal & signal) const
 {
+  // invalid if elements is empty
+  if (signal.elements.empty()) {
+    return true;
+  }
   // check occlusion, backlight(shape is unknown) and no detection(shape is circle)
   if (
     signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
@@ -344,7 +352,7 @@ void CrosswalkTrafficLightEstimatorNode::updateFlashingState(const TrafficSignal
 
   // flashing green
   if (
-    signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
+    !signal.elements.empty() && signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
     signal.elements.front().confidence != 0 &&  // not due to occlusion
     current_color_state_.at(id) != TrafficSignalElement::UNKNOWN) {
     is_flashing_.at(id) = true;


### PR DESCRIPTION
## Description
- V2I信号連携で歩行者信号を受信するとcrosswalk traffic light estimatorが落ちる現象への対策として、#10281 (以下#10281と記載)をcherry-pickする

## Related links

**Private Links:**

- [Tier IV Internal Link](https://tier4.atlassian.net/browse/RT0-34969)

**cherry-pick PR:**
- #10281

## How was this PR tested?
- Planning Simulator(Local)
  - PSIM上での自動走行および自動走行時にV2I信号連携で歩行者信号を受信してもcrosswalk traffic light estimatorが落ちないことを確認

- Evaluator
本branchを対象としたpilot.auto.x2環境(tmp/V2I_fix_check_v4.0_v0.29)および直近でEvaluatorにかけられたpilot.auto.x2環境(beta/4.0.2)との比較を以下の表に示す。

| テスト対象 | テスト総数 | OK数 | NG数 |
| :-------- | :------------ | :------ | :------ |
|[tmp/V2I_fix_check_v4.0_v0.29](https://evaluation.tier4.jp/evaluation/reports/701fe0dd-ad1e-5755-88d2-ea3dc074c783?project_id=x2_dev)| 2761 | 2141 | 620 |
|[beta/4.0.2(2/19時点)](https://evaluation.tier4.jp/evaluation/reports/0dd36591-500e-5dde-8879-f3dfe2376447?project_id=x2_dev) | 2615 | 2143 | 472 |

上記結果より、大幅なOK/NGの増減が無いためデグレーションなく取り込めていると判断する。

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.