### PR TITLE
fix(pointcloud_preprocessor): restore the previously deleted concatenate_mutex_ for Agnocast 

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
@@ -73,7 +73,7 @@ public:
   std::unordered_map<std::string, AUTOWARE_MESSAGE_SHARED_PTR(sensor_msgs::msg::PointCloud2)>
   get_topic_to_cloud_map();
 
-  [[nodiscard]] CollectorStatus get_status() const;
+  [[nodiscard]] CollectorStatus get_status();
 
   void set_info(std::shared_ptr<CollectorInfoBase> collector_info);
   [[nodiscard]] std::shared_ptr<CollectorInfoBase> get_info() const;
@@ -89,6 +89,7 @@ private:
   uint64_t num_of_clouds_;
   double timeout_sec_;
   bool debug_mode_;
+  std::mutex concatenate_mutex_;
   std::shared_ptr<CollectorInfoBase> collector_info_;
   CollectorStatus status_;
 };

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/cloud_collector.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/cloud_collector.cpp
@@ -137,7 +137,7 @@ void CloudCollector::show_debug_message()
              << ros2_parent_node_->get_clock()->now().seconds() << " seconds\n";
 
   if (auto advanced_info = std::dynamic_pointer_cast<AdvancedCollectorInfo>(collector_info_)) {
-    log_stream << "Advanced strategy:\n Collector's reference time mi/n: "
+    log_stream << "Advanced strategy:\n Collector's reference time min: "
                << advanced_info->timestamp - advanced_info->noise_window
                << " to max: " << advanced_info->timestamp + advanced_info->noise_window
                << " seconds\n";


### PR DESCRIPTION
## Description
In the current implementation of Agnocast, variables that can be accessed by both the Agnocast subscription callback and ROS2 subscription or timer callbacks must be protected by locks for exclusive control. Therefore, variables such as topic_to_cloud_map_ and status_ need to be accessed while holding a lock.

## Related links
This mutex was once deleted in [this PR](https://github.com/autowarefoundation/autoware_universe/pull/10082) based on [this conversation](https://github.com/autowarefoundation/autoware_universe/pull/10082#issuecomment-2668139391).
[X2 bench debug for applying Agnocast](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3678176064/X2+-#III%3A-autoware%3A%3Apointcloud_preprocessor%3A%3ACloudCollector%3A%3Aconcatenate_callback()-%E3%81%A7%E8%90%BD%E3%81%A1%E3%82%8B)


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
