### PR TITLE
fix(segmentation pointcloud fusion): fix launch for selectable camera…

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -49,6 +49,7 @@
   <arg name="input/camera7/info"/>
   <arg name="input/camera7/rois"/>
   <arg name="image_topic_name"/>
+  <arg name="segmentation_pointcloud_fusion_camera_ids"/>
   <arg name="input/radar"/>
   <arg name="input/tracked_objects" default="/perception/object_recognition/tracking/objects"/>
   <arg name="output/objects" default="objects"/>
@@ -183,6 +184,8 @@
       <arg name="detection_by_tracker_param_path" value="$(var detection_by_tracker_param_path)"/>
       <arg name="use_low_intensity_cluster_filter" value="$(var use_low_intensity_cluster_filter)"/>
       <arg name="use_image_segmentation_based_filter" value="$(var use_image_segmentation_based_filter)"/>
+      <arg name="segmentation_pointcloud_fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
+      <arg name="image_topic_name" value="$(var image_topic_name)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -36,6 +36,9 @@
   <arg name="input/camera7/info"/>
   <arg name="input/camera7/rois"/>
 
+  <arg name="segmentation_pointcloud_fusion_camera_ids"/>
+  <arg name="image_topic_name"/>
+
   <arg name="node/pointcloud_container"/>
   <arg name="input/pointcloud"/>
   <arg name="input/pointcloud_map/pointcloud"/>
@@ -127,9 +130,11 @@
 
   <!-- Image_segmentation based filter, apply for camera0 only-->
   <group>
-    <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/segmentation_pointcloud_fusion.launch.xml" if="$(var use_image_segmentation_based_filter)">
+    <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/segmentation_pointcloud_fusion.launch.py" if="$(var use_image_segmentation_based_filter)">
       <arg name="input/pointcloud" value="$(var segmentation_based_filtered/input/pointcloud)"/>
       <arg name="output/pointcloud" value="$(var segmentation_based_filtered/output/pointcloud)"/>
+      <arg name="image_topic_name" value="$(var image_topic_name)"/>
+      <arg name="fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -86,6 +86,8 @@
   <arg name="detection_rois7" default="/perception/object_recognition/detection/rois7"/>
   <arg name="image_number" default="6" description="choose image raw number(1-8)"/>
   <arg name="image_topic_name" default="image_rect_color" description="image topic name options `image_rect_color`, `image_raw"/>
+  <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,1,5]" description="list of camera ids used for segmentation_pointcloud_fusion node"/>
+
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
   <!-- Pipeline junctions -->
@@ -269,6 +271,7 @@
           <arg name="objects_filter_method" value="$(var objects_filter_method)"/>
           <arg name="use_irregular_object_detector" value="$(var use_irregular_object_detector)"/>
           <arg name="image_topic_name" value="$(var image_topic_name)"/>
+          <arg name="segmentation_pointcloud_fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
         </include>
       </group>
 

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
@@ -1,0 +1,165 @@
+# Copyright 2025 Tier IV, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+from launch.conditions import IfCondition
+from launch.conditions import UnlessCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+import yaml
+
+
+class SegmentationPointcloudFusion:
+    def __init__(self, context):
+        self.context = context
+        with open(LaunchConfiguration("sync_param_path").perform(context), "r") as f:
+            self.segmentation_pointcloud_fusion_sync_param = yaml.safe_load(f)["/**"][
+                "ros__parameters"
+            ]
+
+        with open(
+            LaunchConfiguration("segmentation_pointcloud_fusion_param_path").perform(context), "r"
+        ) as f:
+            self.segmentation_pointcloud_fusion_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
+        self.camera_ids = LaunchConfiguration("fusion_camera_ids").perform(context)
+        # convert string to list
+        self.camera_ids = yaml.load(self.camera_ids, Loader=yaml.FullLoader)
+        self.segmentation_pointcloud_fusion_param["rois_number"] = len(self.camera_ids)
+        mask_timestamp_offsets = []
+        approximate_camera_projection = []
+        rois_timestamp_noise_window = []
+        point_project_to_unrectified_image = []
+        image_topic_name = LaunchConfiguration("image_topic_name")
+
+        for index, camera_id in enumerate(self.camera_ids):
+            mask_timestamp_offsets.append(
+                self.segmentation_pointcloud_fusion_sync_param["rois_timestamp_offsets"][camera_id]
+            )
+            rois_timestamp_noise_window.append(
+                self.segmentation_pointcloud_fusion_sync_param["matching_strategy"][
+                    "rois_timestamp_noise_window"
+                ][camera_id]
+            )
+            approximate_camera_projection.append(
+                self.segmentation_pointcloud_fusion_sync_param["approximate_camera_projection"][
+                    camera_id
+                ]
+            )
+            point_project_to_unrectified_image.append(
+                self.segmentation_pointcloud_fusion_sync_param[
+                    "point_project_to_unrectified_image"
+                ][camera_id]
+            )
+            self.segmentation_pointcloud_fusion_param[f"input/rois{index}"] = (
+                f"/perception/object_recognition/detection/mask{camera_id}"
+            )
+            self.segmentation_pointcloud_fusion_param[f"input/camera_info{index}"] = (
+                f"/sensing/camera/camera{camera_id}/camera_info"
+            )
+            self.segmentation_pointcloud_fusion_param[f"input/image{index}"] = (
+                f"/sensing/camera/camera{camera_id}/{image_topic_name}"
+            )
+
+        self.segmentation_pointcloud_fusion_sync_param["rois_timestamp_offsets"] = (
+            mask_timestamp_offsets
+        )
+        self.segmentation_pointcloud_fusion_sync_param["approximate_camera_projection"] = (
+            approximate_camera_projection
+        )
+        self.segmentation_pointcloud_fusion_sync_param["matching_strategy"][
+            "rois_timestamp_noise_window"
+        ] = rois_timestamp_noise_window
+        self.segmentation_pointcloud_fusion_sync_param["approximate_camera_projection"] = (
+            approximate_camera_projection
+        )
+        self.segmentation_pointcloud_fusion_sync_param["point_project_to_unrectified_image"] = (
+            point_project_to_unrectified_image
+        )
+
+    def create_segmentation_pointcloud_fusion_node(self, input_topic, output_topic):
+        node = Node(
+            package="autoware_image_projection_based_fusion",
+            executable="segmentation_pointcloud_fusion_node",
+            name="segmentation_pointcloud_fusion",
+            remappings=[
+                ("input", input_topic),
+                ("output", output_topic),
+            ],
+            parameters=[
+                self.segmentation_pointcloud_fusion_sync_param,
+                self.segmentation_pointcloud_fusion_param,
+            ],
+        )
+        return node
+
+
+def launch_setup(context, *args, **kwargs):
+    pipeline = SegmentationPointcloudFusion(context)
+    segmentation_pointcloud_fusion_node = pipeline.create_segmentation_pointcloud_fusion_node(
+        LaunchConfiguration("input/pointcloud"), LaunchConfiguration("output/pointcloud")
+    )
+    # TODO(badai-nguyen): add option of using container
+    return [segmentation_pointcloud_fusion_node]
+
+
+def generate_launch_description():
+    launch_arguments = []
+
+    def add_launch_arg(name: str, default_value=None):
+        launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
+
+    add_launch_arg("input/pointcloud", "pointcloud_map_filtered/pointcloud")
+    add_launch_arg("output/pointcloud", "segmentation_based_filtered/pointcloud")
+    add_launch_arg("use_intra_process", "True")
+    add_launch_arg("use_multithread", "True")
+    add_launch_arg("fusion_camera_ids", "[0]")
+    add_launch_arg("image_topic_name", "image_raw")
+    add_launch_arg("pointcloud_container_name", "pointcloud_container")
+    add_launch_arg("use_pointcloud_container", "True")
+    add_launch_arg(
+        "segmentation_pointcloud_fusion_param_path",
+        [
+            FindPackageShare("autoware_image_projection_based_fusion"),
+            "/config/segmentation_pointcloud_fusion.param.yaml",
+        ],
+    )
+    add_launch_arg(
+        "sync_param_path",
+        [
+            FindPackageShare("autoware_launch"),
+            "/config/perception/object_recognition/detection/image_projection_based_fusion/fusion_common.param.yaml",
+        ],
+    )
+
+    set_container_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container",
+        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
+    )
+
+    set_container_mt_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container_mt",
+        condition=IfCondition(LaunchConfiguration("use_multithread")),
+    )
+    return launch.LaunchDescription(
+        launch_arguments
+        + [set_container_executable, set_container_mt_executable]
+        + [OpaqueFunction(function=launch_setup)]
+    )


### PR DESCRIPTION
## Description

* cherry-picking of https://github.com/autowarefoundation/autoware_universe/pull/10609

## Related links

- [TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-36931?linkSource=email)

## How was this PR tested?

I confirmed that autoware was started and that the `segmentation_based_filter` was started correctly.
Also confirmed that `roi_cluster_fusion` subscribes to **6 masks** and `segmentation_base_filter` subscribes to **3 masks** .

```shell
# launch autoware with camera_lidar mode and segmentation filter
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=$HOME/*** \
    vehicle_model:=sample_vehicle \
    sensor_model:=aip_xx1 \
    perception_mode:=camera_lidar_fusion use_image_segmentation_based_filter:=true


ros2 node info /perception/object_recognition/detection/segmentation_pointcloud_fusion

ros2 node info /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
```

## Notes for reviewers

> [!NOTE]
> * This PR should be merged with https://github.com/tier4/autoware_launch/pull/870

## Interface changes

None.


## Effects on system behavior

None.
