### PR TITLE
feat(out_of_lane): resample object predicted paths to prevent empty gaps

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
@@ -18,6 +18,7 @@
 
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common_universe</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -20,6 +20,7 @@
 #include <autoware/motion_velocity_planner_common_universe/planner_data.hpp>
 
 #include <optional>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::out_of_lane
 {
@@ -44,6 +45,11 @@ std::optional<autoware_utils::LineString2d> find_next_stop_line(
 void cut_predicted_path_beyond_red_lights(
   autoware_perception_msgs::msg::PredictedPath & predicted_path, const EgoData & ego_data,
   const double object_front_overhang);
+
+/// @brief resample the predicted paths such that there are no gaps between successive footprints
+void resample_predicted_paths(
+  std::vector<autoware_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const autoware_perception_msgs::msg::Shape & shape);
 
 /// @brief filter predicted objects and their predicted paths
 /// @param [in] planner_data planner data


### PR DESCRIPTION
## Description

Cherry pick #10606

## Related links

https://tier4.atlassian.net/browse/RT0-36839?linkSource=email

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
