### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): fix for mishandling lateral-distance 

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -233,6 +233,7 @@ void ObstacleSlowDownModule::update_parameters(
 std::vector<autoware::motion_velocity_planner::SlowDownPointData>
 ObstacleSlowDownModule::convert_point_cloud_to_slow_down_points(
   const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
+  const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
   const VehicleInfo & vehicle_info, const size_t ego_idx)
 {
   if (pointcloud.pointcloud.empty()) {
@@ -280,12 +281,24 @@ ObstacleSlowDownModule::convert_point_cloud_to_slow_down_points(
     for (const auto & index : cluster_indices.indices) {
       const auto obstacle_point = autoware::motion_velocity_planner::utils::to_geometry_point(
         filtered_points_ptr->points[index]);
+      // 1. brief filtering - filters out point-cloud points that are far from the trajectory
+      // laterally The lateral distance of the obstacle-point to trajectory is measured below
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
+      // The minimum lateral distance to the trajectory polygon is estimated by assuming that the
+      // ego-vehicle is fully perpendicular to the trajectory, in the very worst case
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
-
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.max_longitudinal_offset_m;
+      // The trajectory polygon is ignored if the minimum lateral distance is more than maximum
+      // lateral margin
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
+        continue;
+      }
+
+      // precise filtering
+      const double precise_min_lat_dist_to_traj_poly =
+        utils::get_dist_to_traj_poly(obstacle_point, decimated_traj_polys_with_lat_margin);
+      if (precise_min_lat_dist_to_traj_poly > 0.0) {
         continue;
       }
 
@@ -330,21 +343,32 @@ VelocityPlanningResult ObstacleSlowDownModule::plan(
   debug_data_ptr_ = std::make_shared<DebugData>();
   decimated_traj_polys_ = std::nullopt;
 
+  // calculate collision points with trajectory with lateral stop margin
+  // NOTE: For additional margin, hysteresis is not divided by two.
+  const auto & p = obstacle_filtering_param_;
+  const auto & tp = planner_data->trajectory_polygon_collision_check;
+
   const auto decimated_traj_points = utils::decimate_trajectory_points_from_ego(
     raw_trajectory_points, planner_data->current_odometry.pose.pose,
     planner_data->ego_nearest_dist_threshold, planner_data->ego_nearest_yaw_threshold,
     planner_data->trajectory_polygon_collision_check.decimate_trajectory_step_length, 0.0);
 
+  const auto decimated_traj_polys_with_lat_margin = polygon_utils::create_one_step_polygons(
+    decimated_traj_points, planner_data->vehicle_info_, planner_data->current_odometry.pose.pose,
+    p.max_lat_margin + p.lat_hysteresis_margin, tp.enable_to_consider_current_pose,
+    tp.time_to_convergence, tp.decimate_trajectory_step_length);
+  debug_data_ptr_->decimated_traj_polys = decimated_traj_polys_with_lat_margin;
+
   auto slow_down_obstacles_for_predicted_object = filter_slow_down_obstacle_for_predicted_object(
     planner_data->current_odometry, planner_data->ego_nearest_dist_threshold,
-    planner_data->ego_nearest_yaw_threshold, raw_trajectory_points, decimated_traj_points,
-    planner_data->objects, rclcpp::Time(planner_data->predicted_objects_header.stamp),
-    planner_data->vehicle_info_, planner_data->trajectory_polygon_collision_check);
+    planner_data->ego_nearest_yaw_threshold, decimated_traj_polys_with_lat_margin,
+    raw_trajectory_points, planner_data->objects,
+    rclcpp::Time(planner_data->predicted_objects_header.stamp), planner_data->vehicle_info_,
+    planner_data->trajectory_polygon_collision_check);
 
   auto slow_down_obstacles_for_point_cloud = filter_slow_down_obstacle_for_point_cloud(
-    planner_data->current_odometry, raw_trajectory_points, decimated_traj_points,
-    planner_data->no_ground_pointcloud, planner_data->vehicle_info_,
-    planner_data->trajectory_polygon_collision_check,
+    raw_trajectory_points, decimated_traj_polys_with_lat_margin, planner_data->no_ground_pointcloud,
+    planner_data->vehicle_info_,
     planner_data->find_index(raw_trajectory_points, planner_data->current_odometry.pose.pose));
 
   const auto slow_down_obstacles = autoware::motion_velocity_planner::utils::concat_vectors(
@@ -381,8 +405,9 @@ std::string ObstacleSlowDownModule::get_module_name() const
 std::vector<SlowDownObstacle>
 ObstacleSlowDownModule::filter_slow_down_obstacle_for_predicted_object(
   const Odometry & odometry, const double ego_nearest_dist_threshold,
-  const double ego_nearest_yaw_threshold, const std::vector<TrajectoryPoint> & traj_points,
-  const std::vector<TrajectoryPoint> & decimated_traj_points,
+  const double ego_nearest_yaw_threshold,
+  const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
+  const std::vector<TrajectoryPoint> & traj_points,
   const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
   const rclcpp::Time & predicted_objects_stamp, const VehicleInfo & vehicle_info,
   const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check)
@@ -390,16 +415,6 @@ ObstacleSlowDownModule::filter_slow_down_obstacle_for_predicted_object(
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto & current_pose = odometry.pose.pose;
-
-  // calculate collision points with trajectory with lateral stop margin
-  // NOTE: For additional margin, hysteresis is not divided by two.
-  const auto & p = obstacle_filtering_param_;
-  const auto & tp = trajectory_polygon_collision_check;
-  const auto decimated_traj_polys_with_lat_margin = polygon_utils::create_one_step_polygons(
-    decimated_traj_points, vehicle_info, odometry.pose.pose,
-    p.max_lat_margin + p.lat_hysteresis_margin, tp.enable_to_consider_current_pose,
-    tp.time_to_convergence, tp.decimate_trajectory_step_length);
-  debug_data_ptr_->decimated_traj_polys = decimated_traj_polys_with_lat_margin;
 
   // slow down
   slow_down_condition_counter_.reset_current_uuids();
@@ -444,10 +459,9 @@ ObstacleSlowDownModule::filter_slow_down_obstacle_for_predicted_object(
 }
 
 std::vector<SlowDownObstacle> ObstacleSlowDownModule::filter_slow_down_obstacle_for_point_cloud(
-  const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
-  const std::vector<TrajectoryPoint> & decimated_traj_points,
-  const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
-  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx)
+  const std::vector<TrajectoryPoint> & traj_points,
+  const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
+  const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info, size_t ego_idx)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -455,19 +469,10 @@ std::vector<SlowDownObstacle> ObstacleSlowDownModule::filter_slow_down_obstacle_
     return std::vector<SlowDownObstacle>{};
   }
 
-  // calculate collision points with trajectory with lateral stop margin
-  // NOTE: For additional margin, hysteresis is not divided by two.
-  const auto & p = obstacle_filtering_param_;
-  const auto & tp = trajectory_polygon_collision_check;
-  const auto decimated_traj_polys_with_lat_margin = polygon_utils::create_one_step_polygons(
-    decimated_traj_points, vehicle_info, odometry.pose.pose,
-    p.max_lat_margin + p.lat_hysteresis_margin, tp.enable_to_consider_current_pose,
-    tp.time_to_convergence, tp.decimate_trajectory_step_length);
-  debug_data_ptr_->decimated_traj_polys = decimated_traj_polys_with_lat_margin;
-
   // Get Objects
   const std::vector<autoware::motion_velocity_planner::SlowDownPointData> slow_down_points_data =
-    convert_point_cloud_to_slow_down_points(point_cloud, traj_points, vehicle_info, ego_idx);
+    convert_point_cloud_to_slow_down_points(
+      point_cloud, traj_points, decimated_traj_polys_with_lat_margin, vehicle_info, ego_idx);
 
   // slow down
   std::vector<SlowDownObstacle> slow_down_obstacles;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
@@ -90,19 +90,20 @@ private:
   std::vector<autoware::motion_velocity_planner::SlowDownPointData>
   convert_point_cloud_to_slow_down_points(
     const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
     const VehicleInfo & vehicle_info, const size_t ego_idx);
   std::vector<SlowDownObstacle> filter_slow_down_obstacle_for_predicted_object(
     const Odometry & odometry, const double ego_nearest_dist_threshold,
-    const double ego_nearest_yaw_threshold, const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<TrajectoryPoint> & decimated_traj_points,
+    const double ego_nearest_yaw_threshold,
+    const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
+    const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
     const rclcpp::Time & predicted_objects_stamp, const VehicleInfo & vehicle_info,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
   std::vector<SlowDownObstacle> filter_slow_down_obstacle_for_point_cloud(
-    const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<TrajectoryPoint> & decimated_traj_points,
-    const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
-    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx);
+    const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
+    const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info, size_t ego_idx);
   std::optional<SlowDownObstacle> create_slow_down_obstacle_for_predicted_object(
     const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,


### PR DESCRIPTION
## Description
Pointcloud clusters too far from the footprint of the vehicle are considered to be obstructive and slow-down and stop modules are triggered unnecessarily.
This PR is for the universe changes.

## Related links

**Parent Issue:**

https://tier4.atlassian.net/browse/RT1-10023

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
