### PR TITLE
add lateral jerk validation to pc develope branch

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -15,6 +15,7 @@ The listed features below does not always correspond to the latest implementatio
 | Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, ratio parameter $r$, and offset parameter $c$ | $\lvert v \rvert > (1 + r) \lvert \hat{v} \rvert + c$ |
 | Overrun estimation: estimate overrun even if decelerate by assumed rate.           | assumed deceleration, assumed delay                                                             |                                                       |
 
+- **Lateral jerk** : invalid when the lateral jerk exceeds the configured threshold. The validation uses the vehicle's velocity and steering angle rate to calculate the resulting lateral jerk. The calculation assumes constant velocity (acceleration is zero).
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
 
 ![trajectory_deviation](./image/trajectory_deviation.drawio.svg)
@@ -61,6 +62,7 @@ The input trajectory is detected as invalid if the index exceeds the following t
 | Name                                      | Type   | Description                                                                                                 | Default value |
 | :---------------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
 | `thresholds.max_distance_deviation`       | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| `thresholds.lateral_jerk`                 | double | invalid threshold of the lateral jerk for steering rate validation [m/s^3]                                  | 10.0          |
 | `thresholds.rolling_back_velocity`        | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
 | `thresholds.over_velocity_offset`         | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
 | `thresholds.over_velocity_ratio`          | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -9,6 +9,7 @@
 
     thresholds:
       max_distance_deviation: 1.0
+      lateral_jerk: 2.0
       acc_error_offset: 0.8
       acc_error_scale: 0.2
       rolling_back_velocity: 0.5

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -45,6 +45,7 @@ using autoware_control_msgs::msg::Control;
 using autoware_control_validator::msg::ControlValidatorStatus;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils::get_or_declare_parameter;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
@@ -59,7 +60,7 @@ class LatencyValidator
 public:
   explicit LatencyValidator(rclcpp::Node & node)
   : nominal_latency_threshold{
-      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.nominal_latency")} {};
+      get_or_declare_parameter<double>(node, "thresholds.nominal_latency")} {};
 
   void validate(
     ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const;
@@ -77,8 +78,8 @@ class TrajectoryValidator
 {
 public:
   explicit TrajectoryValidator(rclcpp::Node & node)
-  : max_distance_deviation_threshold{autoware_utils::get_or_declare_parameter<double>(
-      node, "thresholds.max_distance_deviation")} {};
+  : max_distance_deviation_threshold{
+      get_or_declare_parameter<double>(node, "thresholds.max_distance_deviation")} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
@@ -86,6 +87,29 @@ public:
 
 private:
   const double max_distance_deviation_threshold;
+};
+
+/**
+ * @class LateralJerkValidator
+ * @brief Validates lateral jerk is not too high.
+ */
+class LateralJerkValidator
+{
+public:
+  explicit LateralJerkValidator(rclcpp::Node & node)
+  : lateral_jerk_threshold_{get_or_declare_parameter<double>(node, "thresholds.lateral_jerk")},
+    logger_{node.get_logger()},
+    measured_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
+
+  void validate(
+    ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
+    const double wheel_base);
+
+private:
+  double lateral_jerk_threshold_{};  // m/s^3
+  rclcpp::Logger logger_;
+  std::unique_ptr<Control> prev_control_cmd_{};
+  autoware::signal_processing::LowpassFilter1d measured_vel_lpf;
 };
 
 /**
@@ -97,10 +121,10 @@ class AccelerationValidator
 public:
   friend class AccelerationValidatorTest;
   explicit AccelerationValidator(rclcpp::Node & node)
-  : e_offset{autoware_utils::get_or_declare_parameter<double>(node, "thresholds.acc_error_offset")},
-    e_scale{autoware_utils::get_or_declare_parameter<double>(node, "thresholds.acc_error_scale")},
-    desired_acc_lpf{autoware_utils::get_or_declare_parameter<double>(node, "acc_lpf_gain")},
-    measured_acc_lpf{autoware_utils::get_or_declare_parameter<double>(node, "acc_lpf_gain")} {};
+  : e_offset{get_or_declare_parameter<double>(node, "thresholds.acc_error_offset")},
+    e_scale{get_or_declare_parameter<double>(node, "thresholds.acc_error_scale")},
+    desired_acc_lpf{get_or_declare_parameter<double>(node, "acc_lpf_gain")},
+    measured_acc_lpf{get_or_declare_parameter<double>(node, "acc_lpf_gain")} {};
 
   void validate(
     ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
@@ -122,16 +146,16 @@ class VelocityValidator
 {
 public:
   explicit VelocityValidator(rclcpp::Node & node)
-  : rolling_back_velocity_th{autoware_utils::get_or_declare_parameter<double>(
+  : rolling_back_velocity_th{get_or_declare_parameter<double>(
       node, "thresholds.rolling_back_velocity")},
     over_velocity_ratio_th{
-      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.over_velocity_ratio")},
+      get_or_declare_parameter<double>(node, "thresholds.over_velocity_ratio")},
     over_velocity_offset_th{
-      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.over_velocity_offset")},
+      get_or_declare_parameter<double>(node, "thresholds.over_velocity_offset")},
     hold_velocity_error_until_stop{
-      autoware_utils::get_or_declare_parameter<bool>(node, "hold_velocity_error_until_stop")},
-    vehicle_vel_lpf{autoware_utils::get_or_declare_parameter<double>(node, "vel_lpf_gain")},
-    target_vel_lpf{autoware_utils::get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
+      get_or_declare_parameter<bool>(node, "hold_velocity_error_until_stop")},
+    vehicle_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")},
+    target_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
@@ -154,15 +178,13 @@ class OverrunValidator
 {
 public:
   explicit OverrunValidator(rclcpp::Node & node)
-  : overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
+  : overrun_stop_point_dist_th{get_or_declare_parameter<double>(
       node, "thresholds.overrun_stop_point_dist")},
-    will_overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
-      node, "thresholds.will_overrun_stop_point_dist")},
-    assumed_limit_acc{
-      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_limit_acc")},
-    assumed_delay_time{
-      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_delay_time")},
-    vehicle_vel_lpf{autoware_utils::get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
+    will_overrun_stop_point_dist_th{
+      get_or_declare_parameter<double>(node, "thresholds.will_overrun_stop_point_dist")},
+    assumed_limit_acc{get_or_declare_parameter<double>(node, "thresholds.assumed_limit_acc")},
+    assumed_delay_time{get_or_declare_parameter<double>(node, "thresholds.assumed_delay_time")},
+    vehicle_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
@@ -213,6 +235,11 @@ private:
   void publish_debug_info(const geometry_msgs::msg::Pose & ego_pose);
 
   /**
+   * @brief Generate error message based on validation status
+   */
+  std::string generate_error_message(const ControlValidatorStatus & s);
+
+  /**
    * @brief Display validation status on terminal
    */
   void display_status();
@@ -257,6 +284,7 @@ private:
 
   // individual validators
   LatencyValidator latency_validator{*this};
+  LateralJerkValidator lateral_jerk_validator{*this};
   TrajectoryValidator trajectory_validator{*this};
   AccelerationValidator acceleration_validator{*this};
   VelocityValidator velocity_validator{*this};

--- a/control/autoware_control_validator/include/autoware/control_validator/debug_marker.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/debug_marker.hpp
@@ -38,15 +38,9 @@ public:
   /**
    * @brief Push a virtual wall
    * @param pose pose of the virtual wall
+   * @param msg message to be displayed
    */
-  void push_virtual_wall(const geometry_msgs::msg::Pose & pose);
-
-  /**
-   * @brief Push a warning message
-   * @param pose pose of the warning message
-   * @param msg warning message
-   */
-  void push_warning_msg(const geometry_msgs::msg::Pose & pose, const std::string & msg);
+  void push_virtual_wall(const geometry_msgs::msg::Pose & pose, const std::string & msg);
 
   /**
    * @brief Publish markers

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -5,12 +5,15 @@ bool is_valid_max_distance_deviation
 bool is_valid_acc
 bool is_rolling_back
 bool is_over_velocity
+bool is_valid_lateral_jerk
 bool has_overrun_stop_point
 bool will_overrun_stop_point
 bool is_valid_latency
 
 # values
 float64 max_distance_deviation
+float64 steering_rate
+float64 lateral_jerk
 float64 desired_acc
 float64 measured_acc
 float64 target_vel

--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -5,10 +5,10 @@
   <version>0.41.0</version>
   <description>ros node for autoware_control_validator</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
-  <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/control/autoware_control_validator/script/max_steering_rate_checker.py
+++ b/control/autoware_control_validator/script/max_steering_rate_checker.py
@@ -1,0 +1,156 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def calculate_max_steering_rate(velocity, wheel_base, max_lateral_jerk):
+    """Calculate maximum allowable steering rate based on comfort criteria (max lateral jerk).
+
+    Uses simplified lateral jerk formula with approximations: tan(δ) ≈ δ and (1 + tan²(δ)) ≈ 1
+
+    Formula: dδ/dt = (j_y · L) / V²
+
+    Args:
+        velocity: Longitudinal velocity [m/s]
+        wheel_base: Vehicle wheelbase [m]
+        max_lateral_jerk: Maximum allowable lateral jerk [m/s³]
+
+    Returns:
+        Maximum allowable steering rate [rad/s]
+    """
+    # Ensure velocity is at least 0.1 to avoid division by zero
+    safe_velocity = np.maximum(velocity, 0.1)
+
+    # Calculate max steering rate (simplified formula)
+    max_steering_rate = (max_lateral_jerk * wheel_base) / (safe_velocity**2)
+
+    return max_steering_rate
+
+
+def main():
+    # Set up argument parser
+    parser = argparse.ArgumentParser(
+        description="Calculate maximum allowable steering rate based on comfort criteria."
+    )
+    parser.add_argument(
+        "--wheel_base",
+        type=float,
+        default=2.74,
+        help="Wheel base [m]",
+    )
+    parser.add_argument(
+        "--max_velocity",
+        type=float,
+        default=35.0,
+        help="Maximum velocity [m/s]",
+    )
+    parser.add_argument(
+        "--max_lateral_jerk",
+        type=float,
+        default=5.0,
+        help="Maximum allowable lateral jerk [m/s³]",
+    )
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Extract parameters
+    wheel_base = args.wheel_base
+    max_velocity = args.max_velocity
+    max_lateral_jerk = args.max_lateral_jerk
+
+    # Create velocity range for curve
+    velocities = np.linspace(0.1, max_velocity, 100)
+
+    # Calculate max steering rates
+    steer_rates = calculate_max_steering_rate(velocities, wheel_base, max_lateral_jerk)
+    steer_rates_deg = np.degrees(steer_rates)
+
+    # Generate sample velocities automatically (6 points evenly spaced)
+    num_samples = 6
+    sample_velocities = np.linspace(max(1.0, max_velocity * 0.1), max_velocity * 0.9, num_samples)
+    sample_velocities = np.round(
+        sample_velocities, 1
+    )  # Round to 1 decimal point for cleaner display
+
+    # Calculate rates for sample points
+    sample_rates = [
+        np.degrees(calculate_max_steering_rate(v, wheel_base, max_lateral_jerk))
+        for v in sample_velocities
+    ]
+
+    # Create the plot
+    plt.figure(figsize=(10, 6))
+
+    # Plot the curve
+    plt.plot(velocities, steer_rates_deg, "b-", linewidth=2, label="Max Steering Rate")
+
+    # Add sample points
+    plt.plot(sample_velocities, sample_rates, "ro", markersize=8, label="Reference Points")
+
+    # Add labels for sample points - adjust vertical position based on value
+    for v, r in zip(sample_velocities, sample_rates):
+        # Adjust text vertical position to avoid overlap
+        offset = 1.5 if r < 20 else -2.0  # Place text above or below point based on value
+        plt.text(v, r + offset, f"{r:.1f} deg/s", ha="center")
+
+    # Configure plot
+    plt.title(
+        f"Maximum Allowable Steering Rate vs. Velocity\nWheel Base: {wheel_base}m, Max Lateral Jerk: {max_lateral_jerk} m/s³"
+    )
+    plt.xlabel("Velocity [m/s]")
+    plt.ylabel("Max Steering Rate [deg/s]")
+    plt.grid(True, linestyle="--", alpha=0.7)
+    plt.xlim(0, max_velocity)
+
+    max_rate = np.max(steer_rates_deg)
+    plt.ylim(
+        0, min(max_rate * 1.2, 250)
+    )  # Set upper limit to 20% above max value or 250, whichever is smaller
+
+    plt.legend(loc="upper right")
+
+    # Adjust layout to leave room for the formula text
+    plt.subplots_adjust(bottom=0.15)
+
+    # Add formula text
+    # cSpell:ignore figtext boxstyle
+    plt.figtext(
+        0.5,
+        0.02,
+        "Formula: dδ/dt = (j_y · L) / V² (where j_y = 5.0 m/s³)",
+        ha="center",
+        fontsize=12,
+        bbox={"facecolor": "white", "alpha": 0.8, "boxstyle": "round"},
+    )
+
+    # Print reference table
+    print("\nMax Steering Rate Reference Table:")
+    print("-" * 50)
+    print("Velocity (m/s) | Max Steering Rate (deg/s)")
+    print("-" * 50)
+
+    for v, r in zip(sample_velocities, sample_rates):
+        print(f"{v:13.1f} | {r:22.2f}")
+
+    # Show plot in a popup window
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::control_validator
 {
@@ -44,6 +45,54 @@ void TrajectoryValidator::validate(
     calc_max_lateral_distance(reference_trajectory, predicted_trajectory);
   res.is_valid_max_distance_deviation =
     res.max_distance_deviation <= max_distance_deviation_threshold;
+}
+
+void LateralJerkValidator::validate(
+  ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
+  const double wheel_base)
+{
+  const double filtered_velocity = measured_vel_lpf.filter(kinematic_state.twist.twist.linear.x);
+  const double steering_cmd = control_cmd.lateral.steering_tire_angle;
+
+  if (!prev_control_cmd_) {
+    prev_control_cmd_ = std::make_unique<Control>(control_cmd);
+    return;
+  }
+
+  // Calculate time difference
+  rclcpp::Time current_time(control_cmd.stamp);
+  rclcpp::Time prev_time(prev_control_cmd_->stamp);
+  const double dt = (current_time - prev_time).seconds();
+
+  const double prev_steering_cmd = prev_control_cmd_->lateral.steering_tire_angle;
+  const double steering_rate = (steering_cmd - prev_steering_cmd) / dt;
+
+  // Calculate lateral jerk with the formula
+  // j_y = (1/L) * [2V * a_x * θ + V^2 * (dθ/dt)]
+  //
+  // Where:
+  // - L: wheel base
+  // - V: longitudinal velocity
+  // - a_x: longitudinal acceleration (assumed to be zero for constant velocity)
+  // - dθ/dt: steering angle rate of change
+  //
+  // Note: The calculation assumes constant velocity (a_x = 0), so the first term is omitted.
+  const double lateral_jerk =
+    (1.0 / wheel_base) * (filtered_velocity * filtered_velocity * steering_rate);
+
+  res.steering_rate = steering_rate;
+  res.lateral_jerk = lateral_jerk;
+  // Note: Assuming left-right symmetry, only considering the magnitude of jerk
+  res.is_valid_lateral_jerk = std::abs(lateral_jerk) < lateral_jerk_threshold_;
+  if (!res.is_valid_lateral_jerk) {
+    RCLCPP_DEBUG(
+      logger_, "Lateral jerk is too high. %f > %f", std::abs(lateral_jerk),
+      lateral_jerk_threshold_);
+    RCLCPP_DEBUG(
+      logger_, "steering_cmd: %f, prev_steering_cmd: %f, dt: %f", steering_cmd,
+      prev_control_cmd_->lateral.steering_tire_angle, dt);
+  }
+  prev_control_cmd_ = std::make_unique<Control>(control_cmd);
 }
 
 void AccelerationValidator::validate(
@@ -243,6 +292,12 @@ void ControlValidator::setup_diag()
     set_status(
       stat, validation_status_.is_valid_latency, "The latency is larger than expected value.");
   });
+
+  d.add(ns + "steering_rate", [&](auto & stat) {
+    set_status(
+      stat, validation_status_.is_valid_lateral_jerk,
+      "The lateral jerk is larger than expected value.");
+  });
 }
 
 void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
@@ -261,7 +316,7 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
   }
   Trajectory::ConstSharedPtr predicted_trajectory_msg = sub_predicted_traj_->take_data();
   if (!predicted_trajectory_msg) {
-    return waiting(sub_reference_traj_->subscriber()->get_topic_name());
+    return waiting(sub_predicted_traj_->subscriber()->get_topic_name());
   }
   Trajectory::ConstSharedPtr reference_trajectory_msg = sub_reference_traj_->take_data();
   if (!reference_trajectory_msg) {
@@ -290,6 +345,10 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
 
   // validation process
   latency_validator.validate(validation_status_, *control_cmd_msg, *this);
+
+  lateral_jerk_validator.validate(
+    validation_status_, *kinematics_msg, *control_cmd_msg, vehicle_info_.wheel_base_m);
+
   if (predicted_trajectory_msg->points.size() < 2) {
     // TODO(takagi): This check should be moved into each of the individual validate() functions.
     // Passing the rclcpp::Logger as an argument to the validate() function is necessary.
@@ -319,8 +378,8 @@ void ControlValidator::publish_debug_info(const geometry_msgs::msg::Pose & ego_p
   if (!is_all_valid(validation_status_)) {
     geometry_msgs::msg::Pose front_pose = ego_pose;
     shift_pose(front_pose, vehicle_info_.front_overhang_m + vehicle_info_.wheel_base_m);
-    debug_pose_publisher_->push_virtual_wall(front_pose);
-    debug_pose_publisher_->push_warning_msg(front_pose, "INVALID CONTROL");
+    std::string error_message = generate_error_message(validation_status_);
+    debug_pose_publisher_->push_virtual_wall(front_pose, error_message);
   }
   debug_pose_publisher_->publish();
 
@@ -333,18 +392,66 @@ void ControlValidator::publish_debug_info(const geometry_msgs::msg::Pose & ego_p
 
 bool ControlValidator::is_all_valid(const ControlValidatorStatus & s)
 {
-  return s.is_valid_max_distance_deviation && s.is_valid_acc && !s.is_rolling_back &&
-         !s.is_over_velocity && !s.has_overrun_stop_point && !s.will_overrun_stop_point;
+  return s.is_valid_lateral_jerk && s.is_valid_max_distance_deviation && s.is_valid_acc &&
+         !s.is_rolling_back && !s.is_over_velocity && !s.has_overrun_stop_point &&
+         !s.will_overrun_stop_point;
+}
+
+std::string ControlValidator::generate_error_message(const ControlValidatorStatus & s)
+{
+  std::vector<std::string> error_messages;
+
+  if (!s.is_valid_lateral_jerk) {
+    error_messages.push_back("HIGH LATERAL JERK");
+  }
+
+  if (!s.is_valid_max_distance_deviation) {
+    error_messages.push_back("TRAJECTORY DEVIATION");
+  }
+
+  if (!s.is_valid_acc) {
+    error_messages.push_back("ACCELERATION ERROR");
+  }
+
+  if (s.is_rolling_back) {
+    error_messages.push_back("ROLLING BACK");
+  }
+
+  if (s.is_over_velocity) {
+    error_messages.push_back("OVER VELOCITY");
+  }
+
+  if (s.has_overrun_stop_point) {
+    error_messages.push_back("OVERRUN STOP POINT");
+  }
+
+  if (s.will_overrun_stop_point) {
+    error_messages.push_back("WILL OVERRUN STOP POINT");
+  }
+
+  if (error_messages.empty()) {
+    return "INVALID CONTROL";
+  }
+
+  if (error_messages.size() == 1) {
+    return error_messages[0];
+  } else {
+    std::string result = error_messages[0];
+    for (size_t i = 1; i < error_messages.size(); ++i) {
+      result += ", " + error_messages[i];
+    }
+    return result;
+  }
 }
 
 void ControlValidator::display_status()
 {
   if (!display_on_terminal_) return;
-  rclcpp::Clock clock{RCL_ROS_TIME};
+  static rclcpp::Clock clock{RCL_ROS_TIME};
 
-  const auto warn = [this, &clock](const bool status, const std::string & msg) {
+  const auto warn = [this](const bool status, const std::string & msg, const double value) {
     if (!status) {
-      RCLCPP_WARN_THROTTLE(get_logger(), clock, 1000, "%s", msg.c_str());
+      RCLCPP_WARN_THROTTLE(get_logger(), clock, 1000, "%s: %.2f", msg.c_str(), value);
     }
   };
 
@@ -352,7 +459,11 @@ void ControlValidator::display_status()
 
   warn(
     s.is_valid_max_distance_deviation,
-    "predicted trajectory is too far from planning trajectory!!");
+    "predicted trajectory is too far from planning trajectory with max distance deviation: ",
+    s.max_distance_deviation);
+  warn(
+    s.is_valid_lateral_jerk,
+    "lateral jerk exceeds safety threshold with steering rate: ", s.steering_rate);
 }
 
 }  // namespace autoware::control_validator

--- a/control/autoware_control_validator/src/debug_marker.cpp
+++ b/control/autoware_control_validator/src/debug_marker.cpp
@@ -37,24 +37,13 @@ void ControlValidatorDebugMarkerPublisher::clear_markers()
   marker_array_virtual_wall_.markers.clear();
 }
 
-void ControlValidatorDebugMarkerPublisher::push_warning_msg(
+void ControlValidatorDebugMarkerPublisher::push_virtual_wall(
   const geometry_msgs::msg::Pose & pose, const std::string & msg)
 {
-  visualization_msgs::msg::Marker marker = autoware_utils::create_default_marker(
-    "map", node_->get_clock()->now(), "warning_msg", 0, Marker::TEXT_VIEW_FACING,
-    autoware_utils::create_marker_scale(0.0, 0.0, 1.0),
-    autoware_utils::create_marker_color(1.0, 0.1, 0.1, 0.999));
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.pose = pose;
-  marker.text = msg;
-  marker_array_virtual_wall_.markers.push_back(marker);
-}
-
-void ControlValidatorDebugMarkerPublisher::push_virtual_wall(const geometry_msgs::msg::Pose & pose)
-{
   const auto now = node_->get_clock()->now();
+  std::string display_msg = "control_validator \n(" + msg + ")";
   const auto stop_wall_marker =
-    autoware::motion_utils::createStopVirtualWallMarker(pose, "control_validator", now, 0);
+    autoware::motion_utils::createStopVirtualWallMarker(pose, display_msg, now, 0);
   autoware_utils::append_marker_array(stop_wall_marker, &marker_array_virtual_wall_, now);
 }
 


### PR DESCRIPTION
## Description

add lateral jerk validation to pc develope branch
cherry pick of the [PR](https://github.com/autowarefoundation/autoware_universe/pull/10619)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
