### PR TITLE
feat(crosswalk): comfortable stop for uncertain yield judgement

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -45,6 +45,7 @@
         ego_pass_later_margin_y: [13.0] # [[s]] time to collision margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_additional_margin: 0.5 # [s] additional time margin for object pass first situation to suppress chattering
         ego_min_assumed_speed: 2.0 # [m/s] assumed speed to calculate the time to collision point
+        uncertain_yield_offset: 2.0
 
         no_stop_decision: # parameters to determine stop cancel. {-$overrun_threshold_length + f($min_acc, $min_jerk)} is compared against distance to stop pose.
           min_acc: -1.5 # min acceleration [m/ss]

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
@@ -44,7 +44,7 @@ using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using tier4_planning_msgs::msg::StopFactor;
 
-enum class CollisionState { YIELD, EGO_PASS_FIRST, EGO_PASS_LATER, IGNORE };
+enum class CollisionState { YIELD, UNCERTAIN_YIELD, EGO_PASS_FIRST, EGO_PASS_LATER, IGNORE };
 
 struct CollisionPoint
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
@@ -18,6 +18,7 @@
 #include <autoware/motion_utils/marker/marker_helper.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <magic_enum.hpp>
 
 #include <vector>
 
@@ -53,23 +54,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
       string_stream << std::fixed << std::setprecision(2);
       string_stream << "(module, ttc, ttv, state)=(" << module_id << " , "
                     << point.time_to_collision << " , " << point.time_to_vehicle;
-      switch (state) {
-        case CollisionState::YIELD:
-          string_stream << " , YIELD)";
-          break;
-        case CollisionState::EGO_PASS_FIRST:
-          string_stream << " , EGO_PASS_FIRST)";
-          break;
-        case CollisionState::EGO_PASS_LATER:
-          string_stream << " , EGO_PASS_LATER)";
-          break;
-        case CollisionState::IGNORE:
-          string_stream << " , IGNORE)";
-          break;
-        default:
-          string_stream << " , NONE)";
-          break;
-      }
+      string_stream << " ," << magic_enum::enum_name(state) << ")";
       marker.text = string_stream.str();
       marker.pose.position = point.collision_point;
       marker.pose.position.z += 2.0 + i * 0.5;  // NOTE: so that the texts will not overlap

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -106,6 +106,8 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<double>(node, ns + ".pass_judge.ego_pass_later_additional_margin");
   cp.ego_min_assumed_speed =
     get_or_declare_parameter<double>(node, ns + ".pass_judge.ego_min_assumed_speed");
+  cp.uncertain_yield_offset =
+    get_or_declare_parameter<double>(node, ns + ".pass_judge.uncertain_yield_offset");
   cp.min_acc_for_no_stop_decision =
     get_or_declare_parameter<double>(node, ns + ".pass_judge.no_stop_decision.min_acc");
   cp.min_jerk_for_no_stop_decision =


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
