### PR TITLE
feat(out_of_lane): cherry pick out of lane improvements

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -9,8 +9,8 @@
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 1.0 # [s] threshold for difference in time to ovelrap region between ego and target object to trigger stop decision
-        release_threshold: 2.0 # [s] threshold for difference in time to the ovelrap region between ego and target object to release stop decision
+        threshold: 1.0 # [s] threshold for difference in time to overlap region between ego and target object to trigger stop decision
+        release_threshold: 2.0 # [s] threshold for difference in time to the overlap region between ego and target object to release stop decision
 
 
       objects:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -22,6 +22,7 @@
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
         min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
+        min_update_distance: 5.0 # [m] minimum distance needed to update previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap
           velocity: 2.0  # [m/s] slowdown velocity

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -3,7 +3,6 @@
     out_of_lane:  # module to stop or slowdown before overlapping another lane with other objects
       mode: ttc # mode used to consider a conflict with an object. "threshold", or "ttc"
       skip_if_already_overlapping: false # do not run this module when ego already overlaps another lane
-      ignore_overlaps_over_lane_changeable_lanelets: true  # if true, overlaps on lane changeable lanelets are ignored
       max_arc_length: 100.0  # [m] maximum trajectory arc length that is checked for out_of_lane collisions
 
       threshold:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -23,7 +23,8 @@
         precision: 0.1  # [m] precision when inserting a stop pose in the trajectory
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
-        min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
+        min_on_duration: 1.0  # [s] minimum duration needed before a decision can be triggered
+        min_off_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
         update_distance_th: 5.0 # [m] distance threshold for updating previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -9,7 +9,9 @@
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 1.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
+        threshold: 1.0 # [s] threshold for difference in time to ovelrap region between ego and target object to trigger stop decision
+        release_threshold: 2.0 # [s] threshold for difference in time to the ovelrap region between ego and target object to release stop decision
+
 
       objects:
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -22,7 +22,7 @@
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
         min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
-        min_update_distance: 5.0 # [m] minimum distance needed to update previous stop pose position
+        update_distance_th: 5.0 # [m] distance threshold for updating previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap
           velocity: 2.0  # [m/s] slowdown velocity

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/lanelets_selection.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/lanelets_selection.hpp
@@ -47,16 +47,6 @@ lanelet::ConstLanelets calculate_trajectory_lanelets(
   const autoware_utils::LineString2d & trajectory_ls,
   const std::shared_ptr<const route_handler::RouteHandler> route_handler);
 
-/// @brief calculate lanelets that may not be crossed by the trajectory but may be overlapped during
-/// a lane change
-/// @param [in] trajectory_lanelets lanelets driven by the ego vehicle
-/// @param [in] route_handler route handler
-/// @return lanelets that may be overlapped by a lane change (and are not already in
-/// trajectory_lanelets)
-lanelet::ConstLanelets get_missing_lane_change_lanelets(
-  const lanelet::ConstLanelets & trajectory_lanelets,
-  const std::shared_ptr<const route_handler::RouteHandler> & route_handler);
-
 /// @brief calculate lanelets that should be ignored
 /// @param [in] trajectory_lanelets lanelets followed by the ego vehicle
 /// @param [in] route_handler route handler

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -115,14 +115,15 @@ void calculate_min_max_arrival_times(
 void calculate_collisions_to_avoid(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-  const PlannerParam & params)
+  const PlannerParam & params, const bool is_stopping)
 {
   for (auto & out_of_lane_point : out_of_lane_data.outside_points) {
     calculate_min_max_arrival_times(out_of_lane_point, trajectory);
   }
   for (auto & p : out_of_lane_data.outside_points) {
     if (params.mode == "ttc") {
-      p.to_avoid = p.ttc && p.ttc <= params.ttc_threshold;
+      const auto threshold = is_stopping ? params.ttc_release_threshold : params.ttc_threshold;
+      p.to_avoid = p.ttc && p.ttc <= threshold;
     } else {
       p.to_avoid = p.min_object_arrival_time && p.min_object_arrival_time <= params.time_threshold;
     }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
@@ -45,7 +45,7 @@ void calculate_objects_time_collisions(
 void calculate_collisions_to_avoid(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-  const PlannerParam & params);
+  const PlannerParam & params, const bool is_stopping = false);
 
 /// @brief calculate the out of lane points
 std::vector<OutOfLanePoint> calculate_out_of_lane_points(const EgoData & ego_data);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -329,7 +329,8 @@ VelocityPlanningResult OutOfLaneModule::plan(
 
   stopwatch.tic("calculate_times");
   const auto is_stopping = previous_slowdown_pose_ ? true : false;
-  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
+  out_of_lane::calculate_collisions_to_avoid(
+    out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -227,10 +227,10 @@ std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose
   if (slowdown_pose_buffer_.empty()) return {};
 
   // get nearest slowdown pose
-  const auto min_arc_length = std::numeric_limits<double>::max();
   out_of_lane::SlowdownPose nearest_slowdown_pose;
+  nearest_slowdown_pose.arc_length = std::numeric_limits<double>::max();
   for (const auto & sp : slowdown_pose_buffer_) {
-    if (sp.arc_length < min_arc_length) nearest_slowdown_pose = sp;
+    if (sp.arc_length < nearest_slowdown_pose.arc_length) nearest_slowdown_pose = sp;
   }
 
   slowdown_pose = motion_utils::calcInterpolatedPose(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -356,8 +356,7 @@ VelocityPlanningResult OutOfLaneModule::plan(
 
   stopwatch.tic("calculate_times");
   const auto is_stopping = previous_slowdown_pose_ ? true : false;
-  out_of_lane::calculate_collisions_to_avoid(
-    out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
+  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -224,14 +224,14 @@ out_of_lane::OutOfLaneData prepare_out_of_lane_data(const out_of_lane::EgoData &
 std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose(
   const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data)
 {
-  auto slowdown_pose = out_of_lane::calculate_slowdown_pose(ego_data, out_of_lane_data, params_);
+  auto slowdown_pose = out_of_lane::calculate_slowdown_point(ego_data, out_of_lane_data, params_);
 
   update_slowdown_pose_buffer(ego_data, slowdown_pose);
 
   if (slowdown_pose_buffer_.empty()) return {};
 
   // get nearest active slowdown pose
-  const auto min_arc_length = std::numeric_limits<double>::max();
+  auto min_arc_length = std::numeric_limits<double>::max();
   std::optional<out_of_lane::SlowdownPose> nearest_slowdown_pose = {};
   for (const auto & sp : slowdown_pose_buffer_) {
     if (sp.arc_length > min_arc_length || !sp.is_active) continue;
@@ -265,7 +265,7 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
     if (!sp.is_active && !slowdown_pose) continue;
 
     sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
-    if (!sp.is_active && abs(sp.arc_length - slowdown_pose_arc_length) > params_.min_update_distance) {
+    if (!sp.is_active && abs(sp.arc_length - slowdown_pose_arc_length) > params_.update_distance_th) {
       continue;
     }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -247,36 +247,34 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
   const out_of_lane::EgoData & ego_data,
   const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
 {
+  const double slowdown_pose_arc_length = slowdown_pose ?
+    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position) :
+    std::numeric_limits<double>::max();
+
+  // remove no longer valid slowdown poses in the buffer:
+  //  slowdown poses that are active but have exceeded the duration threshold since last detection
+  //  slowdown poses that are invalid and not near the new slowdown pose
   std::vector<out_of_lane::SlowdownPose> valid_poses;
   for (auto & sp : slowdown_pose_buffer_) {
-    if (sp.is_active && (clock_->now() - sp.start_time).seconds() > params_.min_off_duration)
+    const auto sp_duration = (clock_->now() - sp.start_time).seconds();
+    if (sp.is_active && sp_duration > params_.min_off_duration) continue;
+    if (!sp.is_active && !slowdown_pose) continue;
+
+    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
+    if (!sp.is_active && abs(sp.arc_length - slowdown_pose_arc_length) > params_.min_update_distance) {
       continue;
-    if (!sp.is_active && !slowdown_pose)
-      continue;
+    }
+
     if (!sp.is_active && (clock_->now() - sp.start_time).seconds() > params_.min_on_duration) {
       sp.is_active = true;
       sp.start_time = clock_->now();
     }
-    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
     valid_poses.push_back(sp);
   }
 
-  if (!slowdown_pose) {
-    slowdown_pose_buffer_ = valid_poses;
-    return;
-  }
+  slowdown_pose_buffer_ = valid_poses;
 
-  slowdown_pose_buffer_.clear();
-
-  const auto slowdown_pose_arc_length =
-    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position);
-
-  std::copy_if(
-    valid_poses.begin(), valid_poses.end(), std::back_inserter(slowdown_pose_buffer_),
-    [&] (const auto & vp) {
-      return vp.is_active || abs(vp.arc_length - slowdown_pose_arc_length) < params_.min_update_distance;
-    }
-  );
+  if (!slowdown_pose) return;
 
   if (slowdown_pose_buffer_.empty()) {
     slowdown_pose_buffer_.emplace_back(slowdown_pose_arc_length, clock_->now(), *slowdown_pose, false);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -86,6 +86,7 @@ void OutOfLaneModule::init_parameters(rclcpp::Node & node)
 
   pp.time_threshold = get_or_declare_parameter<double>(node, ns_ + ".threshold.time_threshold");
   pp.ttc_threshold = get_or_declare_parameter<double>(node, ns_ + ".ttc.threshold");
+  pp.ttc_release_threshold = get_or_declare_parameter<double>(node, ns_ + ".ttc.release_threshold");
 
   pp.objects_min_vel = get_or_declare_parameter<double>(node, ns_ + ".objects.minimum_velocity");
   pp.objects_min_confidence =
@@ -128,6 +129,7 @@ void OutOfLaneModule::update_parameters(const std::vector<rclcpp::Parameter> & p
 
   update_param(parameters, ns_ + ".threshold.time_threshold", pp.time_threshold);
   update_param(parameters, ns_ + ".ttc.threshold", pp.ttc_threshold);
+  update_param(parameters, ns_ + ".ttc.release_threshold", pp.ttc_release_threshold);
 
   update_param(parameters, ns_ + ".objects.minimum_velocity", pp.objects_min_vel);
   update_param(
@@ -326,8 +328,8 @@ VelocityPlanningResult OutOfLaneModule::plan(
   const auto calculate_time_collisions_us = stopwatch.toc("calculate_time_collisions");
 
   stopwatch.tic("calculate_times");
-  // calculate times
-  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_);
+  const auto is_stopping = previous_slowdown_pose_ ? true : false;
+  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -243,7 +243,7 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
 {
   std::vector<out_of_lane::SlowdownPose> valid_poses;
   for (auto & sp : slowdown_pose_buffer_) {
-    if ((clock_->now() - sp.start_time).seconds() <= params_.min_decision_duration)
+    if ((clock_->now() - sp.start_time).seconds() > params_.min_decision_duration)
       continue;
     sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
     valid_poses.push_back(sp);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -41,6 +41,7 @@
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -96,6 +97,7 @@ void OutOfLaneModule::init_parameters(rclcpp::Node & node)
 
   pp.precision = get_or_declare_parameter<double>(node, ns_ + ".action.precision");
   pp.min_decision_duration = get_or_declare_parameter<double>(node, ns_ + ".action.min_duration");
+  pp.min_update_distance = get_or_declare_parameter<double>(node, ns_ + ".action.min_update_distance");
   pp.lon_dist_buffer =
     get_or_declare_parameter<double>(node, ns_ + ".action.longitudinal_distance_buffer");
   pp.lat_dist_buffer =
@@ -214,6 +216,72 @@ out_of_lane::OutOfLaneData prepare_out_of_lane_data(const out_of_lane::EgoData &
   return out_of_lane_data;
 }
 
+std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose(
+  const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data)
+{
+  auto slowdown_pose = out_of_lane::calculate_slowdown_pose(ego_data, out_of_lane_data, params_);
+
+  update_slowdown_pose_buffer(ego_data, slowdown_pose);
+
+  if (slowdown_pose_buffer_.empty()) return {};
+
+  // get nearest slowdown pose
+  const auto min_arc_length = std::numeric_limits<double>::max();
+  out_of_lane::SlowdownPose nearest_slowdown_pose;
+  for (const auto & sp : slowdown_pose_buffer_) {
+    if (sp.arc_length < min_arc_length) nearest_slowdown_pose = sp;
+  }
+
+  slowdown_pose =
+    motion_utils::calcInterpolatedPose(ego_data.trajectory_points, nearest_slowdown_pose.arc_length);
+
+  return slowdown_pose;
+}
+
+void OutOfLaneModule::update_slowdown_pose_buffer(
+  const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
+{
+  std::vector<out_of_lane::SlowdownPose> valid_poses;
+  for (auto & sp : slowdown_pose_buffer_) {
+    if ((clock_->now() - sp.start_time).seconds() <= params_.min_decision_duration)
+      continue;
+    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
+    valid_poses.push_back(sp);
+  }
+  slowdown_pose_buffer_ = valid_poses;
+
+  if (!slowdown_pose) return;
+
+  const auto slowdown_pose_arc_length =
+    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position);
+
+  if (slowdown_pose_buffer_.empty()) {
+    slowdown_pose_buffer_.emplace_back(slowdown_pose_arc_length, clock_->now(), *slowdown_pose);
+    return;
+  }
+
+  auto nearest_prev_pose_it = slowdown_pose_buffer_.end();
+  auto min_relative_dist = std::numeric_limits<double>::max();
+  for (auto it = slowdown_pose_buffer_.begin(); it < slowdown_pose_buffer_.end(); ++it) {
+    const auto rel_dist = it->arc_length - slowdown_pose_arc_length;
+    if (std::abs(rel_dist) < params_.min_update_distance && rel_dist < min_relative_dist) {
+      nearest_prev_pose_it = it;
+      min_relative_dist = rel_dist;
+    }
+  }
+
+  if (nearest_prev_pose_it == slowdown_pose_buffer_.end()) {
+    slowdown_pose_buffer_.emplace_back(slowdown_pose_arc_length, clock_->now(), *slowdown_pose);
+    return;
+  }
+
+  if (min_relative_dist > 0) {
+    nearest_prev_pose_it->pose = *slowdown_pose;
+    nearest_prev_pose_it->arc_length = slowdown_pose_arc_length;
+  }
+  nearest_prev_pose_it->start_time = clock_->now();
+}
+
 VelocityPlanningResult OutOfLaneModule::plan(
   [[maybe_unused]] const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &
     raw_trajectory_points,
@@ -272,37 +340,10 @@ VelocityPlanningResult OutOfLaneModule::plan(
     return result;
   }
 
-  if (  // reset the previous inserted point if the timer expired
-    previous_slowdown_pose_ &&
-    (clock_->now() - previous_slowdown_time_).seconds() > params_.min_decision_duration) {
-    previous_slowdown_pose_.reset();
-  }
-
   stopwatch.tic("calculate_slowdown_point");
-  auto slowdown_pose = out_of_lane::calculate_slowdown_point(ego_data, out_of_lane_data, params_);
+  const auto slowdown_pose = calculate_slowdown_pose(ego_data, out_of_lane_data);
   const auto calculate_slowdown_point_us = stopwatch.toc("calculate_slowdown_point");
 
-  // reuse previous stop pose if there is no new one or if its velocity is not higher than the new
-  // one and its arc length is lower
-  if (slowdown_pose) {  // reset the clock when we could calculate a valid slowdown pose
-    previous_slowdown_time_ = clock_->now();
-  }
-  const auto should_use_previous_pose = [&]() {
-    if (slowdown_pose && previous_slowdown_pose_) {
-      const auto arc_length =
-        motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position);
-      const auto prev_arc_length = motion_utils::calcSignedArcLength(
-        ego_data.trajectory_points, 0LU, previous_slowdown_pose_->position);
-      return prev_arc_length < arc_length;
-    }
-    return slowdown_pose && previous_slowdown_pose_;
-  }();
-  if (should_use_previous_pose) {
-    // if the trajectory changed the prev point is no longer on the trajectory so we project it
-    const auto new_arc_length = motion_utils::calcSignedArcLength(
-      ego_data.trajectory_points, 0UL, previous_slowdown_pose_->position);
-    slowdown_pose = motion_utils::calcInterpolatedPose(ego_data.trajectory_points, new_arc_length);
-  }
   if (slowdown_pose) {
     const auto arc_length =
       motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0UL, slowdown_pose->position) -

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -241,8 +241,8 @@ std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose
 
   if (!nearest_slowdown_pose) return {};
 
-  slowdown_pose =
-    motion_utils::calcInterpolatedPose(ego_data.trajectory_points, nearest_slowdown_pose->arc_length);
+  slowdown_pose = motion_utils::calcInterpolatedPose(
+    ego_data.trajectory_points, nearest_slowdown_pose->arc_length);
 
   return slowdown_pose;
 }
@@ -251,9 +251,10 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
   const out_of_lane::EgoData & ego_data,
   const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
 {
-  const double slowdown_pose_arc_length = slowdown_pose ?
-    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position) :
-    std::numeric_limits<double>::max();
+  const double slowdown_pose_arc_length =
+    slowdown_pose
+      ? motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position)
+      : std::numeric_limits<double>::max();
 
   // remove no longer valid slowdown poses in the buffer:
   //  slowdown poses that are active but have exceeded the duration threshold since last detection
@@ -264,8 +265,10 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
     if (sp.is_active && sp_duration > params_.min_off_duration) continue;
     if (!sp.is_active && !slowdown_pose) continue;
 
-    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
-    if (!sp.is_active && abs(sp.arc_length - slowdown_pose_arc_length) > params_.update_distance_th) {
+    sp.arc_length =
+      motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
+    if (
+      !sp.is_active && abs(sp.arc_length - slowdown_pose_arc_length) > params_.update_distance_th) {
       continue;
     }
 
@@ -356,7 +359,8 @@ VelocityPlanningResult OutOfLaneModule::plan(
 
   stopwatch.tic("calculate_times");
   const auto is_stopping = previous_slowdown_pose_ ? true : false;
-  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
+  out_of_lane::calculate_collisions_to_avoid(
+    out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -54,6 +54,12 @@ private:
     out_of_lane::EgoData & ego_data,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
     const double max_arc_length);
+  /// @brief calculate the first slowdown pose (if any)
+  std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
+    const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data);
+  void update_slowdown_pose_buffer(
+    const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
+  /// @brief update the given planning result and some internal states of the module
 
   out_of_lane::PlannerParam params_{};
 
@@ -61,7 +67,7 @@ private:
   std::string module_name_{"uninitialized"};
   rclcpp::Clock::SharedPtr clock_{nullptr};
   std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_{std::nullopt};
-  rclcpp::Time previous_slowdown_time_{0};
+  std::vector<out_of_lane::SlowdownPose> slowdown_pose_buffer_{};
 
 protected:
   // Debug

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -58,7 +58,8 @@ private:
   std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
     const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data);
   void update_slowdown_pose_buffer(
-    const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
+    const out_of_lane::EgoData & ego_data,
+    const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
   /// @brief update the given planning result and some internal states of the module
 
   out_of_lane::PlannerParam params_{};

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -30,6 +30,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <optional>
 #include <set>
 #include <string>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -50,6 +50,7 @@ struct PlannerParam
 
   double time_threshold;  // [s](mode="threshold") objects time threshold
   double ttc_threshold;  // [s](mode="ttc") threshold on time to collision between ego and an object
+  double ttc_release_threshold;
 
   bool objects_cut_predicted_paths_beyond_red_lights;  // whether to cut predicted paths beyond red
                                                        // lights' stop lines

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -131,7 +131,7 @@ struct OutOfLanePoint
 
 struct SlowdownPose
 {
-  double arc_length;
+  double arc_length{0.0};
   rclcpp::Time start_time{0};
   geometry_msgs::msg::Pose pose;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -66,6 +66,7 @@ struct PlannerParam
   double precision;            // [m] precision when inserting a stop pose in the trajectory
   double
     min_decision_duration;  // [s] duration needed before a stop or slowdown point can be removed
+  double min_update_distance; // [m] minimum distance needed to update previous stop pose position
 
   // ego dimensions used to create its polygon footprint
   double front_offset;        // [m]  front offset (from vehicle info)
@@ -126,6 +127,16 @@ struct OutOfLanePoint
   std::optional<double> ttc;
   lanelet::ConstLanelets overlapped_lanelets;
   bool to_avoid = false;
+};
+
+struct SlowdownPose {
+  double arc_length;
+  rclcpp::Time start_time{0};
+  geometry_msgs::msg::Pose pose;
+
+  SlowdownPose() = default;
+  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose) :
+    arc_length(arc_length), start_time(start_time), pose(pose) {}
 };
 
 /// @brief data related to the out of lane points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -65,8 +65,8 @@ struct PlannerParam
                                // try to insert a stop point
   double precision;            // [m] precision when inserting a stop pose in the trajectory
   double
-    min_decision_duration;  // [s] duration needed before a stop or slowdown point can be removed
-  double min_update_distance; // [m] minimum distance needed to update previous stop pose position
+    min_decision_duration;    // [s] duration needed before a stop or slowdown point can be removed
+  double update_distance_th;  // [m] distance threshold for updating previous stop pose position
 
   // ego dimensions used to create its polygon footprint
   double front_offset;        // [m]  front offset (from vehicle info)
@@ -129,14 +129,18 @@ struct OutOfLanePoint
   bool to_avoid = false;
 };
 
-struct SlowdownPose {
+struct SlowdownPose
+{
   double arc_length;
   rclcpp::Time start_time{0};
   geometry_msgs::msg::Pose pose;
 
   SlowdownPose() = default;
-  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose) :
-    arc_length(arc_length), start_time(start_time), pose(pose) {}
+  SlowdownPose(
+    const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose)
+  : arc_length(arc_length), start_time(start_time), pose(pose)
+  {
+  }
 };
 
 /// @brief data related to the out of lane points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -65,8 +65,8 @@ struct PlannerParam
   double stop_dist_threshold;  // [m] if a collision is detected bellow this distance ahead of ego,
                                // try to insert a stop point
   double precision;            // [m] precision when inserting a stop pose in the trajectory
-  double
-    min_decision_duration;    // [s] duration needed before a stop or slowdown point can be removed
+  double min_on_duration;  // [s] duration needed before a stop or slowdown point can be triggered
+  double min_off_duration;  // [s] duration needed before a stop or slowdown point can be removed
   double update_distance_th;  // [m] distance threshold for updating previous stop pose position
 
   // ego dimensions used to create its polygon footprint
@@ -135,13 +135,11 @@ struct SlowdownPose
   double arc_length{0.0};
   rclcpp::Time start_time{0};
   geometry_msgs::msg::Pose pose;
+  bool is_active = false;
 
   SlowdownPose() = default;
-  SlowdownPose(
-    const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose)
-  : arc_length(arc_length), start_time(start_time), pose(pose)
-  {
-  }
+  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose, const bool is_active) :
+    arc_length(arc_length), start_time(start_time), pose(pose), is_active(is_active) {}
 };
 
 /// @brief data related to the out of lane points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
@@ -29,8 +30,6 @@
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Polygon.h>
-
-#include <rclcpp/rclcpp.hpp>
 
 #include <optional>
 #include <set>
@@ -67,7 +66,7 @@ struct PlannerParam
   double stop_dist_threshold;  // [m] if a collision is detected bellow this distance ahead of ego,
                                // try to insert a stop point
   double precision;            // [m] precision when inserting a stop pose in the trajectory
-  double min_on_duration;  // [s] duration needed before a stop or slowdown point can be triggered
+  double min_on_duration;   // [s] duration needed before a stop or slowdown point can be triggered
   double min_off_duration;  // [s] duration needed before a stop or slowdown point can be removed
   double update_distance_th;  // [m] distance threshold for updating previous stop pose position
 
@@ -140,8 +139,12 @@ struct SlowdownPose
   bool is_active = false;
 
   SlowdownPose() = default;
-  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose, const bool is_active) :
-    arc_length(arc_length), start_time(start_time), pose(pose), is_active(is_active) {}
+  SlowdownPose(
+    const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose,
+    const bool is_active)
+  : arc_length(arc_length), start_time(start_time), pose(pose), is_active(is_active)
+  {
+  }
 };
 
 /// @brief data related to the out of lane points


### PR DESCRIPTION
## Description

cherry pick of following PRs:
- https://github.com/autowarefoundation/autoware_universe/pull/10446
- https://github.com/autowarefoundation/autoware_universe/pull/10447
- https://github.com/autowarefoundation/autoware_universe/pull/10448

## Related links

- [Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/1181)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
