### PR TITLE
feat(roc): output error/warn message when it's unsafe

### DIFF
--- a/planning/autoware_rear_obstacle_checker/src/node.cpp
+++ b/planning/autoware_rear_obstacle_checker/src/node.cpp
@@ -177,6 +177,7 @@ void RearObstacleCheckerNode::update(diagnostic_updater::DiagnosticStatusWrapper
   DebugData debug_data;
 
   if (!is_safe(debug_data)) {
+    RCLCPP_ERROR(get_logger(), "[ROC] Continuous collision risk detected.");
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "obstacles exist beside ego");
     debug_data.is_safe = false;
   } else {
@@ -321,6 +322,7 @@ bool RearObstacleCheckerNode::is_safe(DebugData & debug)
         return true;
       }
     } else {
+      RCLCPP_WARN(get_logger(), "[ROC] Momentary collision risk detected.");
       last_unsafe_time_ = now;
       if ((now - last_safe_time_).seconds() < p.common.on_time_buffer) {
         return true;


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
