### PR TITLE
feat(behavior_velocity_planner): extend stop line to path bound (#10435)

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -67,8 +67,8 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
   }
 
   // Get stop line geometry
-  const auto stop_line = detection_area::get_stop_line_geometry2d(
-    detection_area_reg_elem_, planner_data_->stop_line_extend_length);
+  const auto stop_line =
+    detection_area::get_stop_line_geometry2d(detection_area_reg_elem_, original_path);
 
   // Get self pose
   const auto & self_pose = planner_data_->current_odometry->pose;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.cpp
@@ -99,10 +99,12 @@ std::pair<lanelet::BasicPoint2d, double> get_smallest_enclosing_circle(
 namespace autoware::behavior_velocity_planner::detection_area
 {
 autoware_utils::LineString2d get_stop_line_geometry2d(
-  const lanelet::autoware::DetectionArea & detection_area, const double extend_length)
+  const lanelet::autoware::DetectionArea & detection_area,
+  const autoware_internal_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto stop_line = detection_area.stopLine();
-  return planning_utils::extendLine(stop_line[0], stop_line[1], extend_length);
+  return planning_utils::extendSegmentToBounds(
+    lanelet::utils::to2D(stop_line).basicLineString(), path.left_bound, path.right_bound);
 }
 
 std::vector<geometry_msgs::msg::Point> get_obstacle_points(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.hpp
@@ -19,6 +19,7 @@
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <rclcpp/time.hpp>
 
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <lanelet2_core/geometry/Point.h>
@@ -34,10 +35,11 @@ namespace autoware::behavior_velocity_planner::detection_area
 
 /// @brief get the extended stop line of the given detection area
 /// @param [in] detection_area detection area
-/// @param [in] extend_length [m] extension length to add on each edge of the stop line
+/// @param [in] path ego path
 /// @return extended stop line
 autoware_utils::LineString2d get_stop_line_geometry2d(
-  const lanelet::autoware::DetectionArea & detection_area, const double extend_length);
+  const lanelet::autoware::DetectionArea & detection_area,
+  const autoware_internal_planning_msgs::msg::PathWithLaneId & path);
 
 /// @brief get the obstacle points found inside a detection area
 /// @param [in] detection_areas detection area polygons

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_utils.cpp
@@ -21,6 +21,18 @@
 
 #include <cstddef>
 #include <memory>
+#include <vector>
+
+namespace
+{
+std::vector<geometry_msgs::msg::Point> make_bound(
+  const lanelet::BasicPoint2d & start, const lanelet::BasicPoint2d & end)
+{
+  return {
+    geometry_msgs::msg::Point{}.set__x(start.x()).set__y(start.y()),
+    geometry_msgs::msg::Point{}.set__x(end.x()).set__y(end.y())};
+};
+}  // namespace
 
 TEST(TestUtils, getStopLine)
 {
@@ -37,18 +49,12 @@ TEST(TestUtils, getStopLine)
   detection_areas.push_back(area);
   auto detection_area =
     lanelet::autoware::DetectionArea::make(lanelet::InvalId, {}, detection_areas, line);
-  {
-    const double extend_length = 0.0;
-    const auto stop_line = get_stop_line_geometry2d(*detection_area, extend_length);
-    ASSERT_EQ(stop_line.size(), 2UL);
-    EXPECT_EQ(stop_line[0].x(), line[0].x());
-    EXPECT_EQ(stop_line[0].y(), line[0].y());
-    EXPECT_EQ(stop_line[1].x(), line[1].x());
-    EXPECT_EQ(stop_line[1].y(), line[1].y());
-  }
   // extended line
-  for (auto extend_length = -2.0; extend_length < 2.0; extend_length += 0.1) {
-    const auto stop_line = get_stop_line_geometry2d(*detection_area, extend_length);
+  for (auto extend_length = 0.0; extend_length < 2.0; extend_length += 0.1) {
+    autoware_internal_planning_msgs::msg::PathWithLaneId path;
+    path.left_bound = make_bound({-1.0, -1.0 - extend_length}, {1.0, -1.0 - extend_length});
+    path.right_bound = make_bound({-1.0, 1.0 + extend_length}, {1.0, 1.0 + extend_length});
+    const auto stop_line = get_stop_line_geometry2d(*detection_area, path);
     ASSERT_EQ(stop_line.size(), 2UL);
     EXPECT_EQ(stop_line[0].x(), line[0].x());
     EXPECT_EQ(stop_line[0].y(), line[0].y() - extend_length);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -323,8 +323,8 @@ std::optional<size_t> IntersectionModule::getStopLineIndexFromMap(
 
   const auto p_start = stopline.front().front();
   const auto p_end = stopline.front().back();
-  const LineString2d extended_stopline =
-    planning_utils::extendLine(p_start, p_end, planner_data_->stop_line_extend_length);
+  const LineString2d extended_stopline = planning_utils::extendSegmentToBounds(
+    {p_start.basicPoint2d(), p_end.basicPoint2d()}, path.left_bound, path.right_bound);
 
   for (size_t i = lane_interval.first; i < lane_interval.second; i++) {
     const auto & p_front = path.points.at(i).point.pose.position;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -73,7 +73,7 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path)
   // Get stop line geometry
   const auto stop_line = no_stopping_area::get_stop_line_geometry2d(
     original_path, no_stopping_area_reg_elem_, planner_param_.stop_line_margin,
-    planner_data_->stop_line_extend_length, planner_data_->vehicle_info_.vehicle_width_m);
+    planner_data_->vehicle_info_.vehicle_width_m);
   if (!stop_line) {
     setSafe(true);
     return true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
@@ -248,13 +248,14 @@ bool check_stop_lines_in_no_stopping_area(
 std::optional<LineString2d> get_stop_line_geometry2d(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::autoware::NoStoppingArea & no_stopping_area_reg_elem,
-  const double stop_line_margin, const double stop_line_extend_length, const double vehicle_width)
+  const double stop_line_margin, const double vehicle_width)
 {
   const auto & stop_line = no_stopping_area_reg_elem.stopLine();
   if (stop_line && stop_line->size() >= 2) {
     // get stop line from map
-    return planning_utils::extendLine(
-      stop_line.value()[0], stop_line.value()[1], stop_line_extend_length);
+    return planning_utils::extendSegmentToBounds(
+      {(*stop_line)[0].basicPoint2d(), (*stop_line)[1].basicPoint2d()}, path.left_bound,
+      path.right_bound);
   }
   return generate_stop_line(
     path, no_stopping_area_reg_elem.noStoppingAreas(), vehicle_width, stop_line_margin);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.hpp
@@ -152,15 +152,13 @@ bool check_stop_lines_in_no_stopping_area(
  * @param path ego path
  * @param no_stopping_area_reg_elem no_stopping_area regulatory element
  * @param stop_line_margin [m] margin between the stop line and the start of the no stopping area
- * @param stop_line_extend_length [m] extra length to add on each side of the stop line (only added
- * to the stop line of the regulatory element)
  * @param vehicle_width [m] width of the ego vehicle
  * @return generated stop line
  */
 std::optional<autoware_utils::LineString2d> get_stop_line_geometry2d(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::autoware::NoStoppingArea & no_stopping_area_reg_elem,
-  const double stop_line_margin, const double stop_line_extend_length, const double vehicle_width);
+  const double stop_line_margin, const double vehicle_width);
 
 }  // namespace autoware::behavior_velocity_planner::no_stopping_area
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -74,8 +74,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
   // Calculate stop pose and insert index
   const auto stop_line = calcStopPointAndInsertIndex(
     input_path, lanelet_stop_lines,
-    planner_param_.stop_margin + planner_data_->vehicle_info_.max_longitudinal_offset_m,
-    planner_data_->stop_line_extend_length);
+    planner_param_.stop_margin + planner_data_->vehicle_info_.max_longitudinal_offset_m);
 
   if (!stop_line.has_value()) {
     RCLCPP_WARN_STREAM_ONCE(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.cpp
@@ -126,14 +126,15 @@ auto createTargetPoint(
 
 auto calcStopPointAndInsertIndex(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path,
-  const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset,
-  const double & stop_line_extend_length) -> std::optional<std::pair<size_t, Eigen::Vector2d>>
+  const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset)
+  -> std::optional<std::pair<size_t, Eigen::Vector2d>>
 {
   LineString2d stop_line;
 
   for (size_t i = 0; i < lanelet_stop_lines.size() - 1; ++i) {
-    stop_line = planning_utils::extendLine(
-      lanelet_stop_lines[i], lanelet_stop_lines[i + 1], stop_line_extend_length);
+    stop_line = planning_utils::extendSegmentToBounds(
+      {lanelet_stop_lines[i].basicPoint2d(), lanelet_stop_lines[i + 1].basicPoint2d()},
+      input_path.left_bound, input_path.right_bound);
 
     // Calculate stop pose and insert index,
     // if there is a collision point between path and stop line

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
@@ -69,14 +69,13 @@ auto createTargetPoint(
  * @param input path.
  * @param stop line.
  * @param longitudinal offset.
- * @param extend length to find intersection point between path and stop line.
  * @return first: insert point index, second: insert point position. if there is no intersection
  * point, return std::nullopt.
  */
 auto calcStopPointAndInsertIndex(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path,
-  const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset,
-  const double & stop_line_extend_length) -> std::optional<std::pair<size_t, Eigen::Vector2d>>;
+  const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset)
+  -> std::optional<std::pair<size_t, Eigen::Vector2d>>;
 
 }  // namespace autoware::behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_utils.cpp
@@ -26,7 +26,9 @@ using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_utils::create_point;
 using autoware_utils::create_quaternion;
 
-PathWithLaneId generatePath(const geometry_msgs::msg::Pose & pose)
+PathWithLaneId generatePath(
+  const geometry_msgs::msg::Pose & pose,
+  const std::optional<double> & bound_y_offset = std::nullopt)
 {
   constexpr double interval_distance = 1.0;
 
@@ -36,6 +38,19 @@ PathWithLaneId generatePath(const geometry_msgs::msg::Pose & pose)
     p.point.pose = pose;
     p.point.pose.position.x += s;
     traj.points.push_back(p);
+  }
+
+  if (bound_y_offset) {
+    traj.left_bound = {
+      geometry_msgs::msg::Point{}.set__x(pose.position.x).set__y(pose.position.y + *bound_y_offset),
+      geometry_msgs::msg::Point{}
+        .set__x(pose.position.x + 10.0)
+        .set__y(pose.position.y + *bound_y_offset)};
+    traj.right_bound = {
+      geometry_msgs::msg::Point{}.set__x(pose.position.x).set__y(pose.position.y - *bound_y_offset),
+      geometry_msgs::msg::Point{}
+        .set__x(pose.position.x + 10.0)
+        .set__y(pose.position.y - *bound_y_offset)};
   }
 
   return traj;
@@ -129,29 +144,26 @@ TEST(BehaviorTrafficLightModuleUtilsTest, calcStopPointAndInsertIndex)
   const auto pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
                       .position(create_point(0.0, 0.0, 0.0))
                       .orientation(create_quaternion(0.0, 0.0, 0.0, 1.0));
-  const auto path = generatePath(pose);
   constexpr double offset = 1.75;
 
-  {
+  {  // Path is empty
     lanelet::Points3d basic_line;
     basic_line.emplace_back(lanelet::InvalId, 5.5, -1.0, 0.0);
     basic_line.emplace_back(lanelet::InvalId, 5.5, 1.0, 0.0);
 
     const auto line = lanelet::LineString3d(lanelet::InvalId, basic_line);
-    constexpr double extend_length = 0.0;
-    const auto output = calcStopPointAndInsertIndex(PathWithLaneId{}, line, offset, extend_length);
+    const auto output = calcStopPointAndInsertIndex(PathWithLaneId{}, line, offset);
 
     EXPECT_FALSE(output.has_value());
   }
 
-  {
+  {  // Normal case
     lanelet::Points3d basic_line;
     basic_line.emplace_back(lanelet::InvalId, 5.5, -1.0, 0.0);
     basic_line.emplace_back(lanelet::InvalId, 5.5, 1.0, 0.0);
 
     const auto line = lanelet::LineString3d(lanelet::InvalId, basic_line);
-    constexpr double extend_length = 0.0;
-    const auto output = calcStopPointAndInsertIndex(path, line, offset, extend_length);
+    const auto output = calcStopPointAndInsertIndex(generatePath(pose, 1.0), line, offset);
 
     EXPECT_TRUE(output.has_value());
     EXPECT_EQ(output.value().first, size_t(4));
@@ -159,29 +171,13 @@ TEST(BehaviorTrafficLightModuleUtilsTest, calcStopPointAndInsertIndex)
     EXPECT_DOUBLE_EQ(output.value().second.y(), 0.0);
   }
 
-  {
+  {  // Stop line does not intersect path bound
     lanelet::Points3d basic_line;
-    basic_line.emplace_back(lanelet::InvalId, 5.5, 2.0, 0.0);
-    basic_line.emplace_back(lanelet::InvalId, 5.5, 1.0, 0.0);
+    basic_line.emplace_back(lanelet::InvalId, 5.5, 0.5, 0.0);
+    basic_line.emplace_back(lanelet::InvalId, 4.5, 0.5, 0.0);
 
     const auto line = lanelet::LineString3d(lanelet::InvalId, basic_line);
-    constexpr double extend_length = 2.0;
-    const auto output = calcStopPointAndInsertIndex(path, line, offset, extend_length);
-
-    EXPECT_TRUE(output.has_value());
-    EXPECT_EQ(output.value().first, size_t(4));
-    EXPECT_DOUBLE_EQ(output.value().second.x(), 3.75);
-    EXPECT_DOUBLE_EQ(output.value().second.y(), 0.0);
-  }
-
-  {
-    lanelet::Points3d basic_line;
-    basic_line.emplace_back(lanelet::InvalId, 5.5, 2.0, 0.0);
-    basic_line.emplace_back(lanelet::InvalId, 5.5, 1.0, 0.0);
-
-    const auto line = lanelet::LineString3d(lanelet::InvalId, basic_line);
-    constexpr double extend_length = 0.0;
-    const auto output = calcStopPointAndInsertIndex(path, line, offset, extend_length);
+    const auto output = calcStopPointAndInsertIndex(generatePath(pose, 1.0), line, offset);
 
     EXPECT_FALSE(output.has_value());
   }


### PR DESCRIPTION
## Description


X1 v2025.6リリース評価課題へのhotfixです。
behaivor velocity plannerでUターンレーンで、誤った位置へ停止線が出る問題への対応です。 

https://star4.slack.com/archives/C03QW0GU6P7/p1748401762847809?thread_ts=1747892870.837609&cid=C03QW0GU6P7

https://github.com/autowarefoundation/autoware_universe/pull/10435 をcherr-pick

## Related links

**Parent Issue:**

coreの修正

- https://github.com/tier4/autoware_core/pull/20

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

 https://evaluation.tier4.jp/evaluation/reports/c41bb852-2c1d-5ce6-8f3a-672a88f916ec?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
