### PR TITLE
feat(default_adapi): cherry-pick add mrm request api (#10550)

### DIFF
--- a/common/autoware_adapi_specs/include/autoware/adapi_specs/fail_safe.hpp
+++ b/common/autoware_adapi_specs/include/autoware/adapi_specs/fail_safe.hpp
@@ -17,7 +17,9 @@
 
 #include <rclcpp/qos.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/mrm_request_list.hpp>
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/send_mrm_request.hpp>
 
 namespace autoware::adapi_specs::fail_safe
 {
@@ -26,6 +28,21 @@ struct MrmState
 {
   using Message = autoware_adapi_v1_msgs::msg::MrmState;
   static constexpr char name[] = "/api/fail_safe/mrm_state";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+};
+
+struct SendMrmRequest
+{
+  using Service = autoware_adapi_v1_msgs::srv::SendMrmRequest;
+  static constexpr char name[] = "/api/fail_safe/mrm_request/send";
+};
+
+struct MrmRequestList
+{
+  using Message = autoware_adapi_v1_msgs::msg::MrmRequestList;
+  static constexpr char name[] = "/api/fail_safe/mrm_request/list";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;

--- a/system/autoware_default_adapi/CMakeLists.txt
+++ b/system/autoware_default_adapi/CMakeLists.txt
@@ -11,6 +11,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/interface.cpp
   src/localization.cpp
   src/motion.cpp
+  src/mrm_request.cpp
   src/operation_mode.cpp
   src/perception.cpp
   src/planning.cpp
@@ -31,6 +32,7 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "autoware::default_adapi::InterfaceNode"
   "autoware::default_adapi::LocalizationNode"
   "autoware::default_adapi::MotionNode"
+  "autoware::default_adapi::MrmRequestNode"
   "autoware::default_adapi::OperationModeNode"
   "autoware::default_adapi::PerceptionNode"
   "autoware::default_adapi::PlanningNode"

--- a/system/autoware_default_adapi/config/default_adapi.param.yaml
+++ b/system/autoware_default_adapi/config/default_adapi.param.yaml
@@ -14,3 +14,17 @@
 /adapi/node/vehicle_door:
   ros__parameters:
     check_autoware_control: true
+
+/adapi/node/manual/local:
+  ros__parameters:
+    mode: local
+
+/adapi/node/manual/remote:
+  ros__parameters:
+    mode: remote
+
+/adapi/node/mrm_request:
+  ros__parameters:
+    diagnostic_updater:
+      period: 1.0
+      use_fqn: true

--- a/system/autoware_default_adapi/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi/launch/default_adapi.launch.py
@@ -48,6 +48,7 @@ def generate_launch_description():
         create_api_node("interface", "InterfaceNode"),
         create_api_node("localization", "LocalizationNode"),
         create_api_node("motion", "MotionNode"),
+        create_api_node("mrm_request", "MrmRequestNode"),
         create_api_node("operation_mode", "OperationModeNode"),
         create_api_node("perception", "PerceptionNode"),
         create_api_node("planning", "PlanningNode"),

--- a/system/autoware_default_adapi/package.xml
+++ b/system/autoware_default_adapi/package.xml
@@ -24,6 +24,7 @@
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>geographic_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_default_adapi/src/mrm_request.cpp
+++ b/system/autoware_default_adapi/src/mrm_request.cpp
@@ -1,0 +1,82 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mrm_request.hpp"
+
+namespace autoware::default_adapi
+{
+
+MrmRequestNode::MrmRequestNode(const rclcpp::NodeOptions & options)
+: Node("mrm_request", options), diagnostics_(this)
+{
+  diagnostics_.setHardwareID("none");
+  diagnostics_.add("delegate", this, &MrmRequestNode::diagnose_delegate);
+
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  adaptor.init_pub(pub_mrm_request_list_);
+  adaptor.init_srv(srv_send_mrm_request_, this, &MrmRequestNode::on_send_mrm_request);
+
+  publish_mrm_request_list();
+}
+
+void MrmRequestNode::diagnose_delegate(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+  bool requested = false;
+
+  for (const auto & [sender, request] : mrm_requests_) {
+    if (request.strategy == MrmRequestItem::DELEGATE) {
+      requested = true;
+      stat.add(sender, "");
+    }
+  }
+  stat.summary(requested ? DiagnosticStatus::ERROR : DiagnosticStatus::OK, "");
+}
+
+void MrmRequestNode::publish_mrm_request_list()
+{
+  MrmRequestList::Message msg;
+  msg.stamp = now();
+  for (const auto & [sender, request] : mrm_requests_) {
+    msg.requests.push_back(request);
+  }
+  pub_mrm_request_list_->publish(msg);
+}
+
+void MrmRequestNode::on_send_mrm_request(
+  const SendMrmRequest::Service::Request::SharedPtr req,
+  const SendMrmRequest::Service::Response::SharedPtr res)
+{
+  switch (req->request.strategy) {
+    case MrmRequestItem::CANCEL:
+      mrm_requests_.erase(req->request.sender);
+      break;
+    case MrmRequestItem::DELEGATE:
+      mrm_requests_[req->request.sender] = req->request;
+      break;
+    default:
+      res->status.success = false;
+      res->status.message = "unknown strategy";
+      return;
+  }
+
+  res->status.success = true;
+  diagnostics_.force_update();
+  publish_mrm_request_list();
+}
+
+}  // namespace autoware::default_adapi
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::default_adapi::MrmRequestNode)

--- a/system/autoware_default_adapi/src/mrm_request.hpp
+++ b/system/autoware_default_adapi/src/mrm_request.hpp
@@ -1,0 +1,56 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MRM_REQUEST_HPP_
+#define MRM_REQUEST_HPP_
+
+#include <autoware/adapi_specs/fail_safe.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+#include <unordered_map>
+
+// This file should be included after messages.
+#include "utils/types.hpp"
+
+namespace autoware::default_adapi
+{
+
+class MrmRequestNode : public rclcpp::Node
+{
+public:
+  explicit MrmRequestNode(const rclcpp::NodeOptions & options);
+
+private:
+  using SendMrmRequest = autoware::adapi_specs::fail_safe::SendMrmRequest;
+  using MrmRequestList = autoware::adapi_specs::fail_safe::MrmRequestList;
+  using MrmRequestItem = autoware_adapi_v1_msgs::msg::MrmRequest;
+
+  Srv<SendMrmRequest> srv_send_mrm_request_;
+  Pub<MrmRequestList> pub_mrm_request_list_;
+
+  void diagnose_delegate(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void publish_mrm_request_list();
+  void on_send_mrm_request(
+    const SendMrmRequest::Service::Request::SharedPtr req,
+    const SendMrmRequest::Service::Response::SharedPtr res);
+
+  diagnostic_updater::Updater diagnostics_;
+  std::unordered_map<std::string, MrmRequestItem> mrm_requests_;
+};
+
+}  // namespace autoware::default_adapi
+
+#endif  // MRM_REQUEST_HPP_


### PR DESCRIPTION
## Description

Cherry-pick mrm request api 

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/pull/10550
- https://star4.slack.com/archives/CRUE57C30/p1748494732663859?thread_ts=1748492332.041889&cid=CRUE57C30

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
