### PR TITLE
fix(run_out): guard against decreasing ego trajectory times (#10746)

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/training_and_data_check/add_training_data_from_csv.py
+++ b/control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/training_and_data_check/add_training_data_from_csv.py
@@ -119,7 +119,7 @@ class add_data_from_csv:
         os.chdir(dir_exe)
 
     def add_data_from_csv(self, dir_name: str, add_mode=default_add_mode) -> None:
-        """Adding teacher data for training from a CSV file."""
+        """Add teacher data for training from a CSV file."""
         acc_ctrl_queue_size = drive_functions.acc_ctrl_queue_size
         steer_ctrl_queue_size = drive_functions.steer_ctrl_queue_size
         ctrl_time_step = drive_functions.ctrl_time_step

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
@@ -92,6 +92,10 @@ double calculate_keep_stop_distance_range(
   std::vector<double> arc_lengths = {0.0};
   for (auto i = 1UL; i < trajectory.size(); ++i) {
     const auto t = rclcpp::Duration(trajectory[i].time_from_start).seconds();
+    if (times.back() >= t) {
+      // we skip trajectory points where the predicted time decreases to avoid interpolation errors
+      continue;
+    }
     const auto arc_length_delta = universe_utils::calcDistance2d(trajectory[i - 1], trajectory[i]);
     times.push_back(t);
     arc_lengths.push_back(arc_lengths.back() + arc_length_delta);


### PR DESCRIPTION
## Description

Cherry pick https://github.com/autowarefoundation/autoware_universe/pull/10746 to prevent crashes of the `run_out` module in the `motion_velocity_planner`.

## Related links

**Parent Issue:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-37423)

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
