### PR TITLE
fix(roi_pointcloud_fusion): add remap output option (#10655)

### DIFF
--- a/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
@@ -5,3 +5,5 @@
     max_cluster_size: 20
     cluster_2d_tolerance: 0.5
     roi_scale_factor: 1.0
+    max_object_size: 2.0
+    override_class_with_unknown: false

--- a/perception/autoware_image_projection_based_fusion/docs/roi-pointcloud-fusion.md
+++ b/perception/autoware_image_projection_based_fusion/docs/roi-pointcloud-fusion.md
@@ -33,12 +33,7 @@ The node `roi_pointcloud_fusion` is to cluster the pointcloud based on Region Of
 
 ### Core Parameters
 
-| Name                   | Type   | Description                                                                                  |
-| ---------------------- | ------ | -------------------------------------------------------------------------------------------- |
-| `min_cluster_size`     | int    | the minimum number of points that a cluster needs to contain in order to be considered valid |
-| `max_cluster_size`     | int    | the maximum number of points that a cluster needs to contain in order to be considered valid |
-| `cluster_2d_tolerance` | double | cluster tolerance measured in radial direction                                               |
-| `rois_number`          | int    | the number of input rois                                                                     |
+{{ json_to_markdown("perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json") }}
 
 ## Assumptions / Known limits
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
@@ -44,9 +44,11 @@ private:
 
   int min_cluster_size_{1};
   int max_cluster_size_{20};
+  double max_object_size_{2.0};
   bool fuse_unknown_only_{true};
   double cluster_2d_tolerance_;
   double roi_scale_factor_{1.0};
+  bool override_class_with_unknown_{false};
 
   std::vector<ClusterObjType> output_fused_objects_;
 };

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -61,6 +61,7 @@ struct PointData
 {
   float distance;
   size_t orig_index;
+  pcl::PointXYZ orig_point;
 };
 
 bool checkCameraInfo(const sensor_msgs::msg::CameraInfo & camera_info);
@@ -73,13 +74,13 @@ Eigen::Affine3d transformToEigen(const geometry_msgs::msg::Transform & t);
 
 void closest_cluster(
   const PointCloudMsgType & cluster, const double cluster_2d_tolerance, const int min_cluster_size,
-  const pcl::PointXYZ & center, PointCloudMsgType & out_cluster);
+  const double max_object_size, const pcl::PointXYZ & center, PointCloudMsgType & out_cluster);
 
 void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_objs, std::vector<PointCloudMsgType> & clusters,
-  const std::vector<size_t> & clusters_data_size, const PointCloudMsgType & in_cloud,
-  const std_msgs::msg::Header & in_roi_header, const tf2_ros::Buffer & tf_buffer,
-  const int min_cluster_size, const int max_cluster_size, const float cluster_2d_tolerance,
+  const PointCloudMsgType & in_cloud, const std_msgs::msg::Header & in_roi_header,
+  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const int max_cluster_size,
+  const float cluster_2d_tolerance, const double max_object_size,
   std::vector<DetectedObjectWithFeature> & output_fused_objects);
 
 geometry_msgs::msg::Point getCentroid(const PointCloudMsgType & pointcloud);

--- a/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
@@ -11,15 +11,23 @@
           "description": "Whether to fuse only UNKNOWN clusters.",
           "default": true
         },
+        "override_class_with_unknown": {
+          "type": "boolean",
+          "description": "Whether to override class of output cluster with UNKNOWN. It is effective only when fuse_unknown_only is false.",
+          "default": false
+        },
+
         "min_cluster_size": {
           "type": "integer",
           "description": "The minimum number of points that a cluster must contain to be considered as valid.",
-          "default": 2
+          "default": 2,
+          "minimum": 2
         },
         "max_cluster_size": {
           "type": "integer",
           "description": "The maximum number of points that a cluster must contain to be considered as valid.",
-          "default": 20
+          "default": 20,
+          "minimum": 2
         },
         "cluster_2d_tolerance": {
           "type": "number",
@@ -32,13 +40,21 @@
           "description": "A scale factor for resizing RoI while checking if points are inside the RoI.",
           "default": 1.0,
           "exclusiveMinimum": 0.0
+        },
+        "max_object_size": {
+          "type": "number",
+          "description": "The maximum size of the object to be considered as valid.",
+          "default": 2.0,
+          "exclusiveMinimum": 0.0
         }
       },
       "required": [
         "fuse_unknown_only",
+        "override_class_with_unknown",
         "min_cluster_size",
         "cluster_2d_tolerance",
-        "roi_scale_factor"
+        "roi_scale_factor",
+        "max_object_size"
       ]
     }
   },

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -35,6 +35,7 @@
 namespace autoware::image_projection_based_fusion
 {
 using autoware_utils::ScopedTimeTrack;
+using Classification = autoware_perception_msgs::msg::ObjectClassification;
 
 RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & options)
 : FusionNode<PointCloudMsgType, RoiMsgType, ClusterMsgType>("roi_pointcloud_fusion", options)
@@ -44,6 +45,8 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
   max_cluster_size_ = declare_parameter<int>("max_cluster_size");
   cluster_2d_tolerance_ = declare_parameter<double>("cluster_2d_tolerance");
   roi_scale_factor_ = declare_parameter<double>("roi_scale_factor");
+  override_class_with_unknown_ = declare_parameter<bool>("override_class_with_unknown");
+  max_object_size_ = declare_parameter<double>("max_object_size");
 
   // publisher
   pub_ptr_ = this->create_publisher<ClusterMsgType>("output", rclcpp::QoS{1});
@@ -68,15 +71,21 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
   // select ROIs for fusion
   for (const auto & feature_obj : input_roi_msg.feature_objects) {
     if (fuse_unknown_only_) {
-      bool is_roi_label_unknown = feature_obj.object.classification.front().label ==
-                                  autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+      bool is_roi_label_unknown =
+        feature_obj.object.classification.front().label == Classification::UNKNOWN;
       if (is_roi_label_unknown) {
         output_objs.push_back(feature_obj);
         debug_image_rois.push_back(feature_obj.feature.roi);
       }
     } else {
       // TODO(badai-nguyen): selected class from a list
-      output_objs.push_back(feature_obj);
+      if (override_class_with_unknown_) {
+        auto feature_obj_remap = feature_obj;
+        feature_obj_remap.object.classification.front().label = Classification::UNKNOWN;
+        output_objs.push_back(feature_obj_remap);
+      } else {
+        output_objs.push_back(feature_obj);
+      }
       debug_image_rois.push_back(feature_obj.feature.roi);
     }
   }
@@ -114,14 +123,12 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
   tf2::doTransform(input_pointcloud_msg, transformed_cloud, transform_stamped);
 
   std::vector<PointCloudMsgType> clusters;
-  std::vector<size_t> clusters_data_size;
   clusters.resize(output_objs.size());
   for (auto & cluster : clusters) {
     cluster.point_step = input_pointcloud_msg.point_step;
     cluster.height = input_pointcloud_msg.height;
     cluster.fields = input_pointcloud_msg.fields;
-    cluster.data.resize(max_cluster_size_ * input_pointcloud_msg.point_step);
-    clusters_data_size.push_back(0);
+    cluster.data.reserve(input_pointcloud_msg.data.size());
   }
   for (size_t offset = 0; offset < input_pointcloud_msg.data.size(); offset += point_step) {
     const float transformed_x =
@@ -145,19 +152,14 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
         const double px = projected_point.x();
         const double py = projected_point.y();
 
-        if (
-          clusters_data_size.at(i) >=
-          static_cast<size_t>(max_cluster_size_) * static_cast<size_t>(point_step)) {
-          continue;
-        }
+        // is not correct to skip fusion and keep a cluster with a partial of points
         if (isPointInsideRoi(check_roi, px, py, roi_scale_factor_)) {
-          std::memcpy(
-            &cluster.data[clusters_data_size.at(i)], &input_pointcloud_msg.data[offset],
-            point_step);
-          clusters_data_size.at(i) += point_step;
+          // append point data to clusters data vector
+          cluster.data.insert(
+            cluster.data.end(), &input_pointcloud_msg.data[offset],
+            &input_pointcloud_msg.data[offset + point_step]);
         }
       }
-
       if (debugger_) {
         // add all points inside image to debug
         debug_image_points.push_back(projected_point);
@@ -167,8 +169,9 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
 
   // refine and update output_fused_objects_
   updateOutputFusedObjects(
-    output_objs, clusters, clusters_data_size, input_pointcloud_msg, input_roi_msg.header,
-    tf_buffer_, min_cluster_size_, max_cluster_size_, cluster_2d_tolerance_, output_fused_objects_);
+    output_objs, clusters, input_pointcloud_msg, input_roi_msg.header, tf_buffer_,
+    min_cluster_size_, max_cluster_size_, cluster_2d_tolerance_, max_object_size_,
+    output_fused_objects_);
 
   // publish debug image
   if (debugger_) {

--- a/perception/autoware_image_projection_based_fusion/test/test_utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/test/test_utils.cpp
@@ -66,9 +66,10 @@ TEST(UtilsTest, closest_cluster_empty_cluster_test_case1)
   // testing closest_cluster function
   double cluster_2d_tolerance = 0.5;
   int min_cluster_size = 3;
+  float max_object_size = 2.0;  // Not used in this test case, but required by function signature
   sensor_msgs::msg::PointCloud2 output_cluster;
   autoware::image_projection_based_fusion::closest_cluster(
-    pointcloud, cluster_2d_tolerance, min_cluster_size, center, output_cluster);
+    pointcloud, cluster_2d_tolerance, min_cluster_size, max_object_size, center, output_cluster);
   EXPECT_EQ(output_cluster.data.size(), std::size_t(0));
 }
 
@@ -97,9 +98,10 @@ TEST(UtilsTest, closest_cluster_test_case2)
   // testing closest_cluster function
   double cluster_2d_tolerance = 0.5;
   int min_cluster_size = 3;
+  float max_object_size = 2.0;  // Not used in this test case, but required by function signature
   sensor_msgs::msg::PointCloud2 output_cluster;
   autoware::image_projection_based_fusion::closest_cluster(
-    pointcloud, cluster_2d_tolerance, min_cluster_size, center, output_cluster);
+    pointcloud, cluster_2d_tolerance, min_cluster_size, max_object_size, center, output_cluster);
   EXPECT_EQ(output_cluster.data.size(), dummy_x.size() * pointcloud.point_step);
 }
 
@@ -128,9 +130,10 @@ TEST(UtilsTest, closest_cluster_test_case3)
   // testing closest_cluster function
   double cluster_2d_tolerance = 0.5;
   int min_cluster_size = 3;
+  float max_object_size = 2.0;  // Not used in this test case, but required by function signature
   sensor_msgs::msg::PointCloud2 output_cluster;
   autoware::image_projection_based_fusion::closest_cluster(
-    pointcloud, cluster_2d_tolerance, min_cluster_size, center, output_cluster);
+    pointcloud, cluster_2d_tolerance, min_cluster_size, max_object_size, center, output_cluster);
   EXPECT_EQ(output_cluster.data.size(), 3 * pointcloud.point_step);
 }
 
@@ -159,9 +162,10 @@ TEST(UtilsTest, closest_cluster_test_case4)
   // testing closest_cluster function
   double cluster_2d_tolerance = 0.5;
   int min_cluster_size = 3;
+  float max_object_size = 2.0;  // Not used in this test case, but required by function signature
   sensor_msgs::msg::PointCloud2 output_cluster;
   autoware::image_projection_based_fusion::closest_cluster(
-    pointcloud, cluster_2d_tolerance, min_cluster_size, center, output_cluster);
+    pointcloud, cluster_2d_tolerance, min_cluster_size, max_object_size, center, output_cluster);
   EXPECT_EQ(output_cluster.data.size(), 6 * pointcloud.point_step);
 }
 


### PR DESCRIPTION
 Cherry-pick: https://github.com/autowarefoundation/autoware_universe/pull/10655
 チケット：https://tier4.atlassian.net/browse/RT0-37158?focusedCommentId=226483
 Related PR:  https://github.com/tier4/autoware_launch.x2/pull/1232


* fix(roi_pointcloud_fusion): add remap output option



* chore: docs update



* fix: update refine cluster func



* chore: fix schema



* fix: test utils



---------