### PR TITLE
chore: apply v2i related changes to autoware_behavior_velocity_traffic_light_module

### DIFF
--- a/.github/workflows/beta-to-tier4-main-sync.yaml
+++ b/.github/workflows/beta-to-tier4-main-sync.yaml
@@ -1,0 +1,34 @@
+name: beta-to-tier4-main-sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: Source branch
+        required: true
+        type: string
+
+jobs:
+  sync-beta-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-branches
+        uses: autowarefoundation/autoware-github-actions/sync-branches@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base-branch: tier4/main
+          sync-pr-branch: beta-to-tier4-main-sync
+          sync-target-repository: https://github.com/tier4/autoware.universe.git
+          sync-target-branch: ${{ inputs.source_branch }}
+          pr-title: "chore: sync beta branch ${{ inputs.source_branch }} with tier4/main"
+          pr-labels: |
+            bot
+            sync-beta-branch
+          auto-merge-method: merge

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -21,7 +21,7 @@ jobs:
   build-and-test-differential-arm64:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large
+    runs-on: [self-hosted, Linux, ARM64]
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -9,7 +9,7 @@ on:
       # Why is it a JSON string?
       # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
-        default: ubuntu-22.04-m
+        default: "['ubuntu-22.04-m']"
         required: false
         type: string
       rosdistro:

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -6,8 +6,6 @@ on:
       container:
         required: true
         type: string
-      # Why is it a JSON string?
-      # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
         default: ubuntu-22.04-m
         required: false

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -9,7 +9,7 @@ on:
       # Why is it a JSON string?
       # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
-        default: "['ubuntu-22.04-m']"
+        default: ubuntu-22.04-m
         required: false
         type: string
       rosdistro:

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       runner:
-        default: ubuntu-24.04
+        default: ubuntu-22.04-m
         required: false
         type: string
       rosdistro:

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       runner:
-        default: "['ubuntu-22.04-m']"
+        default: ubuntu-24.04
         required: false
         type: string
       rosdistro:

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       runner:
-        default: ubuntu-24.04
+        default: "['ubuntu-22.04-m']"
         required: false
         type: string
       rosdistro:

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -69,7 +69,7 @@ jobs:
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' }}
-      runner: "['ubuntu-22.04-m']"
+      runner: ubuntu-22.04-m
       build-pre-command: taskset --cpu-list 0-6
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -94,4 +94,4 @@ jobs:
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' && needs.build-and-test-differential-cuda.result == 'success' }}
-      runner: "['ubuntu-22.04-m']"
+      runner: ubuntu-22.04-m

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -69,7 +69,7 @@ jobs:
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' }}
-      runner: ubuntu-22.04-m
+      runner: "['ubuntu-22.04-m']"
       build-pre-command: taskset --cpu-list 0-6
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -94,4 +94,4 @@ jobs:
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' && needs.build-and-test-differential-cuda.result == 'success' }}
-      runner: ubuntu-22.04-m
+      runner: "['ubuntu-22.04-m']"

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -10,8 +10,6 @@ on:
         required: false
         default: ""
         type: string
-      # Why is it a JSON string?
-      # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
         default: ubuntu-22.04-m
         required: false

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -93,5 +93,3 @@ jobs:
 
       - name: Show disk space after the tasks
         run: df -h
-  build-and-test-differential:
-    runs-on: ${{ inputs.runner }}

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -13,7 +13,7 @@ on:
       # Why is it a JSON string?
       # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
-        default: "['ubuntu-22.04-m']"
+        default: ubuntu-22.04-m
         required: false
         type: string
       run-condition:

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   clang-tidy-differential:
     if: ${{ inputs.run-condition }}
-    runs-on: ${{ fromJson(inputs.runner) }}
+    runs-on: ${{ inputs.runner }}
     container: ${{ inputs.container }}${{ inputs.container-suffix }}
     steps:
       - name: Set PR fetch depth

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -13,7 +13,7 @@ on:
       # Why is it a JSON string?
       # https://github.com/orgs/community/discussions/11692#discussioncomment-3541856
       runner:
-        default: ubuntu-22.04-m
+        default: "['ubuntu-22.04-m']"
         required: false
         type: string
       run-condition:

--- a/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download analysis results
         run: |
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check out PR head
         if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ steps.set-variables.outputs.pr-head-repo }}
           ref: ${{ steps.set-variables.outputs.pr-head-ref }}

--- a/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/.github/workflows/clang-tidy-pr-comments.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download analysis results
         run: |
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check out PR head
         if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ steps.set-variables.outputs.pr-head-repo }}
           ref: ${{ steps.set-variables.outputs.pr-head-ref }}

--- a/.github/workflows/delete-closed-pr-docs.yaml
+++ b/.github/workflows/delete-closed-pr-docs.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dispatch-push-event.yaml
+++ b/.github/workflows/dispatch-push-event.yaml
@@ -1,0 +1,45 @@
+name: dispatch-push-event
+on:
+  push:
+
+jobs:
+  search-dispatch-repo:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { version: beta/v0.3.**, dispatch-repo: pilot-auto.x1.eve }
+    outputs:
+      dispatch-repo: ${{ steps.search-dispatch-repo.outputs.value }}
+    steps:
+      - name: Search dispatch repo
+        id: search-dispatch-repo
+        run: |
+          if [[ ${{ github.ref_name }} =~ ${{ matrix.version }} ]]; then
+            echo ::set-output name=value::"${{ matrix.dispatch-repo }}"
+            echo "Detected beta branch: ${{ github.ref_name }}"
+            echo "Dispatch repository: ${{ matrix.dispatch-repo }}"
+          fi
+
+  dispatch-push-event:
+    runs-on: ubuntu-latest
+    needs: search-dispatch-repo
+    if: ${{ needs.search-dispatch-repo.outputs.dispatch-repo != '' }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.INTERNAL_APP_ID }}
+          private_key: ${{ secrets.INTERNAL_PRIVATE_KEY }}
+
+      # 注意: workflow_dispatchで指定するブランチはmain固定となっているため、dispatch-repoのmainブランチにupdate-beta-branch.yamlが存在することが前提条件。
+      - name: Dispatch the update-beta-branch workflow
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/tier4/${{ needs.search-dispatch-repo.outputs.dispatch-repo }}/actions/workflows/update-beta-branch.yaml/dispatches \
+          -d '{"ref":"main"}'

--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -1,0 +1,46 @@
+name: dispatch-release-note
+on:
+  push:
+    branches:
+      - beta/v*
+      - tier4/main
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      beta-branch-or-tag-name:
+        description: The name of the beta branch or tag to write release note
+        type: string
+        required: true
+jobs:
+  dispatch-release-note:
+    runs-on: ubuntu-latest
+    name: release-repository-dispatch
+    steps:
+      - name: Set tag name
+        id: set-tag-name
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF_NAME="${{ github.event.inputs.beta-branch-or-tag-name }}"
+          else
+            REF_NAME="${{ github.ref_name }}"
+          fi
+          echo ::set-output name=ref-name::"$REF_NAME"
+          echo ::set-output name=tag-name::"${REF_NAME#beta/}"
+
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Repository dispatch for release note
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ steps.generate-token.outputs.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/tier4/update-release-notes/dispatches" \
+          -d '{"event_type":"${{ steps.set-tag-name.outputs.ref-name }}"}'

--- a/.github/workflows/slack-send.yaml
+++ b/.github/workflows/slack-send.yaml
@@ -1,0 +1,25 @@
+name: slack-send
+on:
+  workflow_run:
+    workflows:
+      - build-and-test
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Send to Slack workflow
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "workflow-url": "${{ github.event.workflow_run.html_url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WORKFLOW_WEBHOOK_URL }}

--- a/.github/workflows/sync-awf-latest.yaml
+++ b/.github/workflows/sync-awf-latest.yaml
@@ -1,0 +1,30 @@
+name: sync-awf-latest
+
+on:
+  schedule:
+    - cron: 50 */1 * * * # every 1 hour (**:50)
+  workflow_dispatch:
+
+jobs:
+  sync-awf-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-branches
+        uses: autowarefoundation/autoware-github-actions/sync-branches@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base-branch: awf-latest
+          sync-pr-branch: sync-awf-latest
+          sync-target-repository: https://github.com/autowarefoundation/autoware.universe.git
+          sync-target-branch: main
+          pr-title: "chore: sync awf-latest"
+          pr-labels: |
+            bot
+          auto-merge-method: merge

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,49 @@
+name: sync-upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Target branch
+        required: true
+        type: string
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - run: npm install @holiday-jp/holiday_jp
+
+      - uses: actions/github-script@v6
+        id: is-holiday
+        with:
+          script: |
+            const holiday_jp = require(`${process.env.GITHUB_WORKSPACE}/node_modules/@holiday-jp/holiday_jp`)
+            core.setOutput('holiday', holiday_jp.isHoliday(new Date()));
+      - name: Print warning for invalid branch name
+        if: ${{ inputs.target_branch  == 'tier4/main' }}
+        run: |
+          echo This action cannot be performed on 'tier4/main' branch
+
+      - name: Run sync-branches
+        if: ${{ inputs.target_branch  != 'tier4/main' }}
+        uses: autowarefoundation/autoware-github-actions/sync-branches@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base-branch: ${{ inputs.target_branch }}
+          sync-pr-branch: sync-upstream
+          sync-target-repository: https://github.com/tier4/autoware.universe.git
+          sync-target-branch: awf-latest
+          pr-title: "chore: sync tier4/autoware.universe:awf-latest"
+          auto-merge-method: merge

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
@@ -12,3 +12,9 @@
       restart_suppression:
         min_behind_distance_to_stop: 0.5 #[m]
         max_behind_distance_to_stop: 1.0 #[m]
+
+      v2i:
+        use_rest_time: false
+        last_time_allowed_to_pass: 2.0 # relative time against at the time of turn to red
+        velocity_threshold: 0.5 # change the decision logic whether the current velocity is faster or not
+        required_time_to_departure: 3.0 # prevent low speed pass

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
@@ -32,6 +32,7 @@
   <depend>autoware_utils</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>jpn_signal_v2i_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

We no longer need to merge tier4/main to beta branches any more but yet we need v2i related changes to the `autoware_behavior_velocity_traffic_light_module`.

(tier4/main to beta/v0.46 we've done in the past)
https://github.com/tier4/autoware_universe/pull/2056

**In addition**, there was a bug in the `clang-tidy-differential.yaml` of beta/v0.47 branch, so this PR also fixes that.

## Note for reviewers

Maybe these PRs have to be merged first to pass the build-and-test.

- https://github.com/tier4/vehicle2infrastructure/pull/139
- https://github.com/tier4/tier4_autoware_msgs/pull/181
