### PR TITLE
fix: clang-tidy-differential updates

### DIFF
--- a/workflow_sync_setting.yaml
+++ b/workflow_sync_setting.yaml
@@ -46,6 +46,6 @@ workflows:
     clang-tidy-differential.yaml:
       updates:
         - on.workflow_call.inputs.runner.default: ubuntu-22.04-m
-        - jobs.build-and-test-differential.runs-on: ${{ inputs.runner }}
+        - jobs.clang-tidy-differential.runs-on: ${{ inputs.runner }}
   unique_tier4_workflows:
     - sync-workflows.yaml


### PR DESCRIPTION
fixing wrong setup, was discovered in beta/v0.47 by @TaikiYamada4 