### PR TITLE
fix(autoware_traffic_light_occlusion_predictor): remove unnecessary comment out to use traffic_light_recognition by camera

### DIFF
--- a/perception/autoware_traffic_light_occlusion_predictor/launch/traffic_light_occlusion_predictor.launch.xml
+++ b/perception/autoware_traffic_light_occlusion_predictor/launch/traffic_light_occlusion_predictor.launch.xml
@@ -15,7 +15,7 @@
     <remap from="~/input/cloud" to="$(var input/cloud)"/>
     <remap from="~/input/rois" to="$(var input/rois)"/>
     <remap from="~/input/car/traffic_signals" to="$(var input/car/traffic_signals)"/>
-    <!-- <remap from="~/input/pedestrian/traffic_signals" to="$(var input/pedestrian/traffic_signals)"/> -->
+    <remap from="~/input/pedestrian/traffic_signals" to="$(var input/pedestrian/traffic_signals)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
     <param from="$(var param_path)"/>
   </node>


### PR DESCRIPTION
# Description

This PR enables to use TLR, As the title says.