### PR TITLE
fix: change the execution order of map_height_fitter cmake

### DIFF
--- a/map/map_height_fitter/CMakeLists.txt
+++ b/map/map_height_fitter/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 project(map_height_fitter)
 
 find_package(autoware_cmake REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
 autoware_package()
+find_package(PCL REQUIRED COMPONENTS common)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_height_fitter.cpp

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
@@ -27,8 +27,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>lanelet2_extension</depend>
   <depend>grid_map_core</depend>
+  <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
## Description

`map_height_fitter` パッケージの `CMakeLists.txt` において、`autoware_package()` と `find_package(PCL ...)` の呼び出し順序を修正しました。
この変更により、PCLが依存する `libusb` が `autoware_package` の前に探索されるようになり、`libusb::libusb` ターゲットが見つからずに発生していたビルドエラーを解消します。

## Tests performed

ローカル環境 & Evaluatorで対象パッケージのビルドが成功することを確認しました。
修正前: https://evaluation.tier4.jp/evaluation/reports/16bcc218-327f-5217-88a9-5c8a9196756a?project_id=X8ft5pPN
修正後: https://evaluation.tier4.jp/evaluation/reports/4d5babf8-842e-5022-bb7b-9075ef7cb327?project_id=X8ft5pPN
## Effects on system behavior

Not applicable.

## Interface changes

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/