### PR TITLE
fix(run_out): guard against decreasing ego trajectory times (#10746)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
@@ -92,6 +92,10 @@ double calculate_keep_stop_distance_range(
   std::vector<double> arc_lengths = {0.0};
   for (auto i = 1UL; i < trajectory.size(); ++i) {
     const auto t = rclcpp::Duration(trajectory[i].time_from_start).seconds();
+    if (times.back() >= t) {
+      // we skip trajectory points where the predicted time decreases to avoid interpolation errors
+      continue;
+    }
     const auto arc_length_delta = universe_utils::calcDistance2d(trajectory[i - 1], trajectory[i]);
     times.push_back(t);
     arc_lengths.push_back(arc_lengths.back() + arc_length_delta);


### PR DESCRIPTION
This is cherry-picked from:
https://github.com/autowarefoundation/autoware_universe/pull/10746

It will fix a bug in this ticket:
[TIER IV internal link](https://tier4.atlassian.net/browse/RT0-37680)
I verified this change on logging_simulator and rosbag. It worked fine