### PR TITLE
fix: pointpainting mising param

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -154,6 +154,11 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
     this->declare_parameter<std::vector<int64_t>>("allow_remapping_by_area_matrix");
   const auto min_area_matrix = this->declare_parameter<std::vector<double>>("min_area_matrix");
   const auto max_area_matrix = this->declare_parameter<std::vector<double>>("max_area_matrix");
+  const float front_back_low_score_threshold = static_cast<float>(
+    this->declare_parameter<double>("post_process_params.front_back_low_score_threshold"));
+  const float ego_width =
+    static_cast<float>(this->declare_parameter<double>("post_process_params.ego_width"));
+
 
   // subscriber
   std::function<void(const PointCloudMsgType::ConstSharedPtr msg)> sub_callback =
@@ -186,7 +191,8 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
   autoware::lidar_centerpoint::CenterPointConfig config(
     class_names_.size(), point_feature_size, cloud_capacity, max_voxel_size, pointcloud_range,
     voxel_size, downsample_factor, encoder_in_feature_size, score_threshold,
-    circle_nms_dist_threshold, yaw_norm_thresholds, has_variance_);
+    circle_nms_dist_threshold, yaw_norm_thresholds, has_variance_, front_back_low_score_threshold,
+    ego_width);
 
   // create detector
   detector_ptr_ = std::make_unique<image_projection_based_fusion::PointPaintingTRT>(

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -159,7 +159,6 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
   const float ego_width =
     static_cast<float>(this->declare_parameter<double>("post_process_params.ego_width"));
 
-
   // subscriber
   std::function<void(const PointCloudMsgType::ConstSharedPtr msg)> sub_callback =
     std::bind(&PointPaintingFusionNode::subCallback, this, std::placeholders::_1);


### PR DESCRIPTION
fix param missing bag in pointpainting to fix the compile error 
``` 
src/autoware/universe/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp:189:66: error: no matching function for call to ‘autoware::lidar_centerpoint::CenterPointConfig::CenterPointConfig(std::vector<std::__cxx11::basic_string<char> >::size_type, const size_t&, const size_t&, const size_t&, std::vector<double, std::allocator<double> >&, const std::vector<double, std::allocator<double> >&, const size_t&, const size_t&, const float&, const float&, const std::vector<double, std::allocator<double> >&, bool&)’
  189 |     circle_nms_dist_threshold, yaw_norm_thresholds, has_variance_);

```

Evaluatorも失敗：https://evaluation.tier4.jp/evaluation/reports/362d575e-266c-59e0-adcc-a6ae0e89e004/builds/278abca5-5d3a-5769-8861-a3f2aa4942cb?project_id=x2_dev