### PR TITLE
feat(lidar_centerpoint): introduce new score filtering logic for dete…

### DIFF
--- a/perception/autoware_image_projection_based_fusion/config/roi_detected_object_fusion.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/roi_detected_object_fusion.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     # UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
-    passthrough_lower_bound_probability_thresholds: [0.35, 0.35, 0.35, 0.35, 0.35, 0.35, 0.35, 0.50]
+    passthrough_lower_bound_probability_thresholds: [0.35, 0.24, 0.24, 0.24, 0.24, 0.24, 0.35, 0.50]
     trust_distances: [50.0, 100.0, 100.0, 100.0, 100.0, 50.0, 50.0, 50.0]
     min_iou_threshold: 0.5
     use_roi_probability: false

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/centerpoint_config.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/centerpoint_config.hpp
@@ -29,7 +29,7 @@ public:
     const std::vector<double> & voxel_size, const std::size_t downsample_factor,
     const std::size_t encoder_in_feature_size, const float score_threshold,
     const float circle_nms_dist_threshold, const std::vector<double> yaw_norm_thresholds,
-    const bool has_variance)
+    const bool has_variance, const float front_back_low_score_threshold, const float ego_width)
   {
     class_size_ = class_size;
     point_feature_size_ = point_feature_size;
@@ -84,6 +84,9 @@ public:
     offset_z_ = range_min_z_ + voxel_size_z_ / 2;
     down_grid_size_x_ = grid_size_x_ / downsample_factor_;
     down_grid_size_y_ = grid_size_y_ / downsample_factor_;
+
+    front_back_low_score_threshold_ = front_back_low_score_threshold;
+    ego_width_ = ego_width;
   };
 
   // input params
@@ -118,6 +121,8 @@ public:
 
   // post-process params
   float score_threshold_{0.35f};
+  float front_back_low_score_threshold_{0.25f};
+  float ego_width_{1.5f};  // the width of the ego vehicle
   float circle_nms_dist_threshold_{1.5f};
   std::vector<float> yaw_norm_thresholds_{};
 

--- a/perception/autoware_lidar_centerpoint/lib/postprocess/postprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/postprocess/postprocess_kernel.cu
@@ -36,6 +36,30 @@ private:
   float t_{0.0};
 };
 
+struct is_score_greater_or_front_back_low_score
+{
+  is_score_greater_or_front_back_low_score(float t, float low_t, float ego_width)
+  : t_(t), low_t_(low_t), ego_width_(ego_width)
+  {
+  }
+
+  __device__ bool operator()(const Box3D & b)
+  {
+    // Always keep if score > high threshold
+    if (b.score > t_) return true;
+
+    // For lower scores, only keep if:
+    // 1. Score > low threshold AND
+    // 2. Object is in front or back (y position within ego width)
+    return (b.score > low_t_) && (fabsf(b.y) < (ego_width_ / 2.0f));
+  }
+
+private:
+  float t_{0.0};
+  float low_t_{0.0};
+  float ego_width_{0.0};
+};
+
 struct is_kept
 {
   __device__ bool operator()(const bool keep) { return keep; }
@@ -161,15 +185,19 @@ cudaError_t PostProcessCUDA::generateDetectedBoxes3D_launch(
     thrust::raw_pointer_cast(boxes3d_d.data()));
 
   // suppress by score
+  // suppress by score with new condition
   const auto num_det_boxes3d = thrust::count_if(
-    thrust::device, boxes3d_d.begin(), boxes3d_d.end(), is_score_greater(config_.score_threshold_));
+    thrust::device, boxes3d_d.begin(), boxes3d_d.end(),
+    is_score_greater_or_front_back_low_score(
+      config_.score_threshold_, config_.front_back_low_score_threshold_, config_.ego_width_));
   if (num_det_boxes3d == 0) {
     return cudaGetLastError();
   }
   thrust::device_vector<Box3D> det_boxes3d_d(num_det_boxes3d);
   thrust::copy_if(
     thrust::device, boxes3d_d.begin(), boxes3d_d.end(), det_boxes3d_d.begin(),
-    is_score_greater(config_.score_threshold_));
+    is_score_greater_or_front_back_low_score(
+      config_.score_threshold_, config_.front_back_low_score_threshold_, config_.ego_width_));
 
   // sort by score
   thrust::sort(det_boxes3d_d.begin(), det_boxes3d_d.end(), score_greater());

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -74,6 +74,10 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<std::vector<int64_t>>("allow_remapping_by_area_matrix");
   const auto min_area_matrix = this->declare_parameter<std::vector<double>>("min_area_matrix");
   const auto max_area_matrix = this->declare_parameter<std::vector<double>>("max_area_matrix");
+  const float front_back_low_score_threshold = static_cast<float>(
+    this->declare_parameter<double>("post_process_params.front_back_low_score_threshold"));
+  const float ego_width =
+    static_cast<float>(this->declare_parameter<double>("post_process_params.ego_width"));
 
   detection_class_remapper_.setParameters(
     allow_remapping_by_area_matrix, min_area_matrix, max_area_matrix);
@@ -104,7 +108,8 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
   CenterPointConfig config(
     class_names_.size(), point_feature_size, cloud_capacity, max_voxel_size, point_cloud_range,
     voxel_size, downsample_factor, encoder_in_feature_size, score_threshold,
-    circle_nms_dist_threshold, yaw_norm_thresholds, has_variance_);
+    circle_nms_dist_threshold, yaw_norm_thresholds, has_variance_, front_back_low_score_threshold,
+    ego_width);
   detector_ptr_ =
     std::make_unique<CenterPointTRT>(encoder_param, head_param, densification_param, config);
   diagnostics_interface_ptr_ =


### PR DESCRIPTION
…cted boxes (#2115)

* feat(postprocess): introduce new score filtering logic for detected boxes

Added a new struct `is_score_greater_or_front_back_low_score` to enhance the filtering of detected 3D boxes based on score thresholds. This new logic allows for retaining lower-scoring boxes if they are within the ego vehicle's width, improving detection accuracy for objects in front or back. Updated the post-processing kernel to utilize this new condition during box suppression.




* add parameters into config



* style(unknown_tracker.cpp): format conditional statement for consistency



* update roi_detected_object_fusion parameters: adjust passthrough_lower_bound_probability_thresholds for improved object detection accuracy



---------