### PR TITLE
feat(autoware_lidar_centerpoint): Add intensity model 

### DIFF
--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
@@ -50,7 +50,7 @@ private:
 
 struct PointCloudWithTransform
 {
-  cuda::unique_ptr<uint8_t []> points_d{nullptr};
+  cuda::unique_ptr<uint8_t[]> points_d{nullptr};
   std_msgs::msg::Header header;
   std::size_t num_points{0};
   std::size_t point_step{0};

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
@@ -50,7 +50,7 @@ private:
 
 struct PointCloudWithTransform
 {
-  cuda::unique_ptr<float[]> points_d{nullptr};
+  cuda::unique_ptr<uint8_t []> points_d{nullptr};
   std_msgs::msg::Header header;
   std::size_t num_points{0};
   std::size_t point_step{0};

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
@@ -21,30 +21,30 @@
 namespace autoware::lidar_centerpoint
 {
 cudaError_t generateSweepPoints_launch(
-  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
+  const uint8_t * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform, int num_features, float * output_points, cudaStream_t stream);
 
 cudaError_t shufflePoints_launch(
   const float * points, const unsigned int * indices, float * shuffled_points,
-  const std::size_t points_size, const std::size_t max_size, const std::size_t offset,
+  const std::size_t points_size, const std::size_t max_size, const std::size_t offset, const int num_features,
   cudaStream_t stream);
 
 cudaError_t generateVoxels_random_launch(
   const float * points, std::size_t points_size, float min_x_range, float max_x_range,
   float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
   float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
-  float * voxels, cudaStream_t stream);
+  float * voxels, const int num_features, cudaStream_t stream);
 
 cudaError_t generateBaseFeatures_launch(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
-  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs,
+  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs, const int num_features,
   cudaStream_t stream);
 
 cudaError_t generateFeatures_launch(
   const float * voxel_features, const float * voxel_num_points, const int * coords,
   const unsigned int * num_voxels, const std::size_t max_voxel_size, const float voxel_size_x,
   const float voxel_size_y, const float voxel_size_z, const float range_min_x,
-  const float range_min_y, const float range_min_z, float * features, cudaStream_t stream);
+  const float range_min_y, const float range_min_z, float * features, const std::size_t encoder_in_feature_size, cudaStream_t stream);
 
 }  // namespace autoware::lidar_centerpoint
 

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
@@ -26,8 +26,8 @@ cudaError_t generateSweepPoints_launch(
 
 cudaError_t shufflePoints_launch(
   const float * points, const unsigned int * indices, float * shuffled_points,
-  const std::size_t points_size, const std::size_t max_size, const std::size_t offset, const int num_features,
-  cudaStream_t stream);
+  const std::size_t points_size, const std::size_t max_size, const std::size_t offset,
+  const int num_features, cudaStream_t stream);
 
 cudaError_t generateVoxels_random_launch(
   const float * points, std::size_t points_size, float min_x_range, float max_x_range,
@@ -37,14 +37,15 @@ cudaError_t generateVoxels_random_launch(
 
 cudaError_t generateBaseFeatures_launch(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
-  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs, const int num_features,
-  cudaStream_t stream);
+  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs,
+  const int num_features, cudaStream_t stream);
 
 cudaError_t generateFeatures_launch(
   const float * voxel_features, const float * voxel_num_points, const int * coords,
   const unsigned int * num_voxels, const std::size_t max_voxel_size, const float voxel_size_x,
   const float voxel_size_y, const float voxel_size_z, const float range_min_x,
-  const float range_min_y, const float range_min_z, float * features, const std::size_t encoder_in_feature_size, cudaStream_t stream);
+  const float range_min_y, const float range_min_z, float * features,
+  const std::size_t encoder_in_feature_size, cudaStream_t stream);
 
 }  // namespace autoware::lidar_centerpoint
 

--- a/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
@@ -246,7 +246,7 @@ bool CenterPointTRT::preprocess(
     voxels_d_.get(), num_points_per_voxel_d_.get(), coordinates_d_.get(), num_voxels_d_.get(),
     config_.max_voxel_size_, config_.voxel_size_x_, config_.voxel_size_y_, config_.voxel_size_z_,
     config_.range_min_x_, config_.range_min_y_, config_.range_min_z_, encoder_in_features_d_.get(),
-    stream_));
+    config_.encoder_in_feature_size_, stream_));
 
   return true;
 }

--- a/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
@@ -219,7 +219,7 @@ bool CenterPointTRT::preprocess(
   const std::size_t random_offset = std::rand() % config_.cloud_capacity_;
   CHECK_CUDA_ERROR(shufflePoints_launch(
     points_aux_d_.get(), shuffle_indices_d_.get(), points_d_.get(), count, config_.cloud_capacity_,
-    random_offset, stream_));
+    random_offset, config_.point_feature_size_, stream_));
 
   CHECK_CUDA_ERROR(cudaMemsetAsync(num_voxels_d_.get(), 0, sizeof(unsigned int), stream_));
   CHECK_CUDA_ERROR(
@@ -235,12 +235,12 @@ bool CenterPointTRT::preprocess(
     points_d_.get(), config_.cloud_capacity_, config_.range_min_x_, config_.range_max_x_,
     config_.range_min_y_, config_.range_max_y_, config_.range_min_z_, config_.range_max_z_,
     config_.voxel_size_x_, config_.voxel_size_y_, config_.voxel_size_z_, config_.grid_size_y_,
-    config_.grid_size_x_, mask_d_.get(), voxels_buffer_d_.get(), stream_));
+    config_.grid_size_x_, mask_d_.get(), voxels_buffer_d_.get(), config_.point_feature_size_, stream_));
 
   CHECK_CUDA_ERROR(generateBaseFeatures_launch(
     mask_d_.get(), voxels_buffer_d_.get(), config_.grid_size_y_, config_.grid_size_x_,
     config_.max_voxel_size_, num_voxels_d_.get(), voxels_d_.get(), num_points_per_voxel_d_.get(),
-    coordinates_d_.get(), stream_));
+    coordinates_d_.get(), config_.point_feature_size_, stream_));
 
   CHECK_CUDA_ERROR(generateFeatures_launch(
     voxels_d_.get(), num_points_per_voxel_d_.get(), coordinates_d_.get(), num_voxels_d_.get(),

--- a/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
@@ -235,7 +235,8 @@ bool CenterPointTRT::preprocess(
     points_d_.get(), config_.cloud_capacity_, config_.range_min_x_, config_.range_max_x_,
     config_.range_min_y_, config_.range_max_y_, config_.range_min_z_, config_.range_max_z_,
     config_.voxel_size_x_, config_.voxel_size_y_, config_.voxel_size_z_, config_.grid_size_y_,
-    config_.grid_size_x_, mask_d_.get(), voxels_buffer_d_.get(), config_.point_feature_size_, stream_));
+    config_.grid_size_x_, mask_d_.get(), voxels_buffer_d_.get(), config_.point_feature_size_,
+    stream_));
 
   CHECK_CUDA_ERROR(generateBaseFeatures_launch(
     mask_d_.get(), voxels_buffer_d_.get(), config_.grid_size_y_, config_.grid_size_x_,

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/pointcloud_densification.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/pointcloud_densification.cpp
@@ -91,8 +91,10 @@ void PointCloudDensification::enqueue(
   current_timestamp_ = rclcpp::Time(msg.header.stamp).seconds();
 
   assert(sizeof(uint8_t) * msg.width * msg.height * msg.point_step % sizeof(float) == 0);
-  auto points_d = cuda::make_unique<float[]>(
-    sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(float));
+  // auto points_d = cuda::make_unique<float[]>(
+    // sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(float));
+  auto points_d = cuda::make_unique<uint8_t[]>(
+    sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(uint8_t));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     points_d.get(), msg.data.data(), sizeof(uint8_t) * msg.width * msg.height * msg.point_step,
     cudaMemcpyHostToDevice, stream));

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/pointcloud_densification.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/pointcloud_densification.cpp
@@ -92,7 +92,7 @@ void PointCloudDensification::enqueue(
 
   assert(sizeof(uint8_t) * msg.width * msg.height * msg.point_step % sizeof(float) == 0);
   // auto points_d = cuda::make_unique<float[]>(
-    // sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(float));
+  // sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(float));
   auto points_d = cuda::make_unique<uint8_t[]>(
     sizeof(uint8_t) * msg.width * msg.height * msg.point_step / sizeof(uint8_t));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -491,12 +491,19 @@ __global__ void generateIntensityFeatures_kernel(
     pillarSumSM[threadIdx.x] = {0, 0, 0};
   }
 
-  pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
-  pillarSM[pillar_idx_inBlock][point_idx][1] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 1];
-  pillarSM[pillar_idx_inBlock][point_idx][2] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 2];
-  pillarSM[pillar_idx_inBlock][point_idx][3] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 3];
-  pillarSM[pillar_idx_inBlock][point_idx][4] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 4];
+//   pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
+//   pillarSM[pillar_idx_inBlock][point_idx][1] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 1];
+//   pillarSM[pillar_idx_inBlock][point_idx][2] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 2];
+//   pillarSM[pillar_idx_inBlock][point_idx][3] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 3];
+//   pillarSM[pillar_idx_inBlock][point_idx][4] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 4];
   
+  #pragma unroll
+  for (int i = 0; i < POINT_DIM_XYZIT; i++) {  
+	int pillarSMId = pillar_idx_inBlock * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
+    int voxel_feature_id = pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
+	((float *)pillarSM)[pillarSMId] = ((float *)voxel_features)[voxel_feature_id];
+  	// pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
+  }
   __syncthreads();
 
   // calculate sm in a pillar

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -111,7 +111,7 @@ cudaError_t generateSweepPoints_launch(
       input_points, points_size, input_point_step, time_lag, transform_d.get(), num_features,
       output_points);
   } else {
-    throw throw std::runtime_error("Value of num_features is not supported!");
+    throw std::runtime_error("Value of num_features is not supported!");
   }
 
   cudaError_t err = cudaGetLastError();
@@ -179,7 +179,7 @@ cudaError_t shufflePoints_launch(
     shufflePoints_kernel<POINT_DIM_XYZIT><<<blocks, threads, 0, stream>>>(
       points, indices, shuffled_points, points_size, max_size, offset);
   } else {
-    throw throw std::runtime_error("Value of num_features is not supported!");
+    throw std::runtime_error("Value of num_features is not supported!");
   }
   cudaError_t err = cudaGetLastError();
   return err;
@@ -278,7 +278,7 @@ cudaError_t generateVoxels_random_launch(
       max_z_range, pillar_x_size, pillar_y_size, pillar_z_size, grid_y_size, grid_x_size, mask,
       voxels);
   } else {
-    throw throw std::runtime_error("Value of num_features is not supported!");
+    throw std::runtime_error("Value of num_features is not supported!");
   }
   cudaError_t err = cudaGetLastError();
   return err;
@@ -348,7 +348,7 @@ cudaError_t generateBaseFeatures_launch(
       mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,
       voxel_idxs);
   } else {
-    throw throw std::runtime_error("Value of num_features is not supported!");
+    throw std::runtime_error("Value of num_features is not supported!");
   }
   cudaError_t err = cudaGetLastError();
   return err;
@@ -598,6 +598,8 @@ cudaError_t generateFeatures_launch(
     generateIntensityFeatures_kernel<<<blocks, threads, 0, stream>>>(
       voxel_features, voxel_num_points, coords, num_voxels, voxel_size_x, voxel_size_y, voxel_size_z,
       range_min_x, range_min_y, range_min_z, features);
+  } else {
+    throw std::runtime_error("Value of encoder_in_feature_size is not supported!");
   }
   return cudaGetLastError();
 }

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -490,19 +490,12 @@ __global__ void generateIntensityFeatures_kernel(
     cordsSM[threadIdx.x] = ((int3 *)coords)[blockIdx.x * WARPS_PER_BLOCK + threadIdx.x];
     pillarSumSM[threadIdx.x] = {0, 0, 0};
   }
-
-//   pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
-//   pillarSM[pillar_idx_inBlock][point_idx][1] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 1];
-//   pillarSM[pillar_idx_inBlock][point_idx][2] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 2];
-//   pillarSM[pillar_idx_inBlock][point_idx][3] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 3];
-//   pillarSM[pillar_idx_inBlock][point_idx][4] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 4];
   
   #pragma unroll
   for (int i = 0; i < POINT_DIM_XYZIT; i++) {  
 	int pillarSMId = pillar_idx_inBlock * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
     int voxel_feature_id = pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
 	((float *)pillarSM)[pillarSMId] = ((float *)voxel_features)[voxel_feature_id];
-  	// pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
   }
   __syncthreads();
 

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -502,9 +502,9 @@ __global__ void generateIntensityFeatures_kernel(
 
   // calculate sm in a pillar
   if (point_idx < pointsNumSM[pillar_idx_inBlock]) {
-    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].x), pillarSM[pillar_idx_inBlock][point_idx].x);
-    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].y), pillarSM[pillar_idx_inBlock][point_idx].y);
-    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].z), pillarSM[pillar_idx_inBlock][point_idx].z);
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].x), pillarSM[pillar_idx_inBlock][point_idx][0]);
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].y), pillarSM[pillar_idx_inBlock][point_idx][1]);
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].z), pillarSM[pillar_idx_inBlock][point_idx][2]);
   }
   __syncthreads();
 
@@ -515,9 +515,9 @@ __global__ void generateIntensityFeatures_kernel(
   mean.y = pillarSumSM[pillar_idx_inBlock].y / validPoints;
   mean.z = pillarSumSM[pillar_idx_inBlock].z / validPoints;
 
-  mean.x = pillarSM[pillar_idx_inBlock][point_idx].x - mean.x;
-  mean.y = pillarSM[pillar_idx_inBlock][point_idx].y - mean.y;
-  mean.z = pillarSM[pillar_idx_inBlock][point_idx].z - mean.z;
+  mean.x = pillarSM[pillar_idx_inBlock][point_idx][0] - mean.x;
+  mean.y = pillarSM[pillar_idx_inBlock][point_idx][1] - mean.y;
+  mean.z = pillarSM[pillar_idx_inBlock][point_idx][2] - mean.z;
 
   // calculate offset
   float x_offset = voxel_x / 2 + cordsSM[pillar_idx_inBlock].z * voxel_x + range_min_x;

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -526,9 +526,9 @@ __global__ void generateIntensityFeatures_kernel(
 
   // feature-offset
   float3 center;
-  center.x = pillarSM[pillar_idx_inBlock][point_idx].x - x_offset;
-  center.y = pillarSM[pillar_idx_inBlock][point_idx].y - y_offset;
-  center.z = pillarSM[pillar_idx_inBlock][point_idx].z - z_offset;
+  center.x = pillarSM[pillar_idx_inBlock][point_idx][0] - x_offset;
+  center.y = pillarSM[pillar_idx_inBlock][point_idx][1] - y_offset;
+  center.z = pillarSM[pillar_idx_inBlock][point_idx][2] - z_offset;
 
   // store output
   if (point_idx < pointsNumSM[pillar_idx_inBlock]) {

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -40,37 +40,58 @@ namespace
 const std::size_t MAX_POINT_IN_VOXEL_SIZE = 32;  // the same as max_point_in_voxel_size_ in config
 const std::size_t WARPS_PER_BLOCK = 4;
 const std::size_t ENCODER_IN_FEATURE_SIZE = 9;  // the same as encoder_in_feature_size_ in config
+const std::size_t POINT_DIM_XYZT = 4;
+const std::size_t POINT_DIM_XYZIT = 5;
+const std::size_t NUM_FEATURES_11 = 11;
 }  // namespace
 
 namespace autoware::lidar_centerpoint
 {
 
+template <std::size_t POINT_NUM_FEATURES> 
 __global__ void generateSweepPoints_kernel(
-  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
+  const uint8_t * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform_array, int num_features, float * output_points)
 {
   int point_idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (point_idx >= points_size) return;
 
-  const float input_x = input_points[point_idx * input_point_step + 0];
-  const float input_y = input_points[point_idx * input_point_step + 1];
-  const float input_z = input_points[point_idx * input_point_step + 2];
 
-  // transform_array is expected to be column-major
-  output_points[point_idx * num_features + 0] = transform_array[0] * input_x +
-                                                transform_array[4] * input_y +
-                                                transform_array[8] * input_z + transform_array[12];
-  output_points[point_idx * num_features + 1] = transform_array[1] * input_x +
-                                                transform_array[5] * input_y +
-                                                transform_array[9] * input_z + transform_array[13];
-  output_points[point_idx * num_features + 2] = transform_array[2] * input_x +
-                                                transform_array[6] * input_y +
-                                                transform_array[10] * input_z + transform_array[14];
-  output_points[point_idx * num_features + 3] = time_lag;
+  union {
+    uint32_t raw{0};
+    float value;
+  } input_x, input_y, input_z;
+
+  #pragma unroll
+  for (int i = 0; i < 4; i++) {  // 4 bytes for float32
+    input_x.raw |= input_points[point_idx * input_point_step + i] << i * 8;
+    input_y.raw |= input_points[point_idx * input_point_step + i + 4] << i * 8;
+    input_z.raw |= input_points[point_idx * input_point_step + i + 8] << i * 8;
+  }
+
+  output_points[point_idx * num_features] =
+    transform_array[0] * input_x.value + transform_array[4] * input_y.value +
+    transform_array[8] * input_z.value + transform_array[12];
+  output_points[point_idx * num_features + 1] =
+    transform_array[1] * input_x.value + transform_array[5] * input_y.value +
+    transform_array[9] * input_z.value + transform_array[13];
+  output_points[point_idx * num_features + 2] =
+    transform_array[2] * input_x.value + transform_array[6] * input_y.value +
+    transform_array[10] * input_z.value + transform_array[14];
+  
+  if (POINT_NUM_FEATURES == POINT_DIM_XYZT) {
+    output_points[point_idx * num_features + 3] = time_lag;
+  } else if (POINT_NUM_FEATURES == POINT_DIM_XYZIT) {
+    float input_intensity = static_cast<float>(input_points[point_idx * input_point_step + 12]);
+    output_points[point_idx * num_features + 3] = input_intensity;
+    output_points[point_idx * num_features + 4] = time_lag;
+  } else {
+    return;
+  }
 }
 
 cudaError_t generateSweepPoints_launch(
-  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
+  const uint8_t * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform_array, int num_features, float * output_points, cudaStream_t stream)
 {
   auto transform_d = cuda::make_unique<float[]>(16);
@@ -79,16 +100,25 @@ cudaError_t generateSweepPoints_launch(
 
   dim3 blocks((points_size + 256 - 1) / 256);
   dim3 threads(256);
-  assert(num_features == 4);
-
-  generateSweepPoints_kernel<<<blocks, threads, 0, stream>>>(
-    input_points, points_size, input_point_step, time_lag, transform_d.get(), num_features,
-    output_points);
+  assert(num_features == POINT_DIM_XYZT || num_features == POINT_DIM_XYZIT);
+  
+  if (num_features == POINT_DIM_XYZT) {
+    generateSweepPoints_kernel<POINT_DIM_XYZT><<<blocks, threads, 0, stream>>>(
+      input_points, points_size, input_point_step, time_lag, transform_d.get(), num_features,
+      output_points);
+  } else if (num_features == POINT_DIM_XYZIT) {
+    generateSweepPoints_kernel<POINT_DIM_XYZIT><<<blocks, threads, 0, stream>>>(
+      input_points, points_size, input_point_step, time_lag, transform_d.get(), num_features,
+      output_points);
+  } else {
+    throw throw std::runtime_error("Value of num_features is not supported!");
+  }
 
   cudaError_t err = cudaGetLastError();
   return err;
 }
 
+template <std::size_t POINT_NUM_FEATURES> 
 __global__ void shufflePoints_kernel(
   const float * points, const unsigned int * indices, float * shuffled_points,
   const std::size_t points_size, const std::size_t max_size, const std::size_t offset)
@@ -99,22 +129,40 @@ __global__ void shufflePoints_kernel(
   int src_idx = indices[(point_idx + offset) % max_size];
   int dst_idx = point_idx;
 
-  if (dst_idx >= points_size) {
-    shuffled_points[4 * dst_idx + 0] = INFINITY;
-    shuffled_points[4 * dst_idx + 1] = INFINITY;
-    shuffled_points[4 * dst_idx + 2] = INFINITY;
-    shuffled_points[4 * dst_idx + 3] = INFINITY;
+  if (POINT_NUM_FEATURES == POINT_DIM_XYZT) {
+    if (dst_idx >= points_size) {
+      shuffled_points[4 * dst_idx + 0] = INFINITY;
+      shuffled_points[4 * dst_idx + 1] = INFINITY;
+      shuffled_points[4 * dst_idx + 2] = INFINITY;
+      shuffled_points[4 * dst_idx + 3] = INFINITY;
+    } else {
+      shuffled_points[4 * dst_idx + 0] = points[4 * src_idx + 0];
+      shuffled_points[4 * dst_idx + 1] = points[4 * src_idx + 1];
+      shuffled_points[4 * dst_idx + 2] = points[4 * src_idx + 2];
+      shuffled_points[4 * dst_idx + 3] = points[4 * src_idx + 3];
+    }
+  } else if (POINT_NUM_FEATURES == POINT_DIM_XYZIT) {
+    if (dst_idx >= points_size) {
+      shuffled_points[5 * dst_idx + 0] = INFINITY;
+      shuffled_points[5 * dst_idx + 1] = INFINITY;
+      shuffled_points[5 * dst_idx + 2] = INFINITY;
+      shuffled_points[5 * dst_idx + 3] = INFINITY;
+      shuffled_points[5 * dst_idx + 4] = INFINITY;
+    } else {
+      shuffled_points[5 * dst_idx + 0] = points[5 * src_idx + 0];
+      shuffled_points[5 * dst_idx + 1] = points[5 * src_idx + 1];
+      shuffled_points[5 * dst_idx + 2] = points[5 * src_idx + 2];
+      shuffled_points[5 * dst_idx + 3] = points[5 * src_idx + 3];
+      shuffled_points[5 * dst_idx + 4] = points[5 * src_idx + 4];
+    }
   } else {
-    shuffled_points[4 * dst_idx + 0] = points[4 * src_idx + 0];
-    shuffled_points[4 * dst_idx + 1] = points[4 * src_idx + 1];
-    shuffled_points[4 * dst_idx + 2] = points[4 * src_idx + 2];
-    shuffled_points[4 * dst_idx + 3] = points[4 * src_idx + 3];
+    return;
   }
 }
 
 cudaError_t shufflePoints_launch(
   const float * points, const unsigned int * indices, float * shuffled_points,
-  const std::size_t points_size, const std::size_t max_size, const std::size_t offset,
+  const std::size_t points_size, const std::size_t max_size, const std::size_t offset, const int num_features,
   cudaStream_t stream)
 {
   dim3 blocks((max_size + 256 - 1) / 256);
@@ -124,10 +172,54 @@ cudaError_t shufflePoints_launch(
     return cudaGetLastError();
   }
 
-  shufflePoints_kernel<<<blocks, threads, 0, stream>>>(
-    points, indices, shuffled_points, points_size, max_size, offset);
+  if (num_features == POINT_DIM_XYZT) {
+    shufflePoints_kernel<POINT_DIM_XYZT><<<blocks, threads, 0, stream>>>(
+      points, indices, shuffled_points, points_size, max_size, offset);
+  } else if (num_features == POINT_DIM_XYZIT) {
+    shufflePoints_kernel<POINT_DIM_XYZIT><<<blocks, threads, 0, stream>>>(
+      points, indices, shuffled_points, points_size, max_size, offset);
+  } else {
+    throw throw std::runtime_error("Value of num_features is not supported!");
+  }
   cudaError_t err = cudaGetLastError();
   return err;
+}
+
+__global__ void generateIntensityVoxels_random_kernel(
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range,
+  float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
+  float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
+  float * voxels)
+{
+  int point_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_idx >= points_size) return;
+
+  float x = points[point_idx * 5];
+  float y = points[point_idx * 5 + 1];
+  float z = points[point_idx * 5 + 2];
+  float i = points[point_idx * 5 + 3];
+  float t = points[point_idx * 5 + 4];
+
+  if (
+    x < min_x_range || x >= max_x_range || y < min_y_range || y >= max_y_range ||
+    z < min_z_range || z >= max_z_range)
+    return;
+
+  int voxel_idx = floorf((x - min_x_range) / pillar_x_size);
+  int voxel_idy = floorf((y - min_y_range) / pillar_y_size);
+  voxel_idx = voxel_idx < 0 ? 0 : voxel_idx >= grid_x_size ? grid_x_size - 1 : voxel_idx;
+  voxel_idy = voxel_idy < 0 ? 0 : voxel_idy >= grid_y_size ? grid_y_size - 1 : voxel_idy;
+  unsigned int voxel_index = (grid_x_size - 1 - voxel_idx) * grid_y_size + voxel_idy;
+
+  unsigned int point_id = atomicAdd(&(mask[voxel_index]), 1);
+
+  if (point_id >= points_per_voxel) return;
+  float * address = voxels + (voxel_index * points_per_voxel + point_id) * POINT_DIM_XYZIT;
+  atomicExch(address + 0, x);
+  atomicExch(address + 1, y);
+  atomicExch(address + 2, z);
+  atomicExch(address + 3, i);
+  atomicExch(address + 4, t);
 }
 
 __global__ void generateVoxels_random_kernel(
@@ -166,7 +258,7 @@ cudaError_t generateVoxels_random_launch(
   const float * points, std::size_t points_size, float min_x_range, float max_x_range,
   float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
   float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
-  float * voxels, cudaStream_t stream)
+  float * voxels, const int num_features, cudaStream_t stream)
 {
   dim3 blocks((points_size + 256 - 1) / 256);
   dim3 threads(256);
@@ -175,14 +267,24 @@ cudaError_t generateVoxels_random_launch(
     return cudaGetLastError();
   }
 
-  generateVoxels_random_kernel<<<blocks, threads, 0, stream>>>(
-    points, points_size, min_x_range, max_x_range, min_y_range, max_y_range, min_z_range,
-    max_z_range, pillar_x_size, pillar_y_size, pillar_z_size, grid_y_size, grid_x_size, mask,
-    voxels);
+  if (num_features == POINT_DIM_XYZT) {
+    generateVoxels_random_kernel<<<blocks, threads, 0, stream>>>(
+      points, points_size, min_x_range, max_x_range, min_y_range, max_y_range, min_z_range,
+      max_z_range, pillar_x_size, pillar_y_size, pillar_z_size, grid_y_size, grid_x_size, mask,
+      voxels);
+  } else if (num_features == POINT_DIM_XYZIT) {
+    generateIntensityVoxels_random_kernel<<<blocks, threads, 0, stream>>>(
+      points, points_size, min_x_range, max_x_range, min_y_range, max_y_range, min_z_range,
+      max_z_range, pillar_x_size, pillar_y_size, pillar_z_size, grid_y_size, grid_x_size, mask,
+      voxels);
+  } else {
+    throw throw std::runtime_error("Value of num_features is not supported!");
+  }
   cudaError_t err = cudaGetLastError();
   return err;
 }
 
+template <std::size_t POINT_NUM_FEATURES>
 __global__ void generateBaseFeatures_kernel(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
   unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs)
@@ -211,7 +313,15 @@ __global__ void generateBaseFeatures_kernel(
   for (int i = 0; i < count; i++) {
     int inIndex = voxel_index * MAX_POINT_IN_VOXEL_SIZE + i;
     int outIndex = current_pillarId * MAX_POINT_IN_VOXEL_SIZE + i;
-    ((float4 *)voxel_features)[outIndex] = ((float4 *)voxels)[inIndex];
+    if (POINT_NUM_FEATURES == POINT_DIM_XYZT) {
+      ((float4 *)voxel_features)[outIndex] = ((float4 *)voxels)[inIndex];
+    } else if (POINT_NUM_FEATURES == POINT_DIM_XYZIT) {
+      voxel_features[outIndex * 5] = voxels[inIndex * 5];
+      voxel_features[outIndex * 5 + 1] = voxels[inIndex * 5 + 1];
+      voxel_features[outIndex * 5 + 2] = voxels[inIndex * 5 + 2];
+      voxel_features[outIndex * 5 + 3] = voxels[inIndex * 5 + 3];
+      voxel_features[outIndex * 5 + 4] = voxels[inIndex * 5 + 4];
+    }
   }
 
   // clear buffer for next infer
@@ -221,21 +331,30 @@ __global__ void generateBaseFeatures_kernel(
 // create 4 channels
 cudaError_t generateBaseFeatures_launch(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
-  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs,
+  unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs, const int num_features,
   cudaStream_t stream)
 {
   // exchange x and y to process in a row-major order
   dim3 threads = {32, 32};
   dim3 blocks = {
     (grid_y_size + threads.x - 1) / threads.x, (grid_x_size + threads.y - 1) / threads.y};
-
-  generateBaseFeatures_kernel<<<blocks, threads, 0, stream>>>(
-    mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,
-    voxel_idxs);
+  
+  if (num_features == POINT_DIM_XYZT) {
+    generateBaseFeatures_kernel<POINT_DIM_XYZT><<<blocks, threads, 0, stream>>>(
+      mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,
+      voxel_idxs);
+  } else if (num_features  == POINT_DIM_XYZIT) {
+    generateBaseFeatures_kernel<POINT_DIM_XYZIT><<<blocks, threads, 0, stream>>>(
+      mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,
+      voxel_idxs);
+  } else {
+    throw throw std::runtime_error("Value of num_features is not supported!");
+  }
   cudaError_t err = cudaGetLastError();
   return err;
 }
 
+template <std::size_t ENCODER_IN_FEATURE_SIZE>
 __global__ void generateFeatures_kernel(
   const float * voxel_features, const float * voxel_num_points, const int * coords,
   const unsigned int * num_voxels, const float voxel_x, const float voxel_y, const float voxel_z,
@@ -312,6 +431,10 @@ __global__ void generateFeatures_kernel(
     pillarOutSM[pillar_idx_inBlock][point_idx][7] = center.x;
     pillarOutSM[pillar_idx_inBlock][point_idx][8] = center.y;
 
+    if (ENCODER_IN_FEATURE_SIZE == 10) {
+      pillarOutSM[pillar_idx_inBlock][point_idx][9] = center.z;
+    }
+
   } else {
     pillarOutSM[pillar_idx_inBlock][point_idx][0] = 0;
     pillarOutSM[pillar_idx_inBlock][point_idx][1] = 0;
@@ -324,6 +447,10 @@ __global__ void generateFeatures_kernel(
 
     pillarOutSM[pillar_idx_inBlock][point_idx][7] = 0;
     pillarOutSM[pillar_idx_inBlock][point_idx][8] = 0;
+
+    if (ENCODER_IN_FEATURE_SIZE == 10) {
+      pillarOutSM[pillar_idx_inBlock][point_idx][9] = 0;
+    }
   }
 
   __syncthreads();
@@ -337,19 +464,141 @@ __global__ void generateFeatures_kernel(
   }
 }
 
+__global__ void generateIntensityFeatures_kernel(
+  const float * voxel_features, const float * voxel_num_points, const int * coords,
+  const unsigned int * num_voxels, const float voxel_x, const float voxel_y, const float voxel_z,
+  const float range_min_x, const float range_min_y, const float range_min_z, float * features)
+{
+  // voxel_features (float): (max_voxel_size, max_point_in_voxel_size, point_feature_size)
+  // voxel_num_points (int): (max_voxel_size)
+  // coords (int): (max_voxel_size, point_dim_size)
+  int pillar_idx = blockIdx.x * WARPS_PER_BLOCK + threadIdx.x / MAX_POINT_IN_VOXEL_SIZE;
+  int point_idx = threadIdx.x % MAX_POINT_IN_VOXEL_SIZE;
+  int pillar_idx_inBlock = threadIdx.x / MAX_POINT_IN_VOXEL_SIZE;  // max_point_in_voxel_size
+
+  unsigned int num_pillars = num_voxels[0];
+  if (pillar_idx >= num_pillars) return;
+
+  // load src
+  __shared__ float pillarSM[WARPS_PER_BLOCK][MAX_POINT_IN_VOXEL_SIZE][POINT_DIM_XYZIT];
+  __shared__ float3 pillarSumSM[WARPS_PER_BLOCK];
+  __shared__ int3 cordsSM[WARPS_PER_BLOCK];
+  __shared__ int pointsNumSM[WARPS_PER_BLOCK];
+  __shared__ float pillarOutSM[WARPS_PER_BLOCK][MAX_POINT_IN_VOXEL_SIZE][NUM_FEATURES_11];
+
+  if (threadIdx.x < WARPS_PER_BLOCK) {
+    pointsNumSM[threadIdx.x] = voxel_num_points[blockIdx.x * WARPS_PER_BLOCK + threadIdx.x];
+    cordsSM[threadIdx.x] = ((int3 *)coords)[blockIdx.x * WARPS_PER_BLOCK + threadIdx.x];
+    pillarSumSM[threadIdx.x] = {0, 0, 0};
+  }
+
+  pillarSM[pillar_idx_inBlock][point_idx][0] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT];
+  pillarSM[pillar_idx_inBlock][point_idx][1] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 1];
+  pillarSM[pillar_idx_inBlock][point_idx][2] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 2];
+  pillarSM[pillar_idx_inBlock][point_idx][3] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 3];
+  pillarSM[pillar_idx_inBlock][point_idx][4] = voxel_features[pillar_idx * MAX_POINT_IN_VOXEL_SIZE * POINT_DIM_XYZIT + point_idx * POINT_DIM_XYZIT + 4];
+  
+  __syncthreads();
+
+  // calculate sm in a pillar
+  if (point_idx < pointsNumSM[pillar_idx_inBlock]) {
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].x), pillarSM[pillar_idx_inBlock][point_idx].x);
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].y), pillarSM[pillar_idx_inBlock][point_idx].y);
+    atomicAdd(&(pillarSumSM[pillar_idx_inBlock].z), pillarSM[pillar_idx_inBlock][point_idx].z);
+  }
+  __syncthreads();
+
+  // feature-mean
+  float3 mean;
+  float validPoints = pointsNumSM[pillar_idx_inBlock];
+  mean.x = pillarSumSM[pillar_idx_inBlock].x / validPoints;
+  mean.y = pillarSumSM[pillar_idx_inBlock].y / validPoints;
+  mean.z = pillarSumSM[pillar_idx_inBlock].z / validPoints;
+
+  mean.x = pillarSM[pillar_idx_inBlock][point_idx].x - mean.x;
+  mean.y = pillarSM[pillar_idx_inBlock][point_idx].y - mean.y;
+  mean.z = pillarSM[pillar_idx_inBlock][point_idx].z - mean.z;
+
+  // calculate offset
+  float x_offset = voxel_x / 2 + cordsSM[pillar_idx_inBlock].z * voxel_x + range_min_x;
+  float y_offset = voxel_y / 2 + cordsSM[pillar_idx_inBlock].y * voxel_y + range_min_y;
+  float z_offset = voxel_z / 2 + cordsSM[pillar_idx_inBlock].x * voxel_z + range_min_z;
+
+  // feature-offset
+  float3 center;
+  center.x = pillarSM[pillar_idx_inBlock][point_idx].x - x_offset;
+  center.y = pillarSM[pillar_idx_inBlock][point_idx].y - y_offset;
+  center.z = pillarSM[pillar_idx_inBlock][point_idx].z - z_offset;
+
+  // store output
+  if (point_idx < pointsNumSM[pillar_idx_inBlock]) {
+    pillarOutSM[pillar_idx_inBlock][point_idx][0] = pillarSM[pillar_idx_inBlock][point_idx][0];
+    pillarOutSM[pillar_idx_inBlock][point_idx][1] = pillarSM[pillar_idx_inBlock][point_idx][1];
+    pillarOutSM[pillar_idx_inBlock][point_idx][2] = pillarSM[pillar_idx_inBlock][point_idx][2];
+    pillarOutSM[pillar_idx_inBlock][point_idx][3] = pillarSM[pillar_idx_inBlock][point_idx][3];
+    pillarOutSM[pillar_idx_inBlock][point_idx][4] = pillarSM[pillar_idx_inBlock][point_idx][4];
+
+    pillarOutSM[pillar_idx_inBlock][point_idx][5] = mean.x;
+    pillarOutSM[pillar_idx_inBlock][point_idx][6] = mean.y;
+    pillarOutSM[pillar_idx_inBlock][point_idx][7] = mean.z;
+
+    pillarOutSM[pillar_idx_inBlock][point_idx][8] = center.x;
+    pillarOutSM[pillar_idx_inBlock][point_idx][9] = center.y;
+    pillarOutSM[pillar_idx_inBlock][point_idx][10] = center.z;
+  } else {
+    pillarOutSM[pillar_idx_inBlock][point_idx][0] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][1] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][2] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][3] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][4] = 0;
+    
+    pillarOutSM[pillar_idx_inBlock][point_idx][5] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][6] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][7] = 0;
+
+    pillarOutSM[pillar_idx_inBlock][point_idx][8] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][9] = 0;
+    pillarOutSM[pillar_idx_inBlock][point_idx][10] = 0;
+  }
+
+  __syncthreads();
+
+  for (int i = 0; i < NUM_FEATURES_11; i++) {
+    int outputSMId = pillar_idx_inBlock * MAX_POINT_IN_VOXEL_SIZE * NUM_FEATURES_11 +
+                     i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
+    int outputId = pillar_idx * MAX_POINT_IN_VOXEL_SIZE * NUM_FEATURES_11 +
+                   i * MAX_POINT_IN_VOXEL_SIZE + point_idx;
+    features[outputId] = ((float *)pillarOutSM)[outputSMId];
+  }
+}
+
 // cspell: ignore divup
 cudaError_t generateFeatures_launch(
   const float * voxel_features, const float * voxel_num_points, const int * coords,
   const unsigned int * num_voxels, const std::size_t max_voxel_size, const float voxel_size_x,
   const float voxel_size_y, const float voxel_size_z, const float range_min_x,
-  const float range_min_y, const float range_min_z, float * features, cudaStream_t stream)
+  const float range_min_y, const float range_min_z, float * features, 
+  const std::size_t encoder_in_feature_size, cudaStream_t stream)
 {
   dim3 blocks(divup(max_voxel_size, WARPS_PER_BLOCK));
   dim3 threads(WARPS_PER_BLOCK * MAX_POINT_IN_VOXEL_SIZE);
-  generateFeatures_kernel<<<blocks, threads, 0, stream>>>(
-    voxel_features, voxel_num_points, coords, num_voxels, voxel_size_x, voxel_size_y, voxel_size_z,
-    range_min_x, range_min_y, range_min_z, features);
 
+  // No intensity and no distance of point cloud to voxel_z 
+  if (encoder_in_feature_size == 9) {
+    generateFeatures_kernel<9><<<blocks, threads, 0, stream>>>(
+      voxel_features, voxel_num_points, coords, num_voxels, voxel_size_x, voxel_size_y, voxel_size_z,
+      range_min_x, range_min_y, range_min_z, features);
+  // No intensity, but include distance of point cloud to voxel_z 
+  } else if (encoder_in_feature_size == 10) {
+    generateFeatures_kernel<10><<<blocks, threads, 0, stream>>>(
+      voxel_features, voxel_num_points, coords, num_voxels, voxel_size_x, voxel_size_y, voxel_size_z,
+      range_min_x, range_min_y, range_min_z, features);
+  // Intensity, and include distance of point cloud to voxel_z 
+  } else if (encoder_in_feature_size == NUM_FEATURES_11) {
+    generateIntensityFeatures_kernel<<<blocks, threads, 0, stream>>>(
+      voxel_features, voxel_num_points, coords, num_voxels, voxel_size_x, voxel_size_y, voxel_size_z,
+      range_min_x, range_min_y, range_min_z, features);
+  }
   return cudaGetLastError();
 }
 

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -39,7 +39,6 @@ namespace
 {
 const std::size_t MAX_POINT_IN_VOXEL_SIZE = 32;  // the same as max_point_in_voxel_size_ in config
 const std::size_t WARPS_PER_BLOCK = 4;
-const std::size_t ENCODER_IN_FEATURE_SIZE = 9;  // the same as encoder_in_feature_size_ in config
 const std::size_t POINT_DIM_XYZT = 4;
 const std::size_t POINT_DIM_XYZIT = 5;
 const std::size_t NUM_FEATURES_11 = 11;

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -213,8 +213,8 @@ __global__ void generateIntensityVoxels_random_kernel(
 
   unsigned int point_id = atomicAdd(&(mask[voxel_index]), 1);
 
-  if (point_id >= points_per_voxel) return;
-  float * address = voxels + (voxel_index * points_per_voxel + point_id) * POINT_DIM_XYZIT;
+  if (point_id >= MAX_POINT_IN_VOXEL_SIZE) return;
+  float * address = voxels + (voxel_index * MAX_POINT_IN_VOXEL_SIZE + point_id) * POINT_DIM_XYZIT;
   atomicExch(address + 0, x);
   atomicExch(address + 1, y);
   atomicExch(address + 2, z);

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/voxel_generator.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/voxel_generator.cpp
@@ -73,7 +73,7 @@ std::size_t VoxelGenerator::generateSweepPoints(float * points_d, cudaStream_t s
     static_assert(std::is_same<decltype(affine_past2current.matrix()), Eigen::Matrix4f &>::value);
     static_assert(!Eigen::Matrix4f::IsRowMajor, "matrices should be col-major.");
     generateSweepPoints_launch(
-      pc_cache_iter->points_d.get(), sweep_num_points, point_step / sizeof(float), time_lag,
+      pc_cache_iter->points_d.get(), sweep_num_points, point_step, time_lag,
       affine_past2current.matrix().data(), config_.point_feature_size_,
       points_d + config_.point_feature_size_ * point_counter, stream);
 


### PR DESCRIPTION
Add intensity support to CenterPoint.

Note that the CenterPoint will choose corresponding input based on `point_feature_size` and `encoder_in_feature_size` in `centerpoint_ml_package.param.yaml`.

To run intensity, we need to set them as:
```
point_feature_size: 5
encoder_in_feature_size: 11
```

It still support previous config without intensity


Demo: 

Before intensity:
https://drive.google.com/file/d/1P4IwESC2VWblrmFL3gl_SM5kkZzu06Jz/view?usp=sharing

After intensity:
https://drive.google.com/file/d/1ZNhAGd4zrBL2iYZueqdeA6UEA-hGpVzO/view?usp=sharing