### PR TITLE
feat(control_mode_rviz_plugin): add rviz plugin for visualizing control mode

### DIFF
--- a/visualization/tier4_control_mode_rviz_plugin/CMakeLists.txt
+++ b/visualization/tier4_control_mode_rviz_plugin/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.5)
+project(tier4_control_mode_rviz_plugin)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(autoware_vehicle_msgs REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(pluginlib REQUIRED)
+
+include_directories(
+  include
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${rviz_common_INCLUDE_DIRS}
+)
+
+set(CMAKE_AUTOMOC ON)
+
+add_library(${PROJECT_NAME} SHARED
+  src/control_mode_display.cpp
+  include/control_mode_display.hpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  rviz_common::rviz_common
+  Qt5::Widgets
+  ${pluginlib_LIBRARIES}
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${rviz_common_INCLUDE_DIRS}
+)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  rviz_common
+  autoware_vehicle_msgs
+  pluginlib
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY plugins
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_export_dependencies(
+  rclcpp
+  rviz_common
+  autoware_vehicle_msgs
+  Qt5
+  pluginlib
+)
+
+ament_export_include_directories(include)
+
+ament_export_libraries(${PROJECT_NAME})
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
+
+ament_package()

--- a/visualization/tier4_control_mode_rviz_plugin/README.md
+++ b/visualization/tier4_control_mode_rviz_plugin/README.md
@@ -1,0 +1,41 @@
+# tier4_control_mode_rviz_plugin
+
+## Purpose
+
+This plugin displays the current control mode status of Autoware.
+The background color changes according to the mode, enabling intuitive status recognition.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                           | Type                                            | Description                                 |
+| ------------------------------ | ----------------------------------------------- | ------------------------------------------- |
+| `/vehicle/status/control_mode` | `autoware_vehicle_msgs::msg::ControlModeReport` | Topic representing the current control mode |
+
+## Control Mode Types
+
+| Mode                     | Value | Color     | Description                      |
+| ------------------------ | ----- | --------- | -------------------------------- |
+| NO_COMMAND               | 0     | Dark Gray | No command state                 |
+| AUTONOMOUS               | 1     | Green     | Autonomous driving mode          |
+| AUTONOMOUS_STEER_ONLY    | 2     | Dark Gray | Autonomous steering control only |
+| AUTONOMOUS_VELOCITY_ONLY | 3     | Dark Gray | Autonomous velocity control only |
+| MANUAL                   | 4     | Red       | Manual driving mode              |
+| DISENGAGED               | 5     | Orange    | Control disengaged state         |
+| NOT_READY                | 6     | Dark Gray | System not ready                 |
+
+## How to Use
+
+1. Launch RViz
+2. Select `Panels` → `Add New Panel` from the menu
+3. Choose `rviz_plugins/ControlModeDisplay`
+4. The panel will display the current control mode
+
+## RViz Configuration Example
+
+```yaml
+Panels:
+  - Class: rviz_plugins/ControlModeDisplay
+    Name: ControlModeDisplay
+```

--- a/visualization/tier4_control_mode_rviz_plugin/include/control_mode_display.hpp
+++ b/visualization/tier4_control_mode_rviz_plugin/include/control_mode_display.hpp
@@ -1,0 +1,58 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTROL_MODE_DISPLAY_HPP_
+#define CONTROL_MODE_DISPLAY_HPP_
+
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <rclcpp/rclcpp.hpp>
+#include <rviz_common/panel.hpp>
+
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+
+#include <memory>
+#include <string>
+
+namespace rviz_plugins
+{
+
+class ControlModeDisplay : public rviz_common::Panel
+{
+  Q_OBJECT
+
+public:
+  explicit ControlModeDisplay(QWidget * parent = nullptr);
+  ~ControlModeDisplay() override;
+
+protected:
+  void onInitialize() override;
+  void load(const rviz_common::Config & config) override;
+  void save(rviz_common::Config config) const override;
+
+private:
+  void processMessage(const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  std::string getModeString(uint8_t mode) const;
+  void subscribe();
+  void unsubscribe();
+
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr subscription_;
+  autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr last_msg_;
+  QLabel * mode_label_;
+};
+
+}  // namespace rviz_plugins
+
+#endif  // CONTROL_MODE_DISPLAY_HPP_

--- a/visualization/tier4_control_mode_rviz_plugin/package.xml
+++ b/visualization/tier4_control_mode_rviz_plugin/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tier4_control_mode_rviz_plugin</name>
+  <version>0.1.0</version>
+  <description>RViz plugin for displaying control mode</description>
+  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
+  <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
+  <maintainer email="shohei.sakai@tier4.jp">Shohei Sakai</maintainer>
+  <maintainer email="naoto.hiramatsu@tier4.jp">Naoto Hiramatsu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>qtbase5-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>rviz_common</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <rviz plugin="${prefix}/plugins/plugin_description.xml"/>
+  </export>
+</package>

--- a/visualization/tier4_control_mode_rviz_plugin/plugins/plugin_description.xml
+++ b/visualization/tier4_control_mode_rviz_plugin/plugins/plugin_description.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<library path="tier4_control_mode_rviz_plugin">
+  <class name="rviz_plugins/ControlModeDisplay"
+         type="rviz_plugins::ControlModeDisplay"
+         base_class_type="rviz_common::Panel">
+    <description>
+      A panel for displaying the control mode of the vehicle.
+    </description>
+  </class>
+</library>

--- a/visualization/tier4_control_mode_rviz_plugin/src/control_mode_display.cpp
+++ b/visualization/tier4_control_mode_rviz_plugin/src/control_mode_display.cpp
@@ -1,0 +1,154 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "control_mode_display.hpp"
+
+#include <pluginlib/class_list_macros.hpp>
+#include <rviz_common/display_context.hpp>
+
+#include <string>
+
+namespace rviz_plugins
+{
+
+ControlModeDisplay::ControlModeDisplay(QWidget * parent)
+: rviz_common::Panel(parent), subscription_(nullptr), last_msg_(nullptr)
+{
+  auto * layout = new QVBoxLayout(this);
+
+  mode_label_ = new QLabel(this);
+  mode_label_->setAlignment(Qt::AlignCenter);
+  mode_label_->setStyleSheet(
+    "QLabel {"
+    "  padding: 10px;"
+    "  border-radius: 5px;"
+    "  background-color: #333333;"
+    "  color: white;"
+    "  font-size: 14px;"
+    "  font-weight: bold;"
+    "}");
+
+  layout->addWidget(mode_label_);
+  setLayout(layout);
+}
+
+ControlModeDisplay::~ControlModeDisplay()
+{
+  unsubscribe();
+}
+
+void ControlModeDisplay::onInitialize()
+{
+  subscribe();
+}
+
+void ControlModeDisplay::load(const rviz_common::Config & config)
+{
+  Panel::load(config);
+}
+
+void ControlModeDisplay::save(rviz_common::Config config) const
+{
+  Panel::save(config);
+}
+
+void ControlModeDisplay::processMessage(
+  const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
+{
+  last_msg_ = msg;
+  std::string mode_str = getModeString(msg->mode);
+  mode_label_->setText(QString::fromStdString(mode_str));
+
+  QString bg_color;
+  switch (msg->mode) {
+    case 1:                  // AUTONOMOUS
+      bg_color = "#4CAF50";  // Green
+      break;
+    case 4:                  // MANUAL
+      bg_color = "#F44336";  // Red
+      break;
+    case 5:                  // DISENGAGED
+      bg_color = "#FF9800";  // Orange
+      break;
+    default:
+      bg_color = "#333333";  // Dark gray
+      break;
+  }
+
+  mode_label_->setStyleSheet(QString("QLabel {"
+                                     "  padding: 10px;"
+                                     "  border-radius: 5px;"
+                                     "  background-color: %1;"
+                                     "  color: white;"
+                                     "  font-size: 14px;"
+                                     "  font-weight: bold;"
+                                     "}")
+                               .arg(bg_color));
+}
+
+std::string ControlModeDisplay::getModeString(uint8_t mode) const
+{
+  switch (mode) {
+    case 0:
+      return "NO_COMMAND";
+    case 1:
+      return "AUTONOMOUS";
+    case 2:
+      return "AUTONOMOUS_STEER_ONLY";
+    case 3:
+      return "AUTONOMOUS_VELOCITY_ONLY";
+    case 4:
+      return "MANUAL";
+    case 5:
+      return "DISENGAGED";
+    case 6:
+      return "NOT_READY";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void ControlModeDisplay::subscribe()
+{
+  if (!isEnabled()) {
+    return;
+  }
+
+  try {
+    auto node = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+    subscription_ = node->create_subscription<autoware_vehicle_msgs::msg::ControlModeReport>(
+      "/vehicle/status/control_mode", 10,
+      std::bind(&ControlModeDisplay::processMessage, this, std::placeholders::_1));
+  } catch (const std::exception & e) {
+    mode_label_->setText("Error: Topic subscription failed");
+    mode_label_->setStyleSheet(
+      "QLabel {"
+      "  padding: 10px;"
+      "  border-radius: 5px;"
+      "  background-color: #F44336;"
+      "  color: white;"
+      "  font-size: 14px;"
+      "  font-weight: bold;"
+      "}");
+  }
+}
+
+void ControlModeDisplay::unsubscribe()
+{
+  subscription_.reset();
+}
+
+}  // namespace rviz_plugins
+
+PLUGINLIB_EXPORT_CLASS(rviz_plugins::ControlModeDisplay, rviz_common::Panel)


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware_universe/pull/10706

* add rviz plugin for visualizing control mode



* fix(tier4_control_mode_rviz_plugin): update background colors for manual and disengaged modes



---------