### PR TITLE
fix: remove lidar_detection_model_type choice to accept product-specific model name

### DIFF
--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -80,15 +80,7 @@
     <choice value="apollo"/>
     <choice value="clustering"/>
   </arg>
-  <arg name="lidar_detection_model_name" default="$(var lidar_detection_model_name)">
-    <choice value="bevfusion_lidar"/>
-    <choice value="centerpoint"/>
-    <choice value="centerpoint_tiny"/>
-    <choice value="centerpoint_sigma"/>
-    <choice value="pointpainting"/>
-    <choice value="transfusion"/>
-    <choice value=""/>
-  </arg>
+  <arg name="lidar_detection_model_name" default="$(var lidar_detection_model_name)"/>
   <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
   <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topic name"/>


### PR DESCRIPTION
lidar_detection_model_nameの選択肢を強制するLauncherになっているため、centerpoint_x2モデルでLaunchできないと思います。
AWF番やpilot-autoとの差分なのでX2専用で修正します。