### PR TITLE
feat(tier4_state_rviz_plugin): display unknown value (#10861)

### DIFF
--- a/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -558,6 +558,7 @@ void AutowareStatePanel::onRoute(const RouteState::ConstSharedPtr msg)
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      route_state = QString("Routing | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -610,6 +611,7 @@ void AutowareStatePanel::onLocalization(const LocalizationInitializationState::C
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      localization_state = QString("Localization | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -656,6 +658,7 @@ void AutowareStatePanel::onMotion(const MotionState::ConstSharedPtr msg)
     default:
       state = Danger;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      motion_state = QString("Motion | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -714,7 +717,7 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
-      mrm_state = "MRM State | Unknown";
+      mrm_state = QString("MRM State | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -758,7 +761,7 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
       default:
         behavior_state = Crash;
         behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
-        mrm_behavior = "MRM Behavior | Unknown";
+        mrm_behavior = QString("MRM Behavior | Unknown(%1)").arg(msg->behavior);
         break;
     }
 

--- a/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
+++ b/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
@@ -49,6 +49,7 @@
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_adapi_v1_msgs/srv/clear_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/initialize_localization.hpp>
+#include <autoware_adapi_v1_msgs/srv/list_mrm_description.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -61,6 +62,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace rviz_plugins
 {
@@ -76,6 +78,7 @@ class AutowareStatePanel : public rviz_common::Panel
   using MotionState = autoware_adapi_v1_msgs::msg::MotionState;
   using AcceptStart = autoware_adapi_v1_msgs::srv::AcceptStart;
   using MRMState = autoware_adapi_v1_msgs::msg::MrmState;
+  using ListMrmDescription = autoware_adapi_v1_msgs::srv::ListMrmDescription;
   using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
   using DiagnosticStatus = diagnostic_msgs::msg::DiagnosticStatus;
 
@@ -186,8 +189,11 @@ protected:
   QLabel * mrm_state_label_ptr_{nullptr};
   CustomIconLabel * mrm_behavior_icon{nullptr};
   QLabel * mrm_behavior_label_ptr_{nullptr};
+  std::unordered_map<uint16_t, std::pair<std::string, std::string>> mrm_behaviors_;
 
   rclcpp::Subscription<MRMState>::SharedPtr sub_mrm_;
+  rclcpp::Client<ListMrmDescription>::SharedPtr client_list_mrm_;
+  rclcpp::TimerBase::SharedPtr timer_list_mrm_;
 
   void onMRMState(const MRMState::ConstSharedPtr msg);
 


### PR DESCRIPTION
See 
https://github.com/autowarefoundation/autoware_universe/pull/10861
https://github.com/autowarefoundation/autoware_universe/pull/10895

When using the command_mode_decider node, the MrmState values can be arbitrarily defined per product—not just those predefined in the existing message. Make changes so that RViz will correctly visualize any arbitrary MrmState value.