### PR TITLE
fix(control_command_gate): fix for pause interface  (#10877)

### DIFF
--- a/control/autoware_control_command_gate/CMakeLists.txt
+++ b/control/autoware_control_command_gate/CMakeLists.txt
@@ -13,6 +13,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/command/subscription.cpp"
   "src/command/publisher.cpp"
   "src/command/filter.cpp"
+  "src/command/compatibility.cpp"
+  "src/command/compatibility/adapi_pause_interface.cpp"
   "src/common/control_command_filter.cpp"
   "src/common/vehicle_status.cpp"
   "src/common/timeout_diagnostics.cpp"

--- a/control/autoware_control_command_gate/config/default.param.yaml
+++ b/control/autoware_control_command_gate/config/default.param.yaml
@@ -9,6 +9,7 @@
       21: emergency_stop
     rate: 10.0
     builtin_emergency_acceleration: -2.4
+    stop_hold_acceleration: -1.5
     diag_timeout_warn_duration: 1.0
     diag_timeout_error_duration: 2.0
     stop_check_duration: 1.0

--- a/control/autoware_control_command_gate/package.xml
+++ b/control/autoware_control_command_gate/package.xml
@@ -11,6 +11,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_command_mode_types</depend>
+  <depend>autoware_component_interface_specs_universe</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_vehicle_cmd_gate</depend>

--- a/control/autoware_control_command_gate/src/command/compatibility.cpp
+++ b/control/autoware_control_command_gate/src/command/compatibility.cpp
@@ -1,0 +1,50 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compatibility.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+namespace autoware::control_command_gate
+{
+
+Compatibility::Compatibility(std::unique_ptr<CommandOutput> && output, rclcpp::Node & node)
+: CommandBridge(std::move(output)), node_(node)
+{
+  stop_hold_acceleration_ = node.declare_parameter<float>("stop_hold_acceleration");
+  adapi_pause_ = std::make_unique<AdapiPauseInterface>(&node_);
+}
+
+void Compatibility::publish()
+{
+  adapi_pause_->publish();
+}
+
+void Compatibility::on_control(const Control & msg)
+{
+  Control out = msg;
+  adapi_pause_->update(out);
+
+  if (adapi_pause_->is_paused()) {
+    out.longitudinal.velocity = std::min(0.0f, out.longitudinal.velocity);
+    out.longitudinal.acceleration =
+      std::min(stop_hold_acceleration_, out.longitudinal.acceleration);
+  }
+
+  CommandBridge::on_control(out);
+}
+
+}  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/command/compatibility.hpp
+++ b/control/autoware_control_command_gate/src/command/compatibility.hpp
@@ -12,35 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMMAND__BUILTIN_HPP_
-#define COMMAND__BUILTIN_HPP_
+#ifndef COMMAND__COMPATIBILITY_HPP_
+#define COMMAND__COMPATIBILITY_HPP_
 
-#include "source.hpp"
+#include "compatibility/adapi_pause_interface.hpp"
+#include "interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
-#include <string>
 
 namespace autoware::control_command_gate
 {
 
-class BuiltinEmergency : public CommandSource
+// Provide vehicle_cmd_gate compatible interface.
+class Compatibility : public CommandBridge
 {
 public:
-  BuiltinEmergency(uint16_t id, const std::string & name, rclcpp::Node & node);
-  void resend_last_command() override;
+  Compatibility(std::unique_ptr<CommandOutput> && output, rclcpp::Node & node);
+  void publish();
   void set_prev_control(std::shared_ptr<Control> control) { prev_control_ = control; }
+  void on_control(const Control & msg) override;
 
 private:
-  void on_timer();
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Clock::SharedPtr clock_;
-
-  double acceleration_;
+  rclcpp::Node & node_;
   std::shared_ptr<Control> prev_control_;
+  std::unique_ptr<AdapiPauseInterface> adapi_pause_;
+  float stop_hold_acceleration_;
 };
 
 }  // namespace autoware::control_command_gate
 
-#endif  // COMMAND__BUILTIN_HPP_
+#endif  // COMMAND__COMPATIBILITY_HPP_

--- a/control/autoware_control_command_gate/src/command/compatibility/adapi_pause_interface.cpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/adapi_pause_interface.cpp
@@ -1,0 +1,68 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adapi_pause_interface.hpp"
+
+namespace autoware::control_command_gate
+{
+
+AdapiPauseInterface::AdapiPauseInterface(rclcpp::Node * node) : node_(node)
+{
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
+  adaptor.init_srv(srv_set_pause_, this, &AdapiPauseInterface::on_pause);
+  adaptor.init_pub(pub_is_paused_);
+  adaptor.init_pub(pub_is_start_requested_);
+
+  is_paused_ = false;
+  is_start_requested_ = false;
+  publish();
+}
+
+bool AdapiPauseInterface::is_paused() const
+{
+  return is_paused_;
+}
+
+void AdapiPauseInterface::publish()
+{
+  if (prev_is_paused_ != is_paused_) {
+    IsPaused::Message msg;
+    msg.stamp = node_->now();
+    msg.data = is_paused_;
+    pub_is_paused_->publish(msg);
+    prev_is_paused_ = is_paused_;
+  }
+
+  if (prev_is_start_requested_ != is_start_requested_) {
+    IsStartRequested::Message msg;
+    msg.stamp = node_->now();
+    msg.data = is_start_requested_;
+    pub_is_start_requested_->publish(msg);
+    prev_is_start_requested_ = is_start_requested_;
+  }
+}
+
+void AdapiPauseInterface::update(const Control & control)
+{
+  is_start_requested_ = eps < std::abs(control.longitudinal.velocity);
+}
+
+void AdapiPauseInterface::on_pause(
+  const SetPause::Service::Request::SharedPtr req, const SetPause::Service::Response::SharedPtr res)
+{
+  is_paused_ = req->pause;
+  res->status.success = true;
+}
+
+}  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/command/compatibility/adapi_pause_interface.hpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/adapi_pause_interface.hpp
@@ -1,0 +1,61 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMAND__COMPATIBILITY__ADAPI_PAUSE_INTERFACE_HPP_
+#define COMMAND__COMPATIBILITY__ADAPI_PAUSE_INTERFACE_HPP_
+
+#include <autoware/component_interface_specs_universe/control.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_control_msgs/msg/control.hpp>
+
+namespace autoware::control_command_gate
+{
+
+class AdapiPauseInterface
+{
+private:
+  static constexpr double eps = 1e-3;
+  using Control = autoware_control_msgs::msg::Control;
+  using SetPause = autoware::component_interface_specs_universe::control::SetPause;
+  using IsPaused = autoware::component_interface_specs_universe::control::IsPaused;
+  using IsStartRequested = autoware::component_interface_specs_universe::control::IsStartRequested;
+
+public:
+  explicit AdapiPauseInterface(rclcpp::Node * node);
+  bool is_paused() const;
+  void publish();
+  void update(const Control & control);
+
+private:
+  bool is_paused_;
+  bool is_start_requested_;
+  std::optional<bool> prev_is_paused_;
+  std::optional<bool> prev_is_start_requested_;
+
+  rclcpp::Node * node_;
+  autoware::component_interface_utils::Service<SetPause>::SharedPtr srv_set_pause_;
+  autoware::component_interface_utils::Publisher<IsPaused>::SharedPtr pub_is_paused_;
+  autoware::component_interface_utils::Publisher<IsStartRequested>::SharedPtr
+    pub_is_start_requested_;
+
+  void on_pause(
+    const SetPause::Service::Request::SharedPtr req,
+    const SetPause::Service::Response::SharedPtr res);
+};
+
+}  // namespace autoware::control_command_gate
+
+#endif  // COMMAND__COMPATIBILITY__ADAPI_PAUSE_INTERFACE_HPP_

--- a/control/autoware_control_command_gate/src/command/filter.hpp
+++ b/control/autoware_control_command_gate/src/command/filter.hpp
@@ -27,7 +27,7 @@ namespace autoware::control_command_gate
 class CommandFilter : public CommandBridge
 {
 public:
-  explicit CommandFilter(std::unique_ptr<CommandOutput> && output, rclcpp::Node & node);
+  CommandFilter(std::unique_ptr<CommandOutput> && output, rclcpp::Node & node);
   void set_nominal_filter_params(const VehicleCmdFilterParam & p);
   void set_transition_filter_params(const VehicleCmdFilterParam & p);
   void set_transition_flag(bool flag);

--- a/control/autoware_control_command_gate/src/command/source.hpp
+++ b/control/autoware_control_command_gate/src/command/source.hpp
@@ -27,7 +27,7 @@ namespace autoware::control_command_gate
 class CommandSource
 {
 public:
-  explicit CommandSource(uint16_t id, const std::string & name);
+  CommandSource(uint16_t id, const std::string & name);
   virtual ~CommandSource() = default;
   virtual void resend_last_command() = 0;
 

--- a/control/autoware_control_command_gate/src/control_command_gate.hpp
+++ b/control/autoware_control_command_gate/src/control_command_gate.hpp
@@ -15,6 +15,7 @@
 #ifndef CONTROL_COMMAND_GATE_HPP_
 #define CONTROL_COMMAND_GATE_HPP_
 
+#include "command/compatibility.hpp"
 #include "command/filter.hpp"
 #include "command/interface.hpp"
 #include "command/selector.hpp"
@@ -56,6 +57,7 @@ private:
   diagnostic_updater::Updater diag_;
   std::unique_ptr<CommandSelector> selector_;
   CommandFilter * output_filter_;
+  Compatibility * compatibility_;
 
   uint16_t current_source_ = 0;
   bool transition_flag_ = false;


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_universe/pull/10877

Since the Motion state was not implemented in the control command gate, it is implemented.