### PR TITLE
feat(diagnostic_graph_aggregator): add initializing flag (#10893)

### DIFF
--- a/system/autoware_diagnostic_graph_aggregator/package.xml
+++ b/system/autoware_diagnostic_graph_aggregator/package.xml
@@ -15,6 +15,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
   <depend>tier4_system_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/graph.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/graph.cpp
@@ -120,6 +120,11 @@ DiagnosticArray Graph::create_unknown_msg(const rclcpp::Time & stamp) const
   return msg;
 }
 
+void Graph::set_initializing(bool initializing)
+{
+  for (const auto & node : nodes_) node->set_initializing(initializing);
+}
+
 void Graph::reset()
 {
   for (const auto & node : nodes_) node->reset();

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/graph.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/graph.hpp
@@ -41,6 +41,7 @@ public:
   DiagGraphStatus create_status_msg(const rclcpp::Time & stamp) const;
   DiagnosticArray create_unknown_msg(const rclcpp::Time & stamp) const;
 
+  void set_initializing(bool initializing);
   void reset();
   std::vector<NodeUnit *> nodes() const { return nodes_; }
   std::vector<DiagUnit *> diags() const { return diags_; }

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/levels.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/levels.cpp
@@ -32,6 +32,14 @@ LatchLevel::LatchLevel(ConfigYaml yaml)
   warn_stamp_ = std::nullopt;
   error_stamp_ = std::nullopt;
   input_level_ = DiagnosticStatus::STALE;
+
+  initializing_ = false;
+}
+
+void LatchLevel::set_initializing(bool initializing)
+{
+  initializing_ = initializing;
+  if (initializing_) reset();
 }
 
 void LatchLevel::reset()
@@ -47,7 +55,7 @@ void LatchLevel::update(const rclcpp::Time & stamp, DiagnosticLevel level)
 {
   input_level_ = level;
 
-  if (latch_enabled_) {
+  if (latch_enabled_ && !initializing_) {
     update_latch_status(stamp, level);
   }
 }

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/levels.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/levels.hpp
@@ -30,6 +30,7 @@ class LatchLevel
 {
 public:
   explicit LatchLevel(ConfigYaml yaml);
+  void set_initializing(bool initializing);
   void reset();
   void update(const rclcpp::Time & stamp, DiagnosticLevel level);
   DiagnosticLevel level() const;
@@ -47,6 +48,8 @@ private:
   bool error_latched_;
   std::optional<rclcpp::Time> warn_stamp_;
   std::optional<rclcpp::Time> error_stamp_;
+
+  bool initializing_;
 };
 
 class TimeoutLevel

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/nodes.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/nodes.cpp
@@ -63,6 +63,11 @@ bool NodeUnit::dependency() const
   return dependency_ && dependency_->level() != DiagnosticStatus::OK;
 }
 
+void NodeUnit::set_initializing(bool initializing)
+{
+  latch_->set_initializing(initializing);
+}
+
 void NodeUnit::reset()
 {
   latch_->reset();

--- a/system/autoware_diagnostic_graph_aggregator/src/common/graph/nodes.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/common/graph/nodes.hpp
@@ -44,6 +44,7 @@ public:
   std::string path() const;
   std::string type() const;
   bool dependency() const;
+  void set_initializing(bool initializing);
   void reset();
   void update(const rclcpp::Time & stamp);
 

--- a/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
@@ -52,6 +52,10 @@ AggregatorNode::AggregatorNode(const rclcpp::NodeOptions & options) : Node("aggr
     srv_reset_ = create_service<ResetDiagGraph>(
       "~/reset",
       std::bind(&AggregatorNode::on_reset, this, std::placeholders::_1, std::placeholders::_2));
+    srv_set_initializing_ = create_service<SetBool>(
+      "~/set_initializing",
+      std::bind(
+        &AggregatorNode::on_set_initializing, this, std::placeholders::_1, std::placeholders::_2));
 
     const auto rate = rclcpp::Rate(declare_parameter<double>("rate"));
     timer_ = rclcpp::create_timer(this, get_clock(), rate.period(), [this]() { on_timer(); });
@@ -90,6 +94,13 @@ void AggregatorNode::on_reset(
 {
   graph_->reset();
   response->status.success = true;
+}
+
+void AggregatorNode::on_set_initializing(
+  const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response)
+{
+  graph_->set_initializing(request->data);
+  response->success = true;
 }
 
 }  // namespace autoware::diagnostic_graph_aggregator

--- a/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.hpp
@@ -20,6 +20,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <std_srvs/srv/set_bool.hpp>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -37,18 +39,22 @@ private:
   std::unique_ptr<Graph> graph_;
   std::unique_ptr<CommandModeMapping> availability_;
 
+  using SetBool = std_srvs::srv::SetBool;
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Subscription<DiagnosticArray>::SharedPtr sub_input_;
   rclcpp::Publisher<DiagGraphStruct>::SharedPtr pub_struct_;
   rclcpp::Publisher<DiagGraphStatus>::SharedPtr pub_status_;
   rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_unknown_;
   rclcpp::Service<ResetDiagGraph>::SharedPtr srv_reset_;
+  rclcpp::Service<SetBool>::SharedPtr srv_set_initializing_;
 
   void on_timer();
   void on_diag(const DiagnosticArray & msg);
   void on_reset(
     const ResetDiagGraph::Request::SharedPtr request,
     const ResetDiagGraph::Response::SharedPtr response);
+  void on_set_initializing(
+    const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response);
 };
 
 }  // namespace autoware::diagnostic_graph_aggregator

--- a/system/autoware_diagnostic_graph_aggregator/test/src/test_levels.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/test/src/test_levels.cpp
@@ -63,7 +63,7 @@ TEST(GraphLevel, Timeout)
   EXPECT_TRUE(match(test.get("path3"), result_1_5));
 }
 
-TEST(GraphLevel, Latch1)
+TEST(GraphLevel, Latch)
 {
   // clang-format off
   const auto input      = "KKKKKEKKEEEKKEEEEEKKKKK";  // cspell:disable-line
@@ -87,7 +87,29 @@ TEST(GraphLevel, Latch1)
   EXPECT_TRUE(match(test.get("path3"), result_0_4));
 }
 
-TEST(GraphLevel, Latch2)
+TEST(GraphLevel, LatchInitializing)
+{
+  // clang-format off
+  const auto input  = "KKKKKEKKEEEKKEEEEEKKKKK";  // cspell:disable-line
+  const auto result = "KKKKKEKKEEEKKEEEEEKKKKK";  // cspell:disable-line
+  // clang-format on
+
+  autoware::diagnostic_graph_aggregator::TimelineTest test;
+  test.set_interval(0.1);
+  test.set_initializing({{0, true}});
+  test.set("dummy: name0", input);
+  test.set("dummy: name1", input);
+  test.set("dummy: name2", input);
+  test.set("dummy: name3", input);
+  test.execute(resource("levels/latch.yaml"));
+
+  EXPECT_TRUE(match(test.get("path0"), result));
+  EXPECT_TRUE(match(test.get("path1"), result));
+  EXPECT_TRUE(match(test.get("path2"), result));
+  EXPECT_TRUE(match(test.get("path3"), result));
+}
+
+TEST(GraphLevel, LatchReset10ms)
 {
   // clang-format off
   const auto input  = "KKKKKEKKKKKKKKKKKKKK";  // cspell:disable-line
@@ -103,7 +125,7 @@ TEST(GraphLevel, Latch2)
   EXPECT_TRUE(match(test.get("path1"), result));
 }
 
-TEST(GraphLevel, Latch3)
+TEST(GraphLevel, LatchReset15ms)
 {
   // clang-format off
   const auto input  = "KKKKKEKKKKKKKKKKKKKK";  // cspell:disable-line
@@ -119,7 +141,7 @@ TEST(GraphLevel, Latch3)
   EXPECT_TRUE(match(test.get("path1"), result));
 }
 
-TEST(GraphLevel, Latch4)
+TEST(GraphLevel, LatchResetOnError)
 {
   // clang-format off
   const auto input  = "KKKKKEEEEEEEEEEEEEEE";  // cspell:disable-line
@@ -135,7 +157,7 @@ TEST(GraphLevel, Latch4)
   EXPECT_TRUE(match(test.get("path1"), result));
 }
 
-TEST(GraphLevel, Latch5)
+TEST(GraphLevel, LatchResetOnWarn)
 {
   // clang-format off
   const auto input  = "KKKKKEWWWWWWWWWKKKKK";  // cspell:disable-line
@@ -151,7 +173,7 @@ TEST(GraphLevel, Latch5)
   EXPECT_TRUE(match(test.get("path1"), result));
 }
 
-TEST(GraphLevel, Hysteresis1)
+TEST(GraphLevel, HysteresisOkeyToError)
 {
   // clang-format off
   const auto input      = "KKKKKKKKKKKKKKKEEEEEEEEEE";  // cspell:disable-line
@@ -174,7 +196,7 @@ TEST(GraphLevel, Hysteresis1)
   EXPECT_TRUE(match(test.get("path3"), result_0_4));
 }
 
-TEST(GraphLevel, Hysteresis2)
+TEST(GraphLevel, HysteresisErrorToOkey)
 {
   // clang-format off
   const auto input      = "EEEEEEEEEEEEEEEKKKKKKKKKK";  // cspell:disable-line
@@ -197,7 +219,7 @@ TEST(GraphLevel, Hysteresis2)
   EXPECT_TRUE(match(test.get("path3"), result_0_4));
 }
 
-TEST(GraphLevel, Hysteresis3)
+TEST(GraphLevel, HysteresisPulseError)
 {
   // clang-format off
   const auto input      = "KKKKKKKKKKKKKKKEKKKKKEEEKKKKKEEEEEKKKKK";  // cspell:disable-line
@@ -220,7 +242,7 @@ TEST(GraphLevel, Hysteresis3)
   EXPECT_TRUE(match(test.get("path3"), result_0_4));
 }
 
-TEST(GraphLevel, Hysteresis4)
+TEST(GraphLevel, HysteresisPulseWarnError)
 {
   // clang-format off
   const auto input      = "KKKKKKKKKKKKKKKEWEWEEEWEEEWEEEEEWEEEEEWEEEEE";  // cspell:disable-line

--- a/system/autoware_diagnostic_graph_aggregator/test/src/tests/timeline.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/test/src/tests/timeline.cpp
@@ -92,13 +92,16 @@ void TimelineTest::execute(const std::string & path)
   const auto structure = graph.create_struct_msg(stamp);
   std::vector<std::string> result_sequence(structure.nodes.size());
   for (size_t step = 0; step < diagnostic_array_sequence.size(); ++step) {
-    DiagnosticArray array;
-    array.header.stamp = stamp;
-    array.status = diagnostic_array_sequence[step];
-
     if (reset_steps_.count(step)) {
       graph.reset();
     }
+    if (initializing_steps_.count(step)) {
+      graph.set_initializing(initializing_steps_.at(step));
+    }
+
+    DiagnosticArray array;
+    array.header.stamp = stamp;
+    array.status = diagnostic_array_sequence[step];
     graph.update(stamp, array);
     graph.update(stamp);
 
@@ -121,6 +124,11 @@ void TimelineTest::set_interval(double interval)
 void TimelineTest::set_reset(const std::unordered_set<size_t> & steps)
 {
   reset_steps_ = steps;
+}
+
+void TimelineTest::set_initializing(const std::unordered_map<size_t, bool> & steps)
+{
+  initializing_steps_ = steps;
 }
 
 void TimelineTest::set(const std::string & name, const std::string & levels)

--- a/system/autoware_diagnostic_graph_aggregator/test/src/tests/timeline.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/test/src/tests/timeline.hpp
@@ -28,6 +28,7 @@ public:
   TimelineTest();
   void execute(const std::string & path);
   void set_interval(double interval);
+  void set_initializing(const std::unordered_map<size_t, bool> & steps);
   void set_reset(const std::unordered_set<size_t> & steps);
   void set(const std::string & name, const std::string & levels);
   std::string get(const std::string & path);
@@ -37,6 +38,7 @@ private:
   std::unordered_map<std::string, std::string> input_;
   std::unordered_map<std::string, std::string> output_;
   std::unordered_set<size_t> reset_steps_;
+  std::unordered_map<size_t, bool> initializing_steps_;
 };
 
 }  // namespace autoware::diagnostic_graph_aggregator


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_universe/pull/10893

The aggregator node now includes a latching feature. This feature causes the aggregator to continue treating a diagnostic as an error—even if the diagnostic returns to OK—so long as the Error state persisted for a specified duration. Because many diagnostics are in Error when Autoware first starts up, the behavior  is modified so that the latching feature can be enabled only once Autoware is already running.