### PR TITLE
feat(autoware_command_mode_switcher_plugins): publish hazard lights c…

### DIFF
--- a/system/autoware_command_mode_switcher/config/default.param.yaml
+++ b/system/autoware_command_mode_switcher/config/default.param.yaml
@@ -14,6 +14,7 @@
       # <plugin name>:  e.g. autoware::command_mode_switcher::StopSwitcher:
       #   <parameter name>: <value>
       autoware::command_mode_switcher::ComfortableStopSwitcher:
+        hazard_lights_hz: 20
         min_acceleration: -1.0
         max_jerk: 0.6
         min_jerk: -0.6

--- a/system/autoware_command_mode_switcher_plugins/package.xml
+++ b/system/autoware_command_mode_switcher_plugins/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_command_mode_switcher</depend>
   <depend>autoware_command_mode_types</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
@@ -21,6 +21,7 @@
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
@@ -53,14 +54,19 @@ public:
 private:
   void publish_velocity_limit();
   void publish_velocity_limit_clear_command();
+  void publish_hazard_lights_command();
   bool is_stopped();
 
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
+    pub_hazard_lights_command_;
+  rclcpp::TimerBase::SharedPtr pub_hazard_lights_timer_;
   std::unique_ptr<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>> sub_odom_;
 
   MrmState mrm_state_;
+  bool enable_hazard_lights_;
   struct Params params_;
 };
 


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_universe/pull/10952

I’ve changed it so that the hazard lights come on during a comfortable stop. The hazard-light selector node subscribes to both the Autonomous command and the MRM command and chooses between them based on the current MRM state.