### PR TITLE
feat(control_command_gate): support vehicle_cmd_gate interface (#10917)

### DIFF
--- a/control/autoware_control_command_gate/CMakeLists.txt
+++ b/control/autoware_control_command_gate/CMakeLists.txt
@@ -15,6 +15,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/command/filter.cpp"
   "src/command/compatibility.cpp"
   "src/command/compatibility/adapi_pause_interface.cpp"
+  "src/command/compatibility/emergency_interface.cpp"
+  "src/command/compatibility/moderate_stop_interface.cpp"
   "src/common/control_command_filter.cpp"
   "src/common/vehicle_status.cpp"
   "src/common/timeout_diagnostics.cpp"

--- a/control/autoware_control_command_gate/config/default.param.yaml
+++ b/control/autoware_control_command_gate/config/default.param.yaml
@@ -10,6 +10,8 @@
     rate: 10.0
     builtin_emergency_acceleration: -2.4
     stop_hold_acceleration: -1.5
+    emergency_acceleration: -2.4
+    moderate_stop_acceleration: -1.5
     diag_timeout_warn_duration: 1.0
     diag_timeout_error_duration: 2.0
     stop_check_duration: 1.0

--- a/control/autoware_control_command_gate/package.xml
+++ b/control/autoware_control_command_gate/package.xml
@@ -21,6 +21,7 @@
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_external_api_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/control/autoware_control_command_gate/src/command/compatibility.hpp
+++ b/control/autoware_control_command_gate/src/command/compatibility.hpp
@@ -16,6 +16,8 @@
 #define COMMAND__COMPATIBILITY_HPP_
 
 #include "compatibility/adapi_pause_interface.hpp"
+#include "compatibility/emergency_interface.hpp"
+#include "compatibility/moderate_stop_interface.hpp"
 #include "interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -38,7 +40,11 @@ private:
   rclcpp::Node & node_;
   std::shared_ptr<Control> prev_control_;
   std::unique_ptr<AdapiPauseInterface> adapi_pause_;
+  std::unique_ptr<EmergencyInterface> emergency_;
+  std::unique_ptr<ModerateStopInterface> moderate_stop_;
   float stop_hold_acceleration_;
+  float emergency_acceleration_;
+  float moderate_stop_acceleration_;
 };
 
 }  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/command/compatibility/emergency_interface.cpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/emergency_interface.cpp
@@ -1,0 +1,44 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "emergency_interface.hpp"
+
+namespace autoware::control_command_gate
+{
+
+EmergencyInterface::EmergencyInterface(rclcpp::Node * node) : node_(node)
+{
+  pub_external_emergency_ = node_->create_publisher<Emergency>(
+    "/api/autoware/get/emergency", rclcpp::QoS(1).transient_local());
+  srv_external_emergency_ = node_->create_service<SetEmergency>(
+    "/api/autoware/set/emergency",
+    std::bind(&EmergencyInterface::on_service, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+void EmergencyInterface::publish()
+{
+  Emergency msg;
+  msg.stamp = node_->now();
+  msg.emergency = is_emergency_;
+  pub_external_emergency_->publish(msg);
+}
+
+void EmergencyInterface::on_service(
+  const SetEmergency::Request::SharedPtr req, const SetEmergency::Response::SharedPtr res)
+{
+  is_emergency_ = req->emergency;
+  res->status.code = tier4_external_api_msgs::msg::ResponseStatus::SUCCESS;
+}
+
+}  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/command/compatibility/emergency_interface.hpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/emergency_interface.hpp
@@ -1,0 +1,50 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMAND__COMPATIBILITY__EMERGENCY_INTERFACE_HPP_
+#define COMMAND__COMPATIBILITY__EMERGENCY_INTERFACE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_external_api_msgs/msg/emergency.hpp>
+#include <tier4_external_api_msgs/srv/set_emergency.hpp>
+
+namespace autoware::control_command_gate
+{
+
+class EmergencyInterface
+{
+private:
+  using Emergency = tier4_external_api_msgs::msg::Emergency;
+  using SetEmergency = tier4_external_api_msgs::srv::SetEmergency;
+
+public:
+  explicit EmergencyInterface(rclcpp::Node * node);
+  bool is_emergency() const { return is_emergency_; }
+  void publish();
+
+private:
+  bool is_emergency_ = false;
+
+  rclcpp::Node * node_;
+  rclcpp::Publisher<Emergency>::SharedPtr pub_external_emergency_;
+  rclcpp::Service<SetEmergency>::SharedPtr srv_external_emergency_;
+
+  void on_service(
+    const SetEmergency::Request::SharedPtr req, const SetEmergency::Response::SharedPtr res);
+};
+
+}  // namespace autoware::control_command_gate
+
+#endif  // COMMAND__COMPATIBILITY__EMERGENCY_INTERFACE_HPP_

--- a/control/autoware_control_command_gate/src/command/compatibility/moderate_stop_interface.cpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/moderate_stop_interface.cpp
@@ -1,0 +1,69 @@
+// Copyright 2023 LeoDrive, A.Ş.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "moderate_stop_interface.hpp"
+
+namespace autoware::control_command_gate
+{
+
+ModerateStopInterface::ModerateStopInterface(rclcpp::Node * node) : node_(node)
+{
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
+  adaptor.init_srv(srv_set_stop_, this, &ModerateStopInterface::on_stop_request);
+  adaptor.init_pub(pub_is_stopped_);
+
+  stop_state_.data = false;
+  stop_state_.requested_sources.clear();
+  publish();
+}
+
+bool ModerateStopInterface::is_stop_requested() const
+{
+  return stop_state_.data;
+}
+
+void ModerateStopInterface::publish()
+{
+  if (prev_stop_map_ != stop_map_) {
+    pub_is_stopped_->publish(stop_state_);
+    prev_stop_map_ = stop_map_;
+  }
+}
+
+void ModerateStopInterface::on_stop_request(
+  const SetStop::Service::Request::SharedPtr req, const SetStop::Service::Response::SharedPtr res)
+{
+  stop_map_[req->request_source] = req->stop;
+  update_stop_state();
+  res->status.success = true;
+}
+
+void ModerateStopInterface::update_stop_state()
+{
+  stop_state_.stamp = node_->now();
+  stop_state_.requested_sources.clear();
+  stop_state_.data = false;
+
+  if (stop_map_.empty()) {
+    return;
+  }
+  for (auto & itr : stop_map_) {
+    if (itr.second) {
+      stop_state_.data = true;
+      stop_state_.requested_sources.push_back(itr.first);
+    }
+  }
+}
+
+}  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/command/compatibility/moderate_stop_interface.hpp
+++ b/control/autoware_control_command_gate/src/command/compatibility/moderate_stop_interface.hpp
@@ -1,0 +1,58 @@
+// Copyright 2023 LeoDrive, A.Ş.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMAND__COMPATIBILITY__MODERATE_STOP_INTERFACE_HPP_
+#define COMMAND__COMPATIBILITY__MODERATE_STOP_INTERFACE_HPP_
+
+#include <autoware/component_interface_specs_universe/control.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+#include <unordered_map>
+
+namespace autoware::control_command_gate
+{
+
+class ModerateStopInterface
+{
+private:
+  using SetStop = autoware::component_interface_specs_universe::control::SetStop;
+  using IsStopped = autoware::component_interface_specs_universe::control::IsStopped;
+  using IsStartRequested = autoware::component_interface_specs_universe::control::IsStartRequested;
+
+public:
+  explicit ModerateStopInterface(rclcpp::Node * node);
+  bool is_stop_requested() const;
+  void publish();
+
+private:
+  IsStopped::Message stop_state_;
+  std::unordered_map<std::string, bool> stop_map_;
+  std::optional<std::unordered_map<std::string, bool>> prev_stop_map_;
+
+  rclcpp::Node * node_;
+  autoware::component_interface_utils::Service<SetStop>::SharedPtr srv_set_stop_;
+  autoware::component_interface_utils::Publisher<IsStopped>::SharedPtr pub_is_stopped_;
+
+  void on_stop_request(
+    const SetStop::Service::Request::SharedPtr req,
+    const SetStop::Service::Response::SharedPtr res);
+
+  void update_stop_state();
+};
+
+}  // namespace autoware::control_command_gate
+
+#endif  // COMMAND__COMPATIBILITY__MODERATE_STOP_INTERFACE_HPP_


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_universe/pull/10917

The functionality from the vehicle_cmd_gate node has been re-implemented in the control_command_gate node for compatibility. Specifically:

- Pressing the “Set Emergency” button in RViz now causes the vehicle to decelerate and come to a stop.
- Calling the /control/vehicle_cmd_gate/set_stop service from an external source will also bring the vehicle to a halt.