### PR TITLE
chore(boundary_departure): add logging for monitoring (#10969)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -57,9 +57,11 @@ void BoundaryDeparturePreventionModule::init(
       if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
         lvl = node_param_.diagnostic_level[DepartureType::CRITICAL_DEPARTURE];
         msg = "vehicle is leaving boundary";
+        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 500, "%s", msg.c_str());
       } else if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
         lvl = node_param_.diagnostic_level[DepartureType::APPROACHING_DEPARTURE];
         msg = "vehicle is moving towards the boundary";
+        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 1000, "%s", msg.c_str());
       } else if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
         lvl = node_param_.diagnostic_level[DepartureType::NEAR_BOUNDARY];
         msg = "vehicle is near boundary";


### PR DESCRIPTION
cherry pick [chore(boundary_departure): add logging for monitoring](https://github.com/tier4/autoware_universe/commit/682615144792bb9d50073fe68b4dd11170e2d995)](https://github.com/autowarefoundation/autoware_universe/pull/10969)

- The purpose of backlogging this is to ensure that we can monitor any false positive detections via MOB