### PR TITLE
fix(boundary_departure): disable when autoware disengaged (#10962)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -235,6 +235,11 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
     return {};
   }
 
+  if (!is_autonomous_mode()) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "Not in autonomous mode.");
+    return {};
+  }
+
   const auto & vehicle_info = planner_data->vehicle_info_;
   const auto & ll_map_ptr = planner_data->route_handler->getLaneletMapPtr();
 
@@ -340,6 +345,12 @@ std::optional<std::string> BoundaryDeparturePreventionModule::is_data_timeout(
   }
 
   return std::nullopt;
+}
+
+bool BoundaryDeparturePreventionModule::is_autonomous_mode() const
+{
+  return (op_mode_state_ptr_->mode == OperationModeState::AUTONOMOUS) &&
+         op_mode_state_ptr_->is_autoware_control_enabled;
 }
 
 bool BoundaryDeparturePreventionModule::is_goal_changed(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -52,6 +52,7 @@ private:
   void take_data();
   std::optional<std::string> is_data_invalid(const TrajectoryPoints & raw_trajectory_points) const;
   std::optional<std::string> is_data_timeout(const Odometry & odom) const;
+  bool is_autonomous_mode() const;
   [[nodiscard]] bool is_goal_changed(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const Pose & new_goal);
 


### PR DESCRIPTION
When autoware is disengaged, the ego's predicted path behavior is undefined. As shown in the following video. This has caused boundary departure to produce false positive results. 

https://github.com/user-attachments/assets/04c90345-1859-4d63-8a31-b41ab46886bb

This PR aims to disable boundary departure during autonomous mode.