### PR TITLE
cherry_pick(boundary_departure): preventing node dying + disable when autoware disengaged

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -165,20 +165,18 @@ void BoundaryDeparturePreventionModule::update_parameters(
 
 void BoundaryDeparturePreventionModule::subscribe_topics(rclcpp::Node & node)
 {
-  sub_ego_pred_traj_ = node.create_subscription<Trajectory>(
-    "/control/trajectory_follower/lateral/predicted_trajectory", rclcpp::QoS{1},
-    [&](const Trajectory::ConstSharedPtr msg) { ego_pred_traj_ptr_ = msg; });
-
-  sub_control_cmd_ = node.create_subscription<Control>(
-    "/control/command/control_cmd", rclcpp::QoS{1},
-    [&](const Control::ConstSharedPtr msg) { control_cmd_ptr_ = msg; });
-  sub_steering_angle_ = node.create_subscription<SteeringReport>(
-    "/vehicle/status/steering_status", rclcpp::QoS{1},
-    [&](const SteeringReport::ConstSharedPtr msg) { steering_angle_ptr_ = msg; });
-
-  sub_op_mode_state_ = node.create_subscription<OperationModeState>(
-    "~/api/operation_mode/state", rclcpp::QoS{1},
-    [this](const OperationModeState::ConstSharedPtr msg) { op_mode_state_ptr_ = msg; });
+  ego_pred_traj_polling_sub_ =
+    autoware_utils::InterProcessPollingSubscriber<Trajectory>::create_subscription(
+      &node, "/control/trajectory_follower/lateral/predicted_trajectory", 1);
+  control_cmd_polling_sub_ =
+    autoware_utils::InterProcessPollingSubscriber<Control>::create_subscription(
+      &node, "/control/command/control_cmd", 1);
+  steering_angle_polling_sub_ =
+    autoware_utils::InterProcessPollingSubscriber<SteeringReport>::create_subscription(
+      &node, "/vehicle/status/steering_status", 1);
+  op_mode_state_polling_sub_ =
+    autoware_utils::InterProcessPollingSubscriber<OperationModeState>::create_subscription(
+      &node, "/api/operation_mode/state", 1);
 }
 
 void BoundaryDeparturePreventionModule::publish_topics(rclcpp::Node & node)
@@ -197,6 +195,27 @@ void BoundaryDeparturePreventionModule::publish_topics(rclcpp::Node & node)
     node.create_publisher<Float64Stamped>("~/debug/" + ns + "/processing_time_ms", 1);
 }
 
+void BoundaryDeparturePreventionModule::take_data()
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  if (const auto ego_pred_traj_msg = ego_pred_traj_polling_sub_->take_data()) {
+    ego_pred_traj_ptr_ = ego_pred_traj_msg;
+  }
+
+  if (const auto control_command_msg = control_cmd_polling_sub_->take_data()) {
+    control_cmd_ptr_ = control_command_msg;
+  }
+
+  if (const auto steering_angle_msg = steering_angle_polling_sub_->take_data()) {
+    steering_angle_ptr_ = steering_angle_msg;
+  }
+
+  if (const auto op_mode_state_msg = op_mode_state_polling_sub_->take_data()) {
+    op_mode_state_ptr_ = op_mode_state_msg;
+  }
+}
+
 VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   const TrajectoryPoints & raw_trajectory_points,
   [[maybe_unused]] const TrajectoryPoints & smoothed_trajectory_points,
@@ -205,6 +224,16 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   StopWatch<std::chrono::milliseconds> stopwatch_ms;
   stopwatch_ms.tic("plan");
+
+  take_data();
+
+  if (!is_data_ready()) {
+    return {};
+  }
+
+  if (is_data_timeout(planner_data->current_odometry)) {
+    return {};
+  }
 
   const auto & vehicle_info = planner_data->vehicle_info_;
   const auto & ll_map_ptr = planner_data->route_handler->getLaneletMapPtr();
@@ -237,20 +266,31 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   return *result_opt;
 }
 
-bool BoundaryDeparturePreventionModule::is_data_ready(
-  [[maybe_unused]] std::unordered_map<std::string, double> & processing_times)
+bool BoundaryDeparturePreventionModule::is_data_ready()
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (!ego_pred_traj_ptr_) {
-    RCLCPP_INFO_THROTTLE(
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
       logger_, *clock_ptr_, throttle_duration_ms, "waiting for predicted trajectory...");
     return false;
   }
 
   if (!op_mode_state_ptr_) {
-    RCLCPP_INFO_THROTTLE(
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
       logger_, *clock_ptr_, throttle_duration_ms, "waiting for operation mode state...");
+    return false;
+  }
+
+  if (!control_cmd_ptr_) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "waiting for control command...");
+    return false;
+  }
+
+  if (!steering_angle_ptr_) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "waiting for steering angle...");
     return false;
   }
 
@@ -262,7 +302,7 @@ bool BoundaryDeparturePreventionModule::is_data_valid() const
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (ego_pred_traj_ptr_->points.empty()) {
-    RCLCPP_INFO_THROTTLE(
+    RCLCPP_WARN_THROTTLE(
       logger_, *clock_ptr_, throttle_duration_ms, "empty predicted trajectory...");
     return false;
   }
@@ -274,11 +314,40 @@ bool BoundaryDeparturePreventionModule::is_data_timeout(const Odometry & odom) c
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto now = clock_ptr_->now();
-  const auto time_diff_s = (rclcpp::Time(odom.header.stamp) - now).seconds();
+  const auto odom_time_diff_s = (rclcpp::Time(odom.header.stamp) - now).seconds();
   constexpr auto th_pose_timeout_s = 1.0;
 
-  if (time_diff_s > th_pose_timeout_s) {
-    RCLCPP_INFO_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "pose timeout...");
+  if (odom_time_diff_s > th_pose_timeout_s) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "pose timeout for %.3f seconds...",
+      odom_time_diff_s);
+    return true;
+  }
+
+  const auto ego_pred_traj_time_diff_s =
+    (rclcpp::Time(ego_pred_traj_ptr_->header.stamp) - now).seconds();
+
+  if (ego_pred_traj_time_diff_s > th_pose_timeout_s) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms,
+      "ego predicted trajectory timeout for %.3f seconds...", ego_pred_traj_time_diff_s);
+    return true;
+  }
+
+  const auto control_command_time_diff_s = (rclcpp::Time(control_cmd_ptr_->stamp) - now).seconds();
+  if (control_command_time_diff_s > th_pose_timeout_s) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "control commands timeout for %.3f seconds...",
+      control_command_time_diff_s);
+    return true;
+  }
+
+  const auto steering_angle_time_diff_s =
+    (rclcpp::Time(steering_angle_ptr_->stamp) - now).seconds();
+  if (steering_angle_time_diff_s > th_pose_timeout_s) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "control commands timeout for %.3f seconds...",
+      steering_angle_time_diff_s);
     return true;
   }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -238,6 +238,11 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
     return {};
   }
 
+  if (!is_autonomous_mode()) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "Not in autonomous mode.");
+    return {};
+  }
+
   const auto & vehicle_info = planner_data->vehicle_info_;
   const auto & ll_map_ptr = planner_data->route_handler->getLaneletMapPtr();
 
@@ -343,6 +348,12 @@ std::optional<std::string> BoundaryDeparturePreventionModule::is_data_timeout(
   }
 
   return std::nullopt;
+}
+
+bool BoundaryDeparturePreventionModule::is_autonomous_mode() const
+{
+  return (op_mode_state_ptr_->mode == OperationModeState::AUTONOMOUS) &&
+         op_mode_state_ptr_->is_autoware_control_enabled;
 }
 
 bool BoundaryDeparturePreventionModule::is_goal_changed(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -227,11 +227,14 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
 
   take_data();
 
-  if (!is_data_ready()) {
+  if (const auto invalid_data_opt = is_data_invalid(raw_trajectory_points)) {
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_ptr_, throttle_duration_ms, "%s", invalid_data_opt->c_str());
     return {};
   }
 
-  if (is_data_timeout(planner_data->current_odometry)) {
+  if (const auto is_timeout_opt = is_data_timeout(planner_data->current_odometry)) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "%s", is_timeout_opt->c_str());
     return {};
   }
 
@@ -248,68 +251,66 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
       std::make_unique<utils::SlowDownInterpolator>(node_param_.bdc_param.th_trigger);
   }
 
-  auto result_opt = plan_slow_down_intervals(raw_trajectory_points, planner_data);
+  try {
+    auto result_opt = plan_slow_down_intervals(raw_trajectory_points, planner_data);
 
-  processing_time_publisher_->publish(std::invoke([&]() {
-    autoware_internal_debug_msgs::msg::Float64Stamped msg;
-    msg.stamp = clock_ptr_->now();
-    msg.data = stopwatch_ms.toc();
-    return msg;
-  }));
+    processing_time_publisher_->publish(std::invoke([&]() {
+      autoware_internal_debug_msgs::msg::Float64Stamped msg;
+      msg.stamp = clock_ptr_->now();
+      msg.data = stopwatch_ms.toc();
+      return msg;
+    }));
 
-  if (!result_opt) {
-    RCLCPP_DEBUG(rclcpp::get_logger(get_module_name()), "%s", result_opt.error().c_str());
-    return {};
+    if (!result_opt) {
+      RCLCPP_DEBUG(logger_, "Planning skipped: %s", result_opt.error().c_str());
+      return {};
+    }
+
+    updater_ptr_->force_update();
+    return *result_opt;
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Exception is caught: %s", e.what());
+  } catch (...) {
+    RCLCPP_ERROR(logger_, "Unknown exception is caught.");
   }
 
-  updater_ptr_->force_update();
-  return *result_opt;
+  return {};
 }
 
-bool BoundaryDeparturePreventionModule::is_data_ready()
+std::optional<std::string> BoundaryDeparturePreventionModule::is_data_invalid(
+  const TrajectoryPoints & raw_trajectory_points) const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   if (!ego_pred_traj_ptr_) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "waiting for predicted trajectory...");
-    return false;
+    return {"waiting for predicted trajectory..."};
+  }
+
+  if (ego_pred_traj_ptr_->points.empty()) {
+    return {"empty predicted trajectory..."};
   }
 
   if (!op_mode_state_ptr_) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "waiting for operation mode state...");
-    return false;
+    return {"waiting for operation mode state..."};
   }
 
   if (!control_cmd_ptr_) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "waiting for control command...");
-    return false;
+    return {"waiting for control command..."};
   }
 
   if (!steering_angle_ptr_) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "waiting for steering angle...");
-    return false;
+    return {"waiting for steering angle..."};
   }
 
-  return true;
-}
-
-bool BoundaryDeparturePreventionModule::is_data_valid() const
-{
-  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
-  if (ego_pred_traj_ptr_->points.empty()) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "empty predicted trajectory...");
-    return false;
+  constexpr size_t min_pts_size = 4;
+  if (raw_trajectory_points.size() < min_pts_size) {
+    return {"Insufficient reference trajectory points."};
   }
-  return true;
+
+  return std::nullopt;
 }
 
-bool BoundaryDeparturePreventionModule::is_data_timeout(const Odometry & odom) const
+std::optional<std::string> BoundaryDeparturePreventionModule::is_data_timeout(
+  const Odometry & odom) const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -318,40 +319,30 @@ bool BoundaryDeparturePreventionModule::is_data_timeout(const Odometry & odom) c
   constexpr auto th_pose_timeout_s = 1.0;
 
   if (odom_time_diff_s > th_pose_timeout_s) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "pose timeout for %.3f seconds...",
-      odom_time_diff_s);
-    return true;
+    return fmt::format("pose timeout for {:.3f} seconds...", odom_time_diff_s);
   }
 
   const auto ego_pred_traj_time_diff_s =
     (rclcpp::Time(ego_pred_traj_ptr_->header.stamp) - now).seconds();
 
   if (ego_pred_traj_time_diff_s > th_pose_timeout_s) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms,
-      "ego predicted trajectory timeout for %.3f seconds...", ego_pred_traj_time_diff_s);
-    return true;
+    return fmt::format(
+      "ego predicted trajectory timeout for {:.3f} seconds...", ego_pred_traj_time_diff_s);
   }
 
   const auto control_command_time_diff_s = (rclcpp::Time(control_cmd_ptr_->stamp) - now).seconds();
   if (control_command_time_diff_s > th_pose_timeout_s) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "control commands timeout for %.3f seconds...",
-      control_command_time_diff_s);
-    return true;
+    return fmt::format(
+      "control commands timeout for {:.3f} seconds...", control_command_time_diff_s);
   }
 
   const auto steering_angle_time_diff_s =
     (rclcpp::Time(steering_angle_ptr_->stamp) - now).seconds();
   if (steering_angle_time_diff_s > th_pose_timeout_s) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_ptr_, throttle_duration_ms, "control commands timeout for %.3f seconds...",
-      steering_angle_time_diff_s);
-    return true;
+    return fmt::format("steering report timeout for {:.3f} seconds...", steering_angle_time_diff_s);
   }
 
-  return false;
+  return std::nullopt;
 }
 
 bool BoundaryDeparturePreventionModule::is_goal_changed(
@@ -398,13 +389,6 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
     processing_times_ms_[tag] = stopwatch_ms.toc(true);
   };
 
-  if (!ego_pred_traj_ptr_) {
-    return tl::make_unexpected("Couldn't read predicted path pointer.");
-  }
-
-  if (raw_trajectory_points.empty()) {
-    return tl::make_unexpected("Empty reference trajectory.");
-  }
   if (autoware_utils::calc_distance2d(curr_position, goal_position) < min_effective_dist) {
     output_.departure_intervals.clear();
     return tl::make_unexpected("Too close to goal.");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -45,7 +45,8 @@ private:
   // === Interface and inputs validation ====
   void subscribe_topics(rclcpp::Node & node);
   void publish_topics(rclcpp::Node & node);
-  [[nodiscard]] bool is_data_ready(std::unordered_map<std::string, double> & processing_times);
+  void take_data();
+  [[nodiscard]] bool is_data_ready();
   [[nodiscard]] bool is_data_valid() const;
   [[nodiscard]] bool is_data_timeout(const Odometry & odom) const;
   [[nodiscard]] bool is_goal_changed(
@@ -76,10 +77,12 @@ private:
   OperationModeState::ConstSharedPtr op_mode_state_ptr_;
   std::unordered_map<std::string, double> processing_times_ms_;
 
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_ego_pred_traj_;
-  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
-  rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_angle_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr sub_op_mode_state_;
+  autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr ego_pred_traj_polling_sub_;
+  autoware_utils::InterProcessPollingSubscriber<Control>::SharedPtr control_cmd_polling_sub_;
+  autoware_utils::InterProcessPollingSubscriber<SteeringReport>::SharedPtr
+    steering_angle_polling_sub_;
+  autoware_utils::InterProcessPollingSubscriber<OperationModeState>::SharedPtr
+    op_mode_state_polling_sub_;
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr processing_time_detail_pub_;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -46,9 +46,8 @@ private:
   void subscribe_topics(rclcpp::Node & node);
   void publish_topics(rclcpp::Node & node);
   void take_data();
-  [[nodiscard]] bool is_data_ready();
-  [[nodiscard]] bool is_data_valid() const;
-  [[nodiscard]] bool is_data_timeout(const Odometry & odom) const;
+  std::optional<std::string> is_data_invalid(const TrajectoryPoints & raw_trajectory_points) const;
+  std::optional<std::string> is_data_timeout(const Odometry & odom) const;
   [[nodiscard]] bool is_goal_changed(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const Pose & new_goal);
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -48,6 +48,7 @@ private:
   void take_data();
   std::optional<std::string> is_data_invalid(const TrajectoryPoints & raw_trajectory_points) const;
   std::optional<std::string> is_data_timeout(const Odometry & odom) const;
+  bool is_autonomous_mode() const;
   [[nodiscard]] bool is_goal_changed(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const Pose & new_goal);
 


### PR DESCRIPTION
Cherry-picking polling sub PRs and preventing node dying.