### PR TITLE
fix(radar_tracks_objects_converter): publish topic even if objects array is empty (backport autowarefoundation#11002)

### DIFF
--- a/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
+++ b/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
@@ -163,10 +163,8 @@ void RadarTracksMsgsConverterNode::onTimer()
 
   TrackedObjects tracked_objects = convertRadarTrackToTrackedObjects();
   DetectedObjects detected_objects = convertTrackedObjectsToDetectedObjects(tracked_objects);
-  if (!tracked_objects.objects.empty()) {
-    pub_tracked_objects_->publish(tracked_objects);
-    pub_detected_objects_->publish(detected_objects);
-  }
+  pub_tracked_objects_->publish(tracked_objects);
+  pub_detected_objects_->publish(detected_objects);
 }
 
 DetectedObjects RadarTracksMsgsConverterNode::convertTrackedObjectsToDetectedObjects(


### PR DESCRIPTION
## Descriptions
backport: https://github.com/autowarefoundation/autoware_universe/pull/11002 

## Related Links
https://tier4.atlassian.net/browse/RT0-37772

## Tests Perfomed
tracked_objectsがemptyの場合にdetected_objectsがpublishされることを確認した