### PR TITLE
feat(planning_validator, intersection_collision_checker): cherry pick improvements

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
@@ -62,9 +62,9 @@ public:
   explicit PlanningValidatorNode(const rclcpp::NodeOptions & options);
 
 private:
-  void onTimer();
+  void onTrajectory(const Trajectory::ConstSharedPtr & traj_msg);
   void setupParameters();
-  void setData();
+  void setData(const Trajectory::ConstSharedPtr & traj_msg);
   bool isDataReady();
 
   void validate(const std::shared_ptr<const PlanningValidatorData> & data);
@@ -75,6 +75,7 @@ private:
   void displayStatus();
 
   // subscriber
+  rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
   autoware_utils::InterProcessPollingSubscriber<
     LaneletRoute, autoware_utils::polling_policy::Newest>
     sub_route_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
@@ -87,8 +88,6 @@ private:
     this, "~/input/kinematics"};
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> sub_acceleration_{
     this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_trajectory_{
-    this, "~/input/trajectory"};
 
   // publisher
   rclcpp::Publisher<Trajectory>::SharedPtr pub_traj_;
@@ -111,7 +110,6 @@ private:
   std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
   StopWatch<std::chrono::milliseconds> stop_watch_;
-  rclcpp::TimerBase::SharedPtr timer_;
 };
 }  // namespace autoware::planning_validator
 

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/config/intersection_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/config/intersection_collision_checker.param.yaml
@@ -8,6 +8,8 @@
       min_time_horizon: 10.0 # [s]
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 1.0 # [s]
+      close_distance_th: 3.0 # [m]
+      close_time_th: 3.0 # [s]
 
       right_turn:
         enable: true
@@ -23,19 +25,20 @@
         height_buffer: 0.5  # [m]
         min_height: 0.5  # [m]
         voxel_grid_filter:
-          x: 0.1
-          y: 0.1
-          z: 0.5
+          x: 0.2
+          y: 0.2
+          z: 0.2
+          min_size: 3
         clustering:
           tolerance: 0.5  #[m]
           min_height: 0.5
           min_size: 10
           max_size: 10000
         velocity_estimation:
-          max_acceleration: 10.0  # [m/s^2]
-          max_velocity: 20.0  # [m/s]
+          max_acceleration: 20.0  # [m/s^2]
+          max_velocity: 25.0  # [m/s]
           observation_time: 0.3  # [s]
-          reset_accel_th: 30.0  # [m/s^2]
+          buffer_size: 10
         latency: 0.3
 
       filter:

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/intersection_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/intersection_collision_checker.hpp
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_validator
 {
@@ -76,6 +77,8 @@ private:
     DebugData & debug_data, const rclcpp::Time & time_stamp,
     const PointCloud::Ptr & filtered_point_cloud, const TargetLanelet & target_lanelet) const;
 
+  void update_tracked_object(PCDObject & object, const PCDObject & new_data) const;
+
   void publish_markers(const DebugData & debug_data) const;
 
   void set_lanelets_debug_marker(const DebugData & debug_data) const;
@@ -101,6 +104,7 @@ private:
 
   PCDObjectsMap history_;
   mutable TargetLaneletsMap target_lanelets_map_;
+  std::vector<lanelet::Id> collision_lanes_;
   rclcpp::Time last_invalid_time_;
   rclcpp::Time last_valid_time_;
 };

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
@@ -31,6 +31,8 @@
 #include <lanelet2_core/primitives/Point.h>
 #include <lanelet2_core/primitives/Polygon.h>
 
+#include <deque>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -93,19 +95,123 @@ struct EgoLanelets
 
 struct PCDObject
 {
+private:
+  size_t buffer_size{10ul};
+
+public:
   rclcpp::Time last_update_time;
   geometry_msgs::msg::Pose pose;
   geometry_msgs::msg::Point overlap_point;
   lanelet::Id overlap_lanelet_id;
+  std::deque<double> distance_history;
+  std::deque<double> timestamp_history;
   double track_duration{};
   double distance_to_overlap{};
   double delay_compensated_distance_to_overlap{};
   double velocity{};
   double moving_time{};
-  double ttc{};
+  double ttc{std::numeric_limits<double>::max()};
   bool is_safe{true};
   bool is_reliable{false};
   bool is_moving{false};
+
+  PCDObject() = default;
+
+  PCDObject(
+    const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Point & overlap_point,
+    const rclcpp::Time & time_stamp, const lanelet::Id ll_id, const double distance)
+  : last_update_time(time_stamp),
+    pose(pose),
+    overlap_point(overlap_point),
+    overlap_lanelet_id(ll_id),
+    distance_to_overlap(distance),
+    delay_compensated_distance_to_overlap(distance)
+  {
+    distance_history.push_back(distance);
+    timestamp_history.push_back(0.0);
+  }
+
+  void set_buffer_size(const size_t size) { buffer_size = size; }
+
+  void update_history(const double dist, const double dt)
+  {
+    static constexpr size_t max_size = 10;
+
+    const auto last_timestamp = timestamp_history.empty() ? 0.0 : timestamp_history.back();
+
+    distance_history.push_back(dist);
+    timestamp_history.push_back(last_timestamp + dt);
+
+    if (distance_history.size() > max_size) distance_history.pop_front();
+    if (timestamp_history.size() > max_size) timestamp_history.pop_front();
+  }
+
+  bool update_velocity()
+  {
+    // need at least two measurements to initialize velocity
+    if (distance_history.size() < 2) return false;
+
+    // perform linear regression to estimate velocity from first few samples
+    const auto n = distance_history.size();
+    const auto x0 = timestamp_history.front();
+
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+    double sum_xy = 0.0;
+    double sum_x2 = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+      double x_val = timestamp_history[i] - x0;
+      double y_val = distance_history[i];
+      sum_x += x_val;
+      sum_y += y_val;
+      sum_xy += x_val * y_val;
+      sum_x2 += x_val * x_val;
+    }
+
+    double denominator = n * sum_x2 - sum_x * sum_x;
+    if (std::abs(denominator) < std::numeric_limits<double>::epsilon()) {
+      return false;
+    }
+
+    double slope_m = (n * sum_xy - sum_x * sum_y) / denominator;
+    velocity = -1.0 * slope_m;  // negate value to estimate approach velocity
+    return true;
+  }
+
+  void update(const double dist, const double dt, const double raw_vel_th, const double accel_th)
+  {
+    const auto raw_velocity = (distance_to_overlap - dist) / dt;
+    if (abs(raw_velocity) > raw_vel_th) {
+      reset();
+      distance_history.push_back(dist);
+      timestamp_history.push_back(0.0);
+      return;
+    }
+
+    const auto last_vel = velocity;
+    update_history(dist, dt);
+    update_velocity();
+    track_duration += dt;
+
+    if (distance_history.size() < 3) return;
+
+    const auto accel = (velocity - last_vel) / dt;
+    if (abs(accel) > accel_th) {
+      reset();
+      distance_history.push_back(dist);
+      timestamp_history.push_back(0.0);
+    }
+  }
+
+  void reset()
+  {
+    velocity = 0.0;
+    track_duration = 0.0;
+    distance_history.clear();
+    timestamp_history.clear();
+    is_reliable = false;
+    is_safe = true;
+  }
 };
 
 struct DebugData

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
@@ -135,15 +135,13 @@ public:
 
   void update_history(const double dist, const double dt)
   {
-    static constexpr size_t max_size = 10;
-
     const auto last_timestamp = timestamp_history.empty() ? 0.0 : timestamp_history.back();
 
     distance_history.push_back(dist);
     timestamp_history.push_back(last_timestamp + dt);
 
-    if (distance_history.size() > max_size) distance_history.pop_front();
-    if (timestamp_history.size() > max_size) timestamp_history.pop_front();
+    if (distance_history.size() > buffer_size) distance_history.pop_front();
+    if (timestamp_history.size() > buffer_size) timestamp_history.pop_front();
   }
 
   bool update_velocity()

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
@@ -26,6 +26,14 @@ intersection_collision_checker_node:
       type: double
       validation:
         gt_eq<>: [0.0]
+    close_distance_th:
+      type: double
+      validation:
+        gt_eq<>: [0.0]
+    close_time_th:
+      type: double
+      validation:
+        gt_eq<>: [0.0]
 
     right_turn:
       enable:
@@ -67,6 +75,10 @@ intersection_collision_checker_node:
           type: double
           validation:
             gt<>: [0.0]
+        min_size:
+          type: int
+          validation:
+            gt<>: [0]
       clustering:
         tolerance:
           type: double
@@ -97,10 +109,10 @@ intersection_collision_checker_node:
           type: double
           validation:
             gt_eq<>: [0.0]
-        reset_accel_th:
-          type: double
+        buffer_size:
+          type: int
           validation:
-            gt<>: [0.0]
+            gt<>: [0]
       latency:
         type: double
         validation:

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
@@ -159,11 +159,21 @@ bool IntersectionCollisionChecker::is_safe(DebugData & debug_data)
   debug_data.is_active = true;
   debug_data.is_safe = true;
 
+  const auto prev_collision_lanes = collision_lanes_;
+  collision_lanes_.clear();
+
   const bool is_safe = check_collision(
     debug_data, filtered_pointcloud, context_->data->obstacle_pointcloud->header.stamp);
 
   const auto & p = params_.icc_parameters;
   const auto now = clock_->now();
+
+  auto consistent_collision_lane = [&]() {
+    return std::find_if(collision_lanes_.begin(), collision_lanes_.end(), [&](const auto & id) {
+             return std::find(prev_collision_lanes.begin(), prev_collision_lanes.end(), id) !=
+                    prev_collision_lanes.end();
+           }) != collision_lanes_.end();
+  };
 
   if (is_safe) {
     if ((now - last_invalid_time_).seconds() > p.off_time_buffer) {
@@ -174,7 +184,7 @@ bool IntersectionCollisionChecker::is_safe(DebugData & debug_data)
     return false;
   }
 
-  if ((now - last_valid_time_).seconds() < p.on_time_buffer) {
+  if ((now - last_valid_time_).seconds() < p.on_time_buffer || !consistent_collision_lane()) {
     RCLCPP_WARN(logger_, "[ICC] Momentary collision risk detected.");
     debug_data.text = "detected momentary collision";
     return true;
@@ -320,6 +330,7 @@ void IntersectionCollisionChecker::filter_pointcloud(
     filter.setLeafSize(
       p.pointcloud.voxel_grid_filter.x, p.pointcloud.voxel_grid_filter.y,
       p.pointcloud.voxel_grid_filter.z);
+    filter.setMinimumPointsNumberPerVoxel(p.pointcloud.voxel_grid_filter.min_size);
     filter.filter(*filtered_pointcloud);
   }
 
@@ -339,7 +350,6 @@ bool IntersectionCollisionChecker::check_collision(
   bool is_safe = true;
 
   const auto & p = params_.icc_parameters;
-  const auto & vel_params = p.pointcloud.velocity_estimation;
 
   auto ego_object_overlap_time =
     [](const double object_ttc, const std::pair<double, double> & ego_time) {
@@ -350,11 +360,10 @@ bool IntersectionCollisionChecker::check_collision(
 
   const auto ego_vel = context_->data->current_kinematics->twist.twist.linear.x;
   const auto close_time_th =
-    ego_vel < p.filter.min_velocity ? p.min_time_horizon : abs(ego_vel / p.ego_deceleration);
-  static constexpr double close_distance_threshold = 3.0;
+    ego_vel < p.filter.min_velocity ? p.close_time_th : abs(ego_vel / p.ego_deceleration);
   auto is_colliding = [&](const PCDObject & object, const std::pair<double, double> & ego_time) {
     if (!object.is_reliable) return false;
-    if (object.distance_to_overlap < close_distance_threshold && ego_time.first < close_time_th)
+    if (object.distance_to_overlap < p.close_distance_th && ego_time.first < close_time_th)
       return true;
     if (object.is_moving && ego_object_overlap_time(object.ttc, ego_time) < p.ttc_threshold) {
       return true;
@@ -369,49 +378,16 @@ bool IntersectionCollisionChecker::check_collision(
     const auto pcd_object = get_pcd_object(debug_data, time_stamp, filtered_point_cloud, target_ll);
     if (!pcd_object.has_value()) continue;
 
-    auto update_object = [&](PCDObject & object, const PCDObject & new_data) {
-      const auto dt = (new_data.last_update_time - object.last_update_time).seconds();
-      const auto dl = object.distance_to_overlap - new_data.distance_to_overlap;
-      if (dt < 1e-6) return;  // too small time difference, skip update
-
-      const auto raw_velocity = dl / dt;
-      const auto raw_accel = std::abs(raw_velocity - object.velocity) / dt;
-      object.is_reliable = object.track_duration > vel_params.observation_time;
-      static constexpr double eps = 0.01;  // small epsilon to avoid division by zero
-      // update velocity only if the object is not yet reliable or velocity change is within limit
-      if (
-        object.is_reliable && object.distance_to_overlap < close_distance_threshold &&
-        new_data.distance_to_overlap < close_distance_threshold) {
-        object.track_duration += dt;
-      } else if (raw_accel > vel_params.reset_accel_th) {
-        object.velocity = 0.0;        // reset velocity if acceleration is too high
-        object.track_duration = 0.0;  // reset track duration
-        object.is_reliable = false;   // reset reliability
-      } else if (!object.is_reliable || raw_accel < vel_params.max_acceleration) {
-        object.velocity = autoware::signal_processing::lowpassFilter(
-          raw_velocity, object.velocity, 0.5);  // apply low-pass filter to velocity
-        object.velocity = std::clamp(object.velocity, eps, vel_params.max_velocity);
-        object.track_duration += dt;
-      }
-
-      object.last_update_time = new_data.last_update_time;
-      object.pose = new_data.pose;
-      object.distance_to_overlap = new_data.distance_to_overlap;
-      object.delay_compensated_distance_to_overlap =
-        std::max(0.0, object.distance_to_overlap - object.velocity * p.pointcloud.latency);
-      object.moving_time =
-        (object.velocity < p.filter.min_velocity) ? 0.0 : object.moving_time + dt;
-      object.is_moving = object.moving_time > p.filter.moving_time;
-      object.ttc = object.delay_compensated_distance_to_overlap / object.velocity;
-    };
-
     if (history_.find(pcd_object->overlap_lanelet_id) == history_.end()) {
       history_[pcd_object->overlap_lanelet_id] = pcd_object.value();
     } else {
       auto & existing_object = history_[pcd_object->overlap_lanelet_id];
-      update_object(existing_object, pcd_object.value());
+      update_tracked_object(existing_object, pcd_object.value());
       existing_object.is_safe = !is_colliding(existing_object, target_ll.ego_overlap_time);
-      is_safe = is_safe && existing_object.is_safe;
+      if (!existing_object.is_safe) {
+        is_safe = false;
+        collision_lanes_.push_back(target_ll.id);
+      }
       debug_data.pcd_objects.push_back(existing_object);
     }
   }
@@ -427,6 +403,31 @@ bool IntersectionCollisionChecker::check_collision(
   }
 
   return is_safe;
+}
+
+void IntersectionCollisionChecker::update_tracked_object(
+  PCDObject & object, const PCDObject & new_data) const
+{
+  const auto dt = (new_data.last_update_time - object.last_update_time).seconds();
+  if (dt < 1e-6) return;  // too small time difference, skip update
+
+  const auto & p = params_.icc_parameters;
+  const auto & vel_params = p.pointcloud.velocity_estimation;
+
+  object.update(
+    new_data.distance_to_overlap, dt, vel_params.max_velocity, vel_params.max_acceleration);
+
+  object.is_reliable = object.track_duration > vel_params.observation_time;
+
+  static constexpr double eps = 0.01;
+  object.last_update_time = new_data.last_update_time;
+  object.pose = new_data.pose;
+  object.distance_to_overlap = new_data.distance_to_overlap;
+  object.delay_compensated_distance_to_overlap =
+    std::max(0.0, object.distance_to_overlap - object.velocity * p.pointcloud.latency);
+  object.moving_time = (object.velocity < p.filter.min_velocity) ? 0.0 : object.moving_time + dt;
+  object.is_moving = object.moving_time > p.filter.moving_time;
+  object.ttc = object.delay_compensated_distance_to_overlap / std::max(object.velocity, eps);
 }
 
 std::optional<PCDObject> IntersectionCollisionChecker::get_pcd_object(
@@ -447,6 +448,8 @@ std::optional<PCDObject> IntersectionCollisionChecker::get_pcd_object(
 
   if (clustered_points->empty()) return pcd_object;
 
+  const auto & vel_params = params_.icc_parameters.pointcloud.velocity_estimation;
+
   const auto overlap_arc_coord =
     lanelet::utils::getArcCoordinates(target_lanelet.lanelets, target_lanelet.overlap_point);
   auto min_arc_length = std::numeric_limits<double>::max();
@@ -463,17 +466,10 @@ std::optional<PCDObject> IntersectionCollisionChecker::get_pcd_object(
 
     min_arc_length = arc_length_to_overlap;
 
-    PCDObject object;
-    object.last_update_time = time_stamp;
-    object.pose = p_geom;
-    object.overlap_point = target_lanelet.overlap_point.position;
-    object.overlap_lanelet_id = target_lanelet.id;
-    object.track_duration = 0.0;
-    object.distance_to_overlap = arc_length_to_overlap;
-    object.delay_compensated_distance_to_overlap = arc_length_to_overlap;
-    object.velocity = 0.0;
-    object.moving_time = 0.0;
-    object.ttc = std::numeric_limits<double>::max();
+    PCDObject object(
+      p_geom, target_lanelet.overlap_point.position, time_stamp, target_lanelet.id,
+      arc_length_to_overlap);
+    object.set_buffer_size(vel_params.buffer_size);
     pcd_object = object;
   }
   return pcd_object;
@@ -539,6 +535,8 @@ void IntersectionCollisionChecker::cluster_pointcloud(
       output->push_back(point);
     }
   }
+
+  if (output->empty()) return;
 
   {
     const auto clustered_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();


### PR DESCRIPTION
Cherry-pick of:
- https://github.com/autowarefoundation/autoware_universe/pull/10979
  - changes planning_validator node to be event driven on trajectory msg to avoid delay
- https://github.com/autowarefoundation/autoware_universe/pull/11030
  - Improves velocity estimation and tracking logic of intersection_collision_checker to address frequent false negatives
- https://github.com/autowarefoundation/autoware_universe/pull/11034
  - minor fix to use parameterized values instead of hard coded constants

Requires https://github.com/tier4/autoware_launch/pull/1022