### PR TITLE
fix(autoware_traffic_light_classifier): move `rclcpp::shutdown();` from child to parent to avoid `rclcpp::exceptions::RCLError`

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -53,10 +53,6 @@ CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
   classifier_ = std::make_unique<autoware::tensorrt_classifier::TrtClassifier>(
     model_file_path, precision, mean_, std_);
   batch_size_ = classifier_->getBatchSize();
-  if (node_ptr_->declare_parameter<bool>("build_only")) {
-    RCLCPP_INFO(node_ptr_->get_logger(), "TensorRT engine is built and shutdown node.");
-    rclcpp::shutdown();
-  }
 }
 
 bool CNNClassifier::getTrafficSignals(

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -64,6 +64,11 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
 
   diagnostics_interface_ptr_ =
     std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic_light_classifier");
+
+  if (this->declare_parameter<bool>("build_only")) {
+    RCLCPP_INFO(get_logger(), "TensorRT engine is built and shutdown node.");
+    rclcpp::shutdown();
+  }
 }
 
 void TrafficLightClassifierNodelet::connectCb()


### PR DESCRIPTION
# Description

Cherry-pick to avoid `rclcpp::exceptions::RCLError`. 
Background : https://star4.slack.com/archives/C076ZGRC15X/p1752741243355159

# Test
https://evaluation.ci.tier4.jp/evaluation/reports/73ebdd30-0e16-579c-aa93-f90e3ab24489?project_id=prd_jt