### PR TITLE
fix(intersection_collision_checker): cherry pick #11058

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/config/intersection_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/config/intersection_collision_checker.param.yaml
@@ -38,6 +38,7 @@
           max_acceleration: 20.0  # [m/s^2]
           max_velocity: 25.0  # [m/s]
           observation_time: 0.3  # [s]
+          max_history_time: 0.5  # [s]
           buffer_size: 10
         latency: 0.3
 

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
@@ -176,8 +176,17 @@ public:
     return true;
   }
 
-  void update(const double dist, const double dt, const double raw_vel_th, const double accel_th)
+  void update(
+    const double dist, const double dt, const double raw_vel_th, const double accel_th,
+    const double min_dist_th)
   {
+    // distance measurement is not reliable near the overlap point, skip velocity update
+    if (is_reliable && delay_compensated_distance_to_overlap < min_dist_th) {
+      update_history(dist, dt);
+      track_duration += dt;
+      return;
+    }
+
     const auto raw_velocity = (distance_to_overlap - dist) / dt;
     if (abs(raw_velocity) > raw_vel_th) {
       reset();

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
@@ -109,6 +109,10 @@ intersection_collision_checker_node:
           type: double
           validation:
             gt_eq<>: [0.0]
+        max_history_time:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
         buffer_size:
           type: int
           validation:


### PR DESCRIPTION
cherry pick of https://github.com/autowarefoundation/autoware_universe/pull/11058
- improves logic for handling objects near overlap point
- adds configuration parameter `max_history_time`

requires https://github.com/tier4/autoware_launch/pull/1037