### PR TITLE
fix(boundary_departure): configurable diagnostic level #11064

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -238,7 +238,7 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   }
 
   if (!is_autonomous_mode()) {
-    RCLCPP_WARN_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "Not in autonomous mode.");
+    RCLCPP_DEBUG_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "Not in autonomous mode.");
     return {};
   }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -32,6 +32,19 @@
 #include <unordered_map>
 #include <vector>
 
+namespace
+{
+using autoware::motion_velocity_planner::experimental::DepartureType;
+std::string to_string(DepartureType type)
+{
+  auto str = std::string(magic_enum::enum_name(type));
+  std::transform(
+    str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
+  std::replace(str.begin(), str.end(), '_', ' ');
+  return str;
+}
+}  // namespace
+
 namespace autoware::motion_velocity_planner::experimental
 {
 
@@ -51,20 +64,24 @@ void BoundaryDeparturePreventionModule::init(
   updater_ptr_->setHardwareID("motion_velocity_boundary_departure_prevention");
   updater_ptr_->add(
     "boundary_departure", [this](diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      int8_t lvl{DiagStatus::OK};
-      std::string msg{"OK"};
+      const auto type = std::invoke([&]() {
+        if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
+          return DepartureType::CRITICAL_DEPARTURE;
+        }
+        if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
+          return DepartureType::APPROACHING_DEPARTURE;
+        }
+        if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
+          return DepartureType::NEAR_BOUNDARY;
+        }
+        return DepartureType::NONE;
+      });
 
-      if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
-        lvl = node_param_.diagnostic_level[DepartureType::CRITICAL_DEPARTURE];
-        msg = "vehicle is leaving boundary";
-        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 500, "%s", msg.c_str());
-      } else if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
-        lvl = node_param_.diagnostic_level[DepartureType::APPROACHING_DEPARTURE];
-        msg = "vehicle is moving towards the boundary";
+      auto lvl = node_param_.diagnostic_level[type];
+      auto msg = to_string(type);
+
+      if (lvl != DiagStatus::OK && type != DepartureType::NONE) {
         RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 1000, "%s", msg.c_str());
-      } else if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
-        lvl = node_param_.diagnostic_level[DepartureType::NEAR_BOUNDARY];
-        msg = "vehicle is near boundary";
       }
 
       stat.summary(lvl, msg);
@@ -239,6 +256,7 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
 
   if (!is_autonomous_mode()) {
     RCLCPP_DEBUG_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "Not in autonomous mode.");
+    updater_ptr_->force_update();
     return {};
   }
 
@@ -265,12 +283,12 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
       return msg;
     }));
 
+    updater_ptr_->force_update();
     if (!result_opt) {
       RCLCPP_DEBUG(logger_, "Planning skipped: %s", result_opt.error().c_str());
       return {};
     }
 
-    updater_ptr_->force_update();
     return *result_opt;
   } catch (const std::exception & e) {
     RCLCPP_WARN(logger_, "Exception is caught: %s", e.what());

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -143,7 +143,7 @@ struct NodeParam
     });
 
     const auto select_diag_lvl = [](const int level) {
-      if (DiagStatus::OK) {
+      if (level == 0) {
         return DiagStatus::OK;
       }
 
@@ -169,6 +169,7 @@ struct NodeParam
       const auto critical_departure_diag_lvl =
         select_diag_lvl(get_or_declare_parameter<int>(node, ns_diag + "critical_departure"));
 
+      diag.insert({DepartureType::NONE, DiagStatus::OK});
       diag.insert({DepartureType::NEAR_BOUNDARY, near_boundary_diag_lvl});
       diag.insert({DepartureType::APPROACHING_DEPARTURE, approaching_departure_diag_lvl});
       diag.insert({DepartureType::CRITICAL_DEPARTURE, critical_departure_diag_lvl});


### PR DESCRIPTION
Cherry-pick 2 PR related to diagnostic and logging.
Both PRs are cherry-picked together to avoid conflict.

[refactor(boundary_departure): reduce autonomous mode logging level #10986](https://github.com/autowarefoundation/autoware_universe/pull/10986)
[fix(boundary_departure): configurable diagnostic level #11064](https://github.com/autowarefoundation/autoware_universe/pull/11064)
