### PR TITLE
fix(boundary_departure): subscribe to route to determine goal changes #11004

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -52,9 +52,8 @@ private:
   void take_data();
   std::optional<std::string> is_data_invalid(const TrajectoryPoints & raw_trajectory_points) const;
   std::optional<std::string> is_data_timeout(const Odometry & odom) const;
+  std::optional<std::string> is_route_changed();
   bool is_autonomous_mode() const;
-  [[nodiscard]] bool is_goal_changed(
-    const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const Pose & new_goal);
 
   // === Internal logic
 
@@ -72,13 +71,14 @@ private:
   std::unique_ptr<utils::SlowDownInterpolator> slow_down_interpolator_ptr_;
   MarkerArray debug_marker_;
   MarkerArray slow_down_wall_marker_;
-  std::unique_ptr<Pose> prev_goal_ptr_;
+  std::unique_ptr<LaneletRoute> prev_route_ptr_;
   static constexpr auto throttle_duration_ms{5000};
 
   Trajectory::ConstSharedPtr ego_pred_traj_ptr_;
   Control::ConstSharedPtr control_cmd_ptr_;
   SteeringReport::ConstSharedPtr steering_angle_ptr_;
   OperationModeState::ConstSharedPtr op_mode_state_ptr_;
+  LaneletRoute::ConstSharedPtr route_ptr_;
   std::unordered_map<std::string, double> processing_times_ms_;
 
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr ego_pred_traj_polling_sub_;
@@ -87,6 +87,8 @@ private:
     steering_angle_polling_sub_;
   autoware_utils::InterProcessPollingSubscriber<OperationModeState>::SharedPtr
     op_mode_state_polling_sub_;
+  autoware_utils::InterProcessPollingSubscriber<
+    LaneletRoute, autoware_utils::polling_policy::Newest>::SharedPtr route_polling_sub_;
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr processing_time_detail_pub_;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/type_alias.hpp
@@ -33,6 +33,7 @@
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
@@ -45,6 +46,7 @@
 namespace autoware::motion_velocity_planner::experimental
 {
 using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Point;


### PR DESCRIPTION
[fix(boundary_departure): subscribe to route to determine goal changes #11004](https://github.com/autowarefoundation/autoware_universe/pull/11004)

* fix(boundary_departure): use route msg to check for goal changes
* changed goal ptr to route ptr
