### PR TITLE
feat(tier4_control_launch, control_command_gate): enable to remap control cmd from autoware launch (#11019)

### DIFF
--- a/control/autoware_control_command_gate/launch/control_command_gate.launch.xml
+++ b/control/autoware_control_command_gate/launch/control_command_gate.launch.xml
@@ -1,14 +1,26 @@
 <launch>
   <arg name="config" default="$(find-pkg-share autoware_control_command_gate)/config/default.param.yaml"/>
+  <arg name="output/control" default="/control/command/control_cmd"/>
+  <arg name="output/gear" default="/control/command/gear_cmd"/>
+  <arg name="output/turn_indicators" default="/control/command/turn_indicators_cmd"/>
+  <arg name="output/hazard_lights" default="/control/command/hazard_lights_cmd"/>
+  <arg name="inputs/main/control" default="/control/trajectory_follower/control_cmd"/>
+  // Confirm that "main" is listed in config input_names
+  <arg name="inputs/main/gear" default="/control/shift_decider/gear_cmd"/>
+  // Confirm that "main" is listed in config input_names
+  <arg name="inputs/main/hazard_lights" default="/planning/hazard_lights_cmd"/>
+  // Confirm that "main" is listed in config input_names
+  <arg name="inputs/main/turn_indicators" default="/planning/turn_indicators_cmd"/>
+  // Confirm that "main" is listed in config input_names
   <node pkg="autoware_control_command_gate" exec="control_command_gate_node">
     <param from="$(var config)"/>
-    <remap from="~/output/control" to="/control/command/control_cmd"/>
-    <remap from="~/output/gear" to="/control/command/gear_cmd"/>
-    <remap from="~/output/turn_indicators" to="/control/command/turn_indicators_cmd"/>
-    <remap from="~/output/hazard_lights" to="/control/command/hazard_lights_cmd"/>
-    <remap from="~/inputs/main/control" to="/control/trajectory_follower/control_cmd"/>
-    <remap from="~/inputs/main/gear" to="/control/shift_decider/gear_cmd"/>
-    <remap from="~/inputs/main/hazard_lights" to="/planning/hazard_lights_cmd"/>
-    <remap from="~/inputs/main/turn_indicators" to="/planning/turn_indicators_cmd"/>
+    <remap from="~/output/control" to="$(var output/control)"/>
+    <remap from="~/output/gear" to="$(var output/gear)"/>
+    <remap from="~/output/turn_indicators" to="$(var output/turn_indicators)"/>
+    <remap from="~/output/hazard_lights" to="$(var output/hazard_lights)"/>
+    <remap from="~/inputs/main/control" to="$(var inputs/main/control)"/>
+    <remap from="~/inputs/main/gear" to="$(var inputs/main/gear)"/>
+    <remap from="~/inputs/main/hazard_lights" to="$(var inputs/main/hazard_lights)"/>
+    <remap from="~/inputs/main/turn_indicators" to="$(var inputs/main/turn_indicators)"/>
   </node>
 </launch>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -51,12 +51,22 @@
   <let name="operation_mode_transition_manager_plugin" value="AutonomousModeTransitionFlagNode" if="$(var use_control_command_gate)"/>
   <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
 
+  <!-- topic remap -->
+  <arg name="output_control_cmd" default="/control/command/control_cmd"/>
+  <arg name="output_gear_cmd" default="/control/command/gear_cmd"/>
+  <arg name="output_turn_indicators_cmd" default="/control/command/turn_indicators_cmd"/>
+  <arg name="output_hazard_lights_cmd" default="/control/command/hazard_lights_cmd"/>
+
   <group>
     <push-ros-namespace namespace="control"/>
 
     <group if="$(var use_control_command_gate)">
       <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
         <arg name="config" value="$(var control_command_gate_param_path)"/>
+        <arg name="output/control" value="$(var output_control_cmd)"/>
+        <arg name="output/gear" value="$(var output_gear_cmd)"/>
+        <arg name="output/turn_indicators" value="$(var output_turn_indicators_cmd)"/>
+        <arg name="output/hazard_lights" value="$(var output_hazard_lights_cmd)"/>
       </include>
     </group>
     <group if="$(var use_control_command_gate)">
@@ -99,10 +109,10 @@
           <remap from="input/kinematics" to="/localization/kinematic_state"/>
           <remap from="input/acceleration" to="/localization/acceleration"/>
           <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-          <remap from="output/control_cmd" to="/control/command/control_cmd"/>
-          <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
-          <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
-          <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
+          <remap from="output/control_cmd" to="$(var output_control_cmd)"/>
+          <remap from="output/gear_cmd" to="$(var output_gear_cmd)"/>
+          <remap from="output/turn_indicators_cmd" to="$(var output_turn_indicators_cmd)"/>
+          <remap from="output/hazard_lights_cmd" to="$(var output_hazard_lights_cmd)"/>
           <remap from="output/gate_mode" to="/control/current_gate_mode"/>
           <remap from="output/engage" to="/api/autoware/get/engage"/>
           <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_universe/pull/11019

This PR enable to remap topics from autoware_launch.

- control_cmd
- gear_cmd
- turn_indicators_cmd
- hazard_lights_cmd

This change is necessary for X2 Psim of redundant configuration.