### PR TITLE
fix(run_out): add missing ament_auto_package in CMakeList (#11096)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
@@ -8,3 +8,5 @@ pluginlib_export_plugin_description_file(autoware_motion_velocity_planner plugin
 ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src
 )
+
+ament_auto_package()


### PR DESCRIPTION
Cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/11096 to fix the `run_out` module not being installed.