### PR TITLE
chore: keep runner

### DIFF
--- a/workflow_sync_setting.yaml
+++ b/workflow_sync_setting.yaml
@@ -43,6 +43,7 @@ workflows:
       updates:
         - jobs.build-and-test-differential-cuda.with.runner: ubuntu-22.04-m
         - jobs.clang-tidy-differential-cuda.with.runner: ubuntu-22.04-m
+        - jobs.build-and-test-packages-above-differential.with.runner: ubuntu-22.04-m
     clang-tidy-differential.yaml:
       updates:
         - on.workflow_call.inputs.runner.default: ubuntu-22.04-m


### PR DESCRIPTION
[runner for the job was changes in awf](https://github.com/tier4/autoware_universe/pull/2266/files), so we need to update our setting to keep the tier4 runner the same