### PR TITLE
fix(operation_mode_transition_manager): modify the engage condition

### DIFF
--- a/control/autoware_operation_mode_transition_manager/src/state.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.cpp
@@ -223,12 +223,6 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
   const auto & trajectory = input_data.trajectory.value();
   const auto & trajectory_follower_control_cmd = input_data.trajectory_follower_control_cmd.value();
   const auto & control_cmd = input_data.control_cmd.value();
-
-  if (!check_engage_condition_) {
-    setAllOk(debug_info_);
-    return true;
-  }
-
   const auto current_speed = kinematics.twist.twist.linear.x;
   const auto target_control_speed = control_cmd.longitudinal.velocity;
   const auto & param = engage_acceptable_param_;
@@ -240,6 +234,11 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
       "stationary.");
     debug_info_ = DebugInfo{};  // all false
     return false;
+  }
+
+  if (!check_engage_condition_) {
+    setAllOk(debug_info_);
+    return true;
   }
 
   if (trajectory.points.size() < 2) {


### PR DESCRIPTION
This PR will cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/11097 that fixes a problem.
When `check_engage_condition_` is set as `false`, `bool isModeChangeAvailable()` will return `true` before `enable_engage_on_driving_` is checked.

Here is the [ticket](https://tier4.atlassian.net/browse/RT0-38624)
For more details, please refer to this [thread](https://star4.slack.com/archives/C012LF6GV54/p1753755720858229?thread_ts=1751936472.561819&cid=C012LF6GV54).