### PR TITLE
fix(pointcloud_preprocessor): handle empty pointclouds in pickup_base (#11003)

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -296,9 +296,14 @@ if(BUILD_TESTING)
     test/test_concatenate_node_unit.cpp
   )
 
+  ament_add_gtest(test_pickup_based_voxel_grid_downsample_filter_node
+    test/test_pickup_based_voxel_grid_downsample_filter_node.cpp
+  )
+
   target_link_libraries(test_utilities pointcloud_preprocessor_filter)
   target_link_libraries(test_distortion_corrector_node pointcloud_preprocessor_filter)
   target_link_libraries(test_concatenate_node_unit pointcloud_preprocessor_filter)
+  target_link_libraries(test_pickup_based_voxel_grid_downsample_filter_node pointcloud_preprocessor_filter)
 
   add_ros_test(
     test/test_concatenate_node_component.py

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,6 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   // std::unordered_map<VoxelKey, size_t, VoxelKeyHash, VoxelKeyEqual> voxel_map;
   robin_hood::unordered_map<VoxelKey, size_t, VoxelKeyHash, VoxelKeyEqual> voxel_map;
 
-  if (input->data.empty()) return;
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;

--- a/sensing/autoware_pointcloud_preprocessor/test/test_pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -1,0 +1,164 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/pointcloud_preprocessor/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+class PickupBasedVoxelGridDownsampleFilterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    // Create node options with parameters
+    rclcpp::NodeOptions node_options;
+    node_options.append_parameter_override("voxel_size_x", 0.1);
+    node_options.append_parameter_override("voxel_size_y", 0.1);
+    node_options.append_parameter_override("voxel_size_z", 0.1);
+
+    // Create the filter node
+    filter_node_ = std::make_shared<
+      autoware::pointcloud_preprocessor::PickupBasedVoxelGridDownsampleFilterComponent>(
+      node_options);
+
+    // Create test node for publishing and subscribing
+    test_node_ = std::make_shared<rclcpp::Node>("test_node");
+
+    // Create publisher for input point cloud with appropriate QoS
+    input_publisher_ =
+      test_node_->create_publisher<sensor_msgs::msg::PointCloud2>("input", rclcpp::SensorDataQoS());
+
+    // Create subscriber for output point cloud with appropriate QoS
+    output_subscriber_ = test_node_->create_subscription<sensor_msgs::msg::PointCloud2>(
+      "output", rclcpp::SensorDataQoS(),
+      [this](const sensor_msgs::msg::PointCloud2::SharedPtr msg) {
+        received_output_ = true;
+        output_msg_ = *msg;
+      });
+
+    // Allow time for setup
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<autoware::pointcloud_preprocessor::PickupBasedVoxelGridDownsampleFilterComponent>
+    filter_node_;
+  std::shared_ptr<rclcpp::Node> test_node_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr input_publisher_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr output_subscriber_;
+
+  bool received_output_ = false;
+  sensor_msgs::msg::PointCloud2 output_msg_;
+};
+
+TEST_F(PickupBasedVoxelGridDownsampleFilterTest, TestPointCloudPublishing)
+{
+  // Create test point cloud
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  cloud.header.stamp = rclcpp::Clock().now();
+  cloud.height = 1;
+  cloud.is_dense = true;
+  cloud.is_bigendian = false;
+
+  // Create point cloud with x, y, z fields
+  sensor_msgs::PointCloud2Modifier modifier(cloud);
+  modifier.setPointCloud2Fields(
+    3, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+
+  // Add test points
+  modifier.resize(1);  // 3x1 grid of points
+
+  // Publish input point cloud
+  input_publisher_->publish(cloud);
+
+  // Spin nodes to process messages
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(5);
+
+  while (!received_output_ && (std::chrono::steady_clock::now() - start_time) < timeout) {
+    rclcpp::spin_some(filter_node_);
+    rclcpp::spin_some(test_node_);
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Check that output was received
+  EXPECT_TRUE(received_output_) << "Expected to receive output point cloud";
+
+  // Check output point cloud is same size as input
+  if (received_output_) {
+    EXPECT_EQ(output_msg_.height, cloud.height);
+    EXPECT_EQ(output_msg_.width, cloud.width);
+    EXPECT_EQ(output_msg_.data.size(), cloud.data.size());
+  }
+}
+
+TEST_F(PickupBasedVoxelGridDownsampleFilterTest, TestEmptyPointCloudPublishing)
+{
+  // Create empty point cloud
+  sensor_msgs::msg::PointCloud2 empty_cloud;
+  empty_cloud.header.frame_id = "base_link";
+  empty_cloud.header.stamp = rclcpp::Clock().now();
+  empty_cloud.height = 1;
+  empty_cloud.width = 0;
+  empty_cloud.is_dense = true;
+  empty_cloud.is_bigendian = false;
+
+  // Create point cloud with x, y, z fields but no data
+  sensor_msgs::PointCloud2Modifier modifier(empty_cloud);
+  modifier.setPointCloud2Fields(
+    3, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+
+  // Don't add any points - keep it empty
+  modifier.resize(0);
+
+  // Reset the received flag
+  received_output_ = false;
+
+  // Publish empty point cloud
+  input_publisher_->publish(empty_cloud);
+
+  // Spin nodes to process messages
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(5);
+
+  while (!received_output_ && (std::chrono::steady_clock::now() - start_time) < timeout) {
+    rclcpp::spin_some(filter_node_);
+    rclcpp::spin_some(test_node_);
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Check that output was received
+  EXPECT_TRUE(received_output_) << "Expected to receive empty output point cloud";
+
+  // Check output point cloud is same size as input
+  if (received_output_) {
+    EXPECT_EQ(output_msg_.height, empty_cloud.height);
+    EXPECT_EQ(output_msg_.width, empty_cloud.width);
+    EXPECT_EQ(output_msg_.data.size(), empty_cloud.data.size());
+  }
+}


### PR DESCRIPTION
## Descritpion

* cherry-pick of https://github.com/autowarefoundation/autoware_universe/pull/11003

## Original PR description
> ## Description
> 
> The `pickup_based_downsample_filter` currently fails to publish an output when it receives an empty pointcloud.
> 
> The expected behavior is to publish an empty pointcloud when the input is also empty. This PR fixes the node to ensure this behavior.
> 
> To verify the fix, I've added integration tests for both single-point and empty pointclouds.
> 
> **Note:** These integration tests are time-consuming. I plan to replace them with faster unit tests for the `filter()` function in a future PR.
> 
> 
> ## Related links
> 
> **Private Links:**
> 
> - [TIER IV internal link](https://tier4.atlassian.net/browse/RT2-2536)

