### PR TITLE
feat(boundary_departure): configurable departure points and type base…

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
@@ -171,7 +171,8 @@ public:
   tl::expected<std::vector<ClosestProjectionToBound>, std::string>
   get_closest_projections_to_boundaries_side(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-    const Abnormalities<ProjectionsToBound> & projections_to_bound, const SideKey side_key);
+    const Abnormalities<ProjectionsToBound> & projections_to_bound, const double min_braking_dist,
+    const double max_braking_dist, const SideKey side_key);
 
   /**
    * @brief Select the closest projections to boundaries for both sides based on all abnormality
@@ -188,7 +189,8 @@ public:
    */
   tl::expected<ClosestProjectionsToBound, std::string> get_closest_projections_to_boundaries(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-    const Abnormalities<ProjectionsToBound> & projections_to_bound);
+    const Abnormalities<ProjectionsToBound> & projections_to_bound, const double curr_vel,
+    const double curr_acc);
 
   /**
    * @brief Generate filtered departure points for both left and right sides.

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -103,6 +103,7 @@ struct ProjectionToBound
   Segment2d nearest_bound_seg;
   double lat_dist{std::numeric_limits<double>::max()};
   size_t ego_sides_idx{0};
+  double time_from_start{std::numeric_limits<double>::max()};
   ProjectionToBound() = default;
   explicit ProjectionToBound(size_t idx) : ego_sides_idx(idx) {}
   ProjectionToBound(

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -136,6 +136,9 @@ struct Param
   int th_max_lateral_query_num{5};
   double th_dist_hysteresis_m{1.0};
   double footprint_extra_margin{0.0};
+  double th_cutoff_time_predicted_path_s{4.0};
+  double th_cutoff_time_departure_s{2.0};
+  double th_cutoff_time_near_boundary_s{3.5};
   AbnormalitiesConfigs abnormality_configs;
   std::vector<std::string> boundary_types_to_detect;
   std::vector<AbnormalityType> abnormality_types_to_compensate;

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -74,6 +74,9 @@ tl::expected<AbnormalitiesData, std::string> BoundaryDepartureChecker::get_abnor
     return tl::make_unexpected("trajectory too short");
   }
 
+  const auto trimmed_pred_traj =
+    utils::trim_pred_path(predicted_traj, param_ptr_->th_cutoff_time_predicted_path_s);
+
   const auto uncertainty_fp_margin =
     utils::calc_margin_from_covariance(curr_pose_with_cov, param_ptr_->footprint_extra_margin);
 
@@ -81,8 +84,8 @@ tl::expected<AbnormalitiesData, std::string> BoundaryDepartureChecker::get_abnor
   for (const auto abnormality_type : param_ptr_->abnormality_types_to_compensate) {
     auto & fps = abnormalities_data.footprints[abnormality_type];
     fps = utils::create_ego_footprints(
-      abnormality_type, uncertainty_fp_margin, predicted_traj, current_steering, *vehicle_info_ptr_,
-      *param_ptr_);
+      abnormality_type, uncertainty_fp_margin, trimmed_pred_traj, current_steering,
+      *vehicle_info_ptr_, *param_ptr_);
 
     abnormalities_data.footprints_sides[abnormality_type] = utils::get_sides_from_footprints(fps);
   }
@@ -99,7 +102,8 @@ tl::expected<AbnormalitiesData, std::string> BoundaryDepartureChecker::get_abnor
   for (const auto abnormality_type : param_ptr_->abnormality_types_to_compensate) {
     auto & proj_to_bound = abnormalities_data.projections_to_bound[abnormality_type];
     proj_to_bound = utils::get_closest_boundary_segments_from_side(
-      abnormalities_data.boundary_segments, abnormalities_data.footprints_sides[abnormality_type]);
+      trimmed_pred_traj, abnormalities_data.boundary_segments,
+      abnormalities_data.footprints_sides[abnormality_type]);
   }
   return abnormalities_data;
 }
@@ -169,7 +173,8 @@ BoundaryDepartureChecker::get_boundary_segments_from_side(
 tl::expected<std::vector<ClosestProjectionToBound>, std::string>
 BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const Abnormalities<ProjectionsToBound> & projections_to_bound, const SideKey side_key)
+  const Abnormalities<ProjectionsToBound> & projections_to_bound, const double min_braking_dist,
+  const double max_braking_dist, const SideKey side_key)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -223,10 +228,18 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
         continue;
       }
 
+      const auto create_min_pt =
+        [](const auto pt, const auto dpt_type, const auto abnormality_type) {
+          std::unique_ptr<ClosestProjectionToBound> min_pt =
+            std::make_unique<ClosestProjectionToBound>(pt);
+          min_pt->departure_type = dpt_type;
+          min_pt->abnormality_type = abnormality_type;
+          min_pt->time_from_start = pt.time_from_start;
+          return min_pt;
+        };
+
       if (abnormality_type == AbnormalityType::NORMAL && is_on_bound(pt.lat_dist, side_key)) {
-        min_pt = std::make_unique<ClosestProjectionToBound>(pt);
-        min_pt->departure_type = DepartureType::CRITICAL_DEPARTURE;
-        min_pt->abnormality_type = abnormality_type;
+        min_pt = create_min_pt(pt, DepartureType::CRITICAL_DEPARTURE, abnormality_type);
         break;
       }
 
@@ -235,9 +248,7 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
       }
 
       if (!min_pt || pt.lat_dist < min_pt->lat_dist) {
-        min_pt = std::make_unique<ClosestProjectionToBound>(pt);
-        min_pt->departure_type = DepartureType::NEAR_BOUNDARY;
-        min_pt->abnormality_type = abnormality_type;
+        min_pt = create_min_pt(pt, DepartureType::NEAR_BOUNDARY, abnormality_type);
       }
     }
     if (!min_pt) {
@@ -251,6 +262,25 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
     }
     min_pt->lon_dist_on_ref_traj =
       trajectory::closest(aw_ref_traj, utils::to_geom_pt(min_pt->pt_on_ego));
+
+    const auto is_exceeding_cutoff =
+      [&min_pt](const auto type, const auto braking_dist, const auto cutoff_time) {
+        return min_pt->departure_type == type && min_pt->lon_dist_on_ref_traj > braking_dist &&
+               min_pt->time_from_start > cutoff_time;
+      };
+
+    if (is_exceeding_cutoff(
+          DepartureType::NEAR_BOUNDARY, max_braking_dist,
+          param_ptr_->th_cutoff_time_near_boundary_s)) {
+      continue;
+    }
+
+    if (is_exceeding_cutoff(
+          DepartureType::CRITICAL_DEPARTURE, min_braking_dist,
+          param_ptr_->th_cutoff_time_departure_s)) {
+      min_pt->departure_type = DepartureType::APPROACHING_DEPARTURE;
+    }
+
     min_to_bound.push_back(*min_pt);
     if (min_to_bound.back().departure_type == DepartureType::CRITICAL_DEPARTURE) {
       break;
@@ -262,15 +292,23 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
 tl::expected<ClosestProjectionsToBound, std::string>
 BoundaryDepartureChecker::get_closest_projections_to_boundaries(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const Abnormalities<ProjectionsToBound> & projections_to_bound)
+  const Abnormalities<ProjectionsToBound> & projections_to_bound, const double curr_vel,
+  const double curr_acc)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto & th_trigger = param_ptr_->th_trigger;
+  const auto min_braking_dist = utils::calc_judge_line_dist_with_jerk_limit(
+    curr_vel, curr_acc, th_trigger.th_acc_mps2.max, th_trigger.th_jerk_mps3.max,
+    th_trigger.brake_delay_s);
+  const auto max_braking_dist = utils::calc_judge_line_dist_with_jerk_limit(
+    curr_vel, curr_acc, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.min,
+    th_trigger.brake_delay_s);
 
   ClosestProjectionsToBound min_to_bound;
 
   for (const auto side_key : g_side_keys) {
-    const auto min_to_bound_opt =
-      get_closest_projections_to_boundaries_side(aw_ref_traj, projections_to_bound, side_key);
+    const auto min_to_bound_opt = get_closest_projections_to_boundaries_side(
+      aw_ref_traj, projections_to_bound, min_braking_dist, max_braking_dist, side_key);
 
     if (!min_to_bound_opt) {
       return tl::make_unexpected(min_to_bound_opt.error());
@@ -281,19 +319,15 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
       continue;
     }
 
+    if (min_to_bound[side_key].back().departure_type != DepartureType::CRITICAL_DEPARTURE) {
+      continue;
+    }
+
     for (auto itr = std::next(min_to_bound[side_key].rbegin());
          itr != min_to_bound[side_key].rend(); ++itr) {
-      const auto & th_trigger = param_ptr_->th_trigger;
-      const auto v_init = th_trigger.th_vel_mps.min;
-      constexpr auto v_end = 0.0;
-      const auto acc = th_trigger.th_acc_mps2.min;
-      const auto jerk = th_trigger.th_jerk_mps3.max;
-      const auto braking_delay = th_trigger.brake_delay_s;
-      const auto braking_dist =
-        utils::compute_braking_distance(v_init, v_end, acc, jerk, braking_delay);
       if (
         min_to_bound[side_key].back().lon_dist_on_ref_traj - itr->lon_dist_on_ref_traj <
-        braking_dist) {
+        max_braking_dist) {
         itr->departure_type = DepartureType::APPROACHING_DEPARTURE;
       }
     }

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -588,14 +588,15 @@ ProjectionToBound find_closest_segment(
 }
 
 ProjectionsToBound get_closest_boundary_segments_from_side(
-  const BoundarySideWithIdx & boundaries, const EgoSides & ego_sides_from_footprints)
+  const TrajectoryPoints & ego_pred_traj, const BoundarySideWithIdx & boundaries,
+  const EgoSides & ego_sides_from_footprints)
 {
   ProjectionsToBound side;
   for (const auto & side_key : g_side_keys) {
     side[side_key].reserve(ego_sides_from_footprints.size());
   }
 
-  for (size_t i = 0; i < ego_sides_from_footprints.size(); ++i) {
+  for (size_t i = 0; i < ego_pred_traj.size(); ++i) {
     const auto & fp = ego_sides_from_footprints[i];
 
     const auto & ego_lb = fp.left.second;
@@ -604,8 +605,8 @@ ProjectionsToBound get_closest_boundary_segments_from_side(
     const auto rear_seg = Segment2d(ego_lb, ego_rb);
 
     for (const auto & side_key : g_side_keys) {
-      const auto closest_bound =
-        find_closest_segment(fp[side_key], rear_seg, i, boundaries[side_key]);
+      auto closest_bound = find_closest_segment(fp[side_key], rear_seg, i, boundaries[side_key]);
+      closest_bound.time_from_start = rclcpp::Duration(ego_pred_traj[i].time_from_start).seconds();
       side[side_key].push_back(closest_bound);
     }
   }
@@ -688,5 +689,51 @@ tl::expected<std::vector<lanelet::LineString3d>, std::string> get_uncrossable_li
   }
 
   return nearby_linestrings;
+}
+
+TrajectoryPoints trim_pred_path(const TrajectoryPoints & ego_pred_traj, const double cutoff_time_s)
+{
+  TrajectoryPoints trimmed_traj;
+  trimmed_traj.reserve(ego_pred_traj.size());
+  for (const auto & p : ego_pred_traj) {
+    trimmed_traj.push_back(p);
+    if (rclcpp::Duration(p.time_from_start).seconds() > cutoff_time_s) {
+      break;
+    }
+  }
+  return trimmed_traj;
+}
+
+// copied form core/mvp_common. will removed once this function is moved to motion_utils
+double calc_judge_line_dist_with_jerk_limit(
+  const double velocity, const double acceleration, const double max_stop_acceleration,
+  const double max_stop_jerk, const double delay_response_time)
+{
+  if (velocity <= 0.0) {
+    return 0.0;
+  }
+
+  const double t1 = delay_response_time;
+  const double x1 = velocity * t1;
+
+  const double v2 = velocity + (std::pow(max_stop_acceleration, 2) - std::pow(acceleration, 2)) /
+                                 (2.0 * max_stop_jerk);
+
+  if (v2 <= 0.0) {
+    const double t2 = -1.0 *
+                      (max_stop_acceleration +
+                       std::sqrt(acceleration * acceleration - 2.0 * max_stop_jerk * velocity)) /
+                      max_stop_jerk;
+    const double x2 =
+      velocity * t2 + acceleration * std::pow(t2, 2) / 2.0 + max_stop_jerk * std::pow(t2, 3) / 6.0;
+    return std::max(0.0, x1 + x2);
+  }
+
+  const double t2 = (max_stop_acceleration - acceleration) / max_stop_jerk;
+  const double x2 =
+    velocity * t2 + acceleration * std::pow(t2, 2) / 2.0 + max_stop_jerk * std::pow(t2, 3) / 6.0;
+
+  const double x3 = -1.0 * std::pow(v2, 2) / (2.0 * max_stop_acceleration);
+  return std::max(0.0, x1 + x2 + x3);
 }
 }  // namespace autoware::boundary_departure_checker::utils

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
@@ -9,6 +9,14 @@
         angle_deg: 5.0
         goal_dist_m: 1.0
 
+      th_cutoff_time_s:
+        predicted_path: 3.5
+        near_boundary: 3.5
+        departure: 2.0
+
+      on_time_buffer_s: 0.15
+      off_time_buffer_s: 0.15
+
       abnormality:
         normal:
           enable: true

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
@@ -48,6 +48,41 @@
           "additionalProperties": false
         },
 
+        "th_cutoff_time_s": {
+          "type": "object",
+          "properties": {
+            "predicted_path": {
+              "type": "number",
+              "description": "Cutoff time to consider from predicted path [s].",
+              "default": 3.5
+            },
+            "near_boundary": {
+              "type": "number",
+              "description": "Cutoff time to consider departure point as near boundary type [s].",
+              "default": 3.5
+            },
+            "departure": {
+              "type": "number",
+              "description": "Cutoff time to consider departure point as critical departure type, anything more than is considered approaching departure [s].",
+              "default": 2.0
+            }
+          },
+          "required": ["predicted_path", "near_boundary", "departure"],
+          "additionalProperties": false
+        },
+
+        "on_time_buffer_s": {
+          "type": "number",
+          "description": "Continuous detection time threshold to insert departure point into departure interval. [s]",
+          "default": 0.15
+        },
+
+        "off_time_buffer_s": {
+          "type": "number",
+          "description": "Continuous detection time threshold to reset departure interval. [s]",
+          "default": 0.15
+        },
+
         "abnormality": {
           "type": "object",
           "properties": {
@@ -352,6 +387,9 @@
         "th_max_lateral_query_num",
         "th_dist_hysteresis_m",
         "th_pt_shift",
+        "th_cutoff_time_s",
+        "on_time_buffer_s",
+        "off_time_buffer_s",
         "abnormality",
         "diagnostic",
         "slow_down_behavior"

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -81,6 +81,9 @@ private:
   LaneletRoute::ConstSharedPtr route_ptr_;
   std::unordered_map<std::string, double> processing_times_ms_;
 
+  std::unique_ptr<double> last_lost_time_ptr_;
+  std::unique_ptr<double> last_found_time_ptr_;
+
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr ego_pred_traj_polling_sub_;
   autoware_utils::InterProcessPollingSubscriber<Control>::SharedPtr control_cmd_polling_sub_;
   autoware_utils::InterProcessPollingSubscriber<SteeringReport>::SharedPtr

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -57,6 +57,8 @@ struct NodeParam
   double th_pt_shift_dist_m{1.0};
   double th_pt_shift_angle_rad{autoware_utils_math::deg2rad(2.0)};
   double th_goal_shift_dist_m{1.0};
+  double on_time_buffer_s{0.1};
+  double off_time_buffer_s{0.1};
   BDCParam bdc_param;
   std::unordered_set<DepartureType> slow_down_types;
   std::unordered_map<DepartureType, int8_t> diagnostic_level;
@@ -76,8 +78,16 @@ struct NodeParam
     th_goal_shift_dist_m =
       get_or_declare_parameter<double>(node, module_name + "th_pt_shift.goal_dist_m");
 
+    bdc_param.th_cutoff_time_predicted_path_s =
+      get_or_declare_parameter<double>(node, module_name + "th_cutoff_time_s.predicted_path");
+    bdc_param.th_cutoff_time_near_boundary_s =
+      get_or_declare_parameter<double>(node, module_name + "th_cutoff_time_s.near_boundary");
+    bdc_param.th_cutoff_time_departure_s =
+      get_or_declare_parameter<double>(node, module_name + "th_cutoff_time_s.departure");
+
     bdc_param.th_max_lateral_query_num =
       get_or_declare_parameter<int>(node, module_name + "th_max_lateral_query_num");
+
     std::invoke([&node, &module_name, this]() {
       const std::string ns_abnormality{module_name + "abnormality."};
       const std::string ns_normal_abnormality{ns_abnormality + "normal."};

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -21,6 +21,8 @@
 #include <tf2/convert.hpp>
 
 #include <algorithm>
+#include <limits>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -156,8 +158,6 @@ void check_departure_points_between_intervals(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double vehicle_length_m,
   const SideKey side_key, const std::unordered_set<DepartureType> & enable_type)
 {
-  // check if departure point is in between any intervals.
-  // if close to end pose, update end pose.
   for (auto & departure_interval : departure_intervals) {
     if (departure_interval.side_key != side_key) {
       continue;
@@ -195,16 +195,26 @@ void update_departure_intervals(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double vehicle_length_m,
   const TrajectoryPoint & ref_traj_fr_pt, const double ego_dist_from_traj_front,
   const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad,
-  const std::unordered_set<DepartureType> & enable_type)
+  const std::unordered_set<DepartureType> & enable_type, const bool is_reset_interval,
+  const bool is_departure_persist)
 {
   update_departure_intervals_poses(
     departure_intervals, aw_ref_traj, ref_traj_fr_pt, ego_dist_from_traj_front, th_pt_shift_dist_m,
     th_pt_shift_angle_rad);
 
   for (const auto side_key : g_side_keys) {
-    check_departure_points_between_intervals(
-      departure_intervals, departure_points[side_key], aw_ref_traj, vehicle_length_m, side_key,
-      enable_type);
+    if (is_reset_interval) {
+      utils::remove_if(departure_intervals, [&](const DepartureInterval & interval) {
+        return interval.side_key == side_key;
+      });
+      continue;
+    }
+
+    if (is_departure_persist) {
+      check_departure_points_between_intervals(
+        departure_intervals, departure_points[side_key], aw_ref_traj, vehicle_length_m, side_key,
+        enable_type);
+    }
   }
 
   if (!departure_intervals.empty()) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -138,14 +138,18 @@ DepartureIntervals init_departure_intervals(
  * @param[in] ego_dist_from_traj_front Ego’s current distance along the trajectory.
  * @param[in] th_pt_shift_dist_m Threshold distance for detecting shifted points.
  * @param[in] th_pt_shift_angle_rad Threshold angle for detecting shifted points.
+ * @param[in] enable_type Set of enabled departure types to consider for intervals.
  * @param[in] enable_type Enabled departure types.
+ * @param[in] is_reset_interval Flags to reset departure intervals if no departure point found.
+ * @param[in] is_departure_persist Checks to insert departure point to departure intervals.
  */
 void update_departure_intervals(
   DepartureIntervals & departure_intervals, Side<DeparturePoints> & departure_points,
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double vehicle_length_m,
   const TrajectoryPoint & ref_traj_fr_pt, const double ego_dist_from_traj_front,
   const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad,
-  const std::unordered_set<DepartureType> & enable_type);
+  const std::unordered_set<DepartureType> & enable_type, const bool is_reset_interval,
+  const bool is_departure_persist);
 
 /**
  * @brief Refresh and add critical departure points based on updated trajectory.


### PR DESCRIPTION
Currently ego's predicted path is used as is, and all departure points and critical departure points are accepted as is. This has caused a lot of false positive to occur especially when path chatters.

This PR provides two configurable option:

1. Trim ego points and update departure type based on cutoff time.
2. add hysteresis (on_time_buffer and off_time_buffer) as countermeasure to chattering predicted path.

Launcher: https://github.com/tier4/autoware_launch/pull/1056


---------------



…d on time (#11073)

* feat(boundary_departure): configurable departure points and type based on time



* Update planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp




* move out is_departure_persist



* cutoff time based on decel



* refactoring



* refactoring



---------