### PR TITLE
feat(autoware_system_monitor): publish msgs for system_monitor API 

### DIFF
--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
@@ -57,6 +57,11 @@ protected:
     diagnostic_updater::DiagnosticStatusWrapper & stat) override;  // NOLINT(runtime/references)
 
   /**
+   * @brief Get CPU thermal throttling status
+   */
+  int getThermalThrottlingStatus() const override;
+
+  /**
    * @brief get names for core temperature files
    */
   void getTemperatureFileNames() override;

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
@@ -82,6 +82,11 @@ protected:
   void updateThermalThrottlingImpl(
     diagnostic_updater::DiagnosticStatusWrapper & stat) override;  // NOLINT(runtime/references)
 
+  /**
+   * @brief Get CPU thermal throttling status
+   */
+  int getThermalThrottlingStatus() const override;
+
   // The format of Thermal Throttling report depends on CPU model.
   // So, Thermal Throttling report is implemented in derived class.
 

--- a/system/autoware_system_monitor/include/system_monitor/gpu_monitor/nvml_gpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/gpu_monitor/nvml_gpu_monitor.hpp
@@ -64,13 +64,18 @@ public:
   explicit GPUMonitor(const rclcpp::NodeOptions & options);
 
   /**
+   * @brief destructor
+   */
+  ~GPUMonitor() override;
+
+protected:
+  /**
    * @brief Terminate the node, log final statements. An independent function is preferred to allow
    * an explicit way to operate actions that require a valid rclcpp context. By default this method
    * does nothing.
    */
   void shut_down() override;
 
-protected:
   /**
    * @brief check GPU temperature
    * @param [out] stat diagnostic message passed directly to diagnostic publish calls
@@ -133,6 +138,12 @@ protected:
    */
   void checkFrequency(
     diagnostic_updater::DiagnosticStatusWrapper & stat) override;  // NOLINT(runtime/references)
+
+  /**
+   * @brief get GPU status
+   * @return GPU status list
+   */
+  std::vector<GpuStatus> getGPUStatus() const override;
 
   /**
    * @brief get supported GPU clocks

--- a/system/autoware_system_monitor/include/system_monitor/mem_monitor/mem_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/mem_monitor/mem_monitor.hpp
@@ -22,6 +22,8 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
+#include <tier4_external_api_msgs/msg/memory_status.hpp>
+
 #include <climits>
 #include <map>
 #include <string>
@@ -65,11 +67,20 @@ protected:
    */
   std::string toHumanReadable(const std::string & str);
 
+  /**
+   * @brief publish memory status
+   * @param [in] usage memory usage
+   */
+  void publishMemoryStatus(float usage);
+
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
 
   char hostname_[HOST_NAME_MAX + 1];  //!< @brief host name
 
   size_t available_size_;  //!< @brief Memory available size to generate error
+
+  rclcpp::Publisher<tier4_external_api_msgs::msg::MemoryStatus>::SharedPtr
+    pub_memory_status_;  //!< @brief publisher
 
   /**
    * @brief Memory usage status messages

--- a/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
@@ -25,6 +25,9 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
+#include <tier4_external_api_msgs/msg/network_interface_status.hpp>
+#include <tier4_external_api_msgs/msg/network_status.hpp>
+
 #include <boost/asio.hpp>
 
 #include <climits>
@@ -366,8 +369,16 @@ protected:
    */
   void close_connection();
 
+  /**
+   * @brief publish Network status
+   */
+  void publishNetworkStatus();
+
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
   rclcpp::TimerBase::SharedPtr timer_;   //!< @brief timer to get Network information
+
+  rclcpp::Publisher<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr
+    pub_network_status_;  //!< @brief publisher
 
   char hostname_[HOST_NAME_MAX + 1];             //!< @brief host name
   std::map<std::string, Bytes> bytes_;           //!< @brief list of bytes

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -102,6 +102,9 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   pub_cpu_usage_ =
     this->create_publisher<tier4_external_api_msgs::msg::CpuUsage>("~/cpu_usage", durable_qos);
 
+  pub_cpu_temperature_ = this->create_publisher<tier4_external_api_msgs::msg::CpuTemperature>(
+    "~/cpu_temperature", durable_qos);
+
   using namespace std::literals::chrono_literals;
   // Start timer for collecting cpu statistics
   timer_callback_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -462,6 +465,13 @@ void CPUMonitorBase::updateThermalThrottlingImpl(
     this->get_logger(), "CPUMonitorBase::checkThermalThrottlingImpl not implemented.");
 }
 
+int CPUMonitorBase::getThermalThrottlingStatus() const
+{
+  RCLCPP_INFO_ONCE(
+    this->get_logger(), "CPUMonitorBase::getThermalThrottlingStatus not implemented.");
+  return DiagStatus::OK;
+}
+
 void CPUMonitorBase::checkFrequency()
 {
   // Remember start time to measure elapsed time
@@ -585,6 +595,25 @@ void CPUMonitorBase::publishCpuUsage(tier4_external_api_msgs::msg::CpuUsage usag
   pub_cpu_usage_->publish(usage);
 }
 
+void CPUMonitorBase::publishCpuTemperature()
+{
+  using tier4_external_api_msgs::msg::CpuTemperature;
+  CpuTemperature cpu_temperature;
+  cpu_temperature.stamp = this->now();
+  cpu_temperature.hostname = hostname_;
+  {
+    std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+    if (!temperature_data_.core_data.empty()) {
+      cpu_temperature.temperature = temperature_data_.core_data[0].temperature;
+    }
+  }
+  int thermal_throttling = getThermalThrottlingStatus();
+  cpu_temperature.thermal_throttling = (thermal_throttling == DiagStatus::OK)
+                                         ? CpuTemperature::THERMAL_THROTTLING_OFF
+                                         : CpuTemperature::THERMAL_THROTTLING_ON;
+  pub_cpu_temperature_->publish(cpu_temperature);
+}
+
 void CPUMonitorBase::onTimer()
 {
   checkTemperature();
@@ -592,4 +621,6 @@ void CPUMonitorBase::onTimer()
   checkLoad();
   checkFrequency();
   checkThermalThrottling();
+
+  publishCpuTemperature();
 }

--- a/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
@@ -210,6 +210,12 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
+int CPUMonitor::getThermalThrottlingStatus() const
+{
+  std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+  return thermal_throttling_data_.summary_status;
+}
+
 // This function is called from a locked context in the timer callback.
 void CPUMonitor::getTemperatureFileNames()
 {

--- a/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
@@ -105,6 +105,12 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
+int CPUMonitor::getThermalThrottlingStatus() const
+{
+  std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+  return thermal_throttling_data_.summary_status;
+}
+
 // This function is called from a locked context in the timer callback.
 void CPUMonitor::getTemperatureFileNames()
 {

--- a/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -78,6 +78,11 @@ GPUMonitor::GPUMonitor(const rclcpp::NodeOptions & options) : GPUMonitorBase("gp
   }
 }
 
+GPUMonitor::~GPUMonitor()
+{
+  shut_down();
+}
+
 void GPUMonitor::shut_down()
 {
   nvmlReturn_t ret = nvmlShutdown();
@@ -445,6 +450,66 @@ void GPUMonitor::checkFrequency(diagnostic_updater::DiagnosticStatusWrapper & st
 
   // Measure elapsed time since start time and report
   SystemMonitorUtility::stopMeasurement(t_start, stat);
+}
+
+std::vector<GPUMonitorBase::GpuStatus> GPUMonitor::getGPUStatus() const
+{
+  std::vector<GpuStatus> gpu_status_list;
+
+  int index = 0;
+  for (auto itr = gpus_.begin(); itr != gpus_.end(); ++itr, ++index) {
+    nvmlReturn_t ret{};
+    nvmlUtilization_t utilization;
+    ret = nvmlDeviceGetUtilizationRates(itr->device, &utilization);
+    if (ret != NVML_SUCCESS) {
+      continue;
+    }
+
+    unsigned int clock = 0;
+    ret = nvmlDeviceGetClockInfo(itr->device, NVML_CLOCK_GRAPHICS, &clock);
+    if (ret != NVML_SUCCESS) {
+      continue;
+    }
+
+    unsigned int temp = 0;
+    ret = nvmlDeviceGetTemperature(itr->device, NVML_TEMPERATURE_GPU, &temp);
+    if (ret != NVML_SUCCESS) {
+      continue;
+    }
+
+    unsigned long long clocksThrottleReasons = 0LL;  // NOLINT
+    ret = nvmlDeviceGetCurrentClocksThrottleReasons(itr->device, &clocksThrottleReasons);
+    if (ret != NVML_SUCCESS) {
+      continue;
+    }
+
+    int thermal_throttling = DiagStatus::OK;
+    while (clocksThrottleReasons) {
+      unsigned long long flag = clocksThrottleReasons & ((~clocksThrottleReasons) + 1);  // NOLINT
+      clocksThrottleReasons ^= flag;
+
+      switch (flag) {
+        case nvmlClocksThrottleReasonGpuIdle:
+        case nvmlClocksThrottleReasonApplicationsClocksSetting:
+        case nvmlClocksThrottleReasonSwPowerCap:
+          // we do not treat as error
+          break;
+        default:
+          thermal_throttling = DiagStatus::ERROR;
+          break;
+      }
+    }
+
+    GpuStatus gpu_status;
+    gpu_status.name = itr->name;
+    gpu_status.usage = static_cast<float>(utilization.gpu);
+    gpu_status.clock = static_cast<int>(clock);
+    gpu_status.temperature = static_cast<int>(temp);
+    gpu_status.thermal_throttling = thermal_throttling;
+    gpu_status_list.push_back(gpu_status);
+  }
+
+  return gpu_status_list;
 }
 
 bool GPUMonitor::getSupportedGPUClocks(

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -69,6 +69,12 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
   updater_.add("IP Packet Reassembles Failed", this, &NetMonitor::check_reassembles_failed);
   updater_.add("UDP Buf Errors", this, &NetMonitor::check_udp_buf_errors);
 
+  // Publisher
+  rclcpp::QoS durable_qos{1};
+  durable_qos.transient_local();
+  pub_network_status_ = this->create_publisher<tier4_external_api_msgs::msg::NetworkStatus>(
+    "~/network_status", durable_qos);
+
   nl80211_.init();
 
   // Run I/O service processing loop
@@ -374,6 +380,7 @@ void NetMonitor::on_timer()
 {
   // Update list of network information
   update_network_list();
+  publishNetworkStatus();
 }
 
 void NetMonitor::shutdown_nl80211()
@@ -734,6 +741,44 @@ void NetMonitor::close_connection()
 {
   // Close socket
   socket_->close();
+}
+
+void NetMonitor::publishNetworkStatus()
+{
+  tier4_external_api_msgs::msg::NetworkStatus network_status;
+  network_status.stamp = this->now();
+  network_status.hostname = hostname_;
+
+  for (const auto & network : network_list_) {
+    // Skip if network is not supported
+    if (network.is_invalid) continue;
+
+    auto & interface_status = network_status.interfaces.emplace_back();
+    interface_status.name = network.interface_name;
+    interface_status.rx_traffic = network.rx_traffic;
+    interface_status.tx_traffic = network.tx_traffic;
+    interface_status.capacity = network.speed;
+    interface_status.rx_errors = network.rx_errors;
+    interface_status.tx_errors = network.tx_errors;
+    interface_status.collisions = network.collisions;
+  }
+
+  uint64_t total_errors = 0;
+  uint64_t unit_errors = 0;
+  NetSnmp::Result ret = reassembles_failed_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_ip_packet_reassembles_failed = unit_errors;
+  }
+  ret = udp_rcvbuf_errors_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_udp_buf_rx = unit_errors;
+  }
+  ret = udp_sndbuf_errors_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_udp_buf_tx = unit_errors;
+  }
+
+  pub_network_status_->publish(network_status);
 }
 
 NetSnmp::NetSnmp(rclcpp::Node * node)


### PR DESCRIPTION
## Description

Cherry-pick PR to beta/v0.48. This PR is expected to be included in X2 beta/v4.3.

Cherry-picking of the following PRs for Metrics collection

- https://github.com/autowarefoundation/autoware_universe/pull/11020
- https://github.com/autowarefoundation/autoware_universe/pull/11021
- https://github.com/autowarefoundation/autoware_universe/pull/11022
- https://github.com/autowarefoundation/autoware_universe/pull/11023
- https://github.com/autowarefoundation/autoware_universe/pull/11024


## Related links

This PR implements the contents of the following PRs that added the API (msg) and have been already merged.

- https://github.com/tier4/tier4_autoware_msgs/pull/192
- https://github.com/tier4/pilot-auto/pull/1698

### Private Links:

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38268)


## How was this PR tested?

- Running lsim with [beta/v0.48 ](https://github.com/tier4/pilot-auto/tree/beta/v0.48) with: 
  - autoware_universe: [cherry-pick/beta/v0.48+system_monitor_api](https://github.com/tier4/autoware_universe/tree/cherry-pick/beta/v0.48%2Bsystem_monitor_api)
  -  `launch_system_monitor:=true`
- Confirmed `/api/external/get/system_monitor` is published

```
ros2 topic echo /api/external/get/system_monitor
stamp:
  sec: 1585897285
  nanosec: 189880315
hostname: dpc2205002
cpu_temperature:
  stamp:
    sec: 1585897285
    nanosec: 189880315
  hostname: dpc2205002
  temperature: 60.0
  thermal_throttling: 1
memory_status:
  stamp:
    sec: 1585897285
    nanosec: 48099244
  hostname: dpc2205002
  usage: 20.946941375732422
gpu_status:
  stamp:
    sec: 1585897285
    nanosec: 7555326
  hostname: dpc2205002
  gpus: []
network_status:
  stamp:
    sec: 1585897285
    nanosec: 17687050
  hostname: dpc2205002
  interfaces:
  - name: lo
    rx_traffic: 2809.197265625
    tx_traffic: 2809.197265625
    capacity: -1.0
    rx_errors: 0
    tx_errors: 0
    collisions: 0
  - name: enp4s0
    rx_traffic: 0.014484170824289322
    tx_traffic: 0.004875780548900366
    capacity: 1000.0
    rx_errors: 0
    tx_errors: 0
    collisions: 0
  - name: docker0
    rx_traffic: 0.0
    tx_traffic: 0.0
    capacity: 65535.0
    rx_errors: 0
    tx_errors: 0
    collisions: 0
  error_ip_packet_reassembles_failed: 0
  error_udp_buf_rx: 0
  error_udp_buf_tx: 0
hdd_status:
  stamp:
    sec: 1585897285
    nanosec: 88705498
  hostname: dpc2205002
  devices:
  - name: /dev/nvme0n1
    read_data_rate: 0.0
    write_data_rate: 0.22304189205169678
    read_iops: 0.0
    write_iops: 21.65813636779785
  partitions:
  - size: 959827
    used: 384367
    avail: 526632
    capacity: 43
    filesystem: /dev/nvme0n1p2
    mounted_on: /

```
