### PR TITLE
fix(start_planner): incorrect function call (#11107)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1400,7 +1400,7 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
 
     // crop backward path
     const size_t start_segment_idx =
-      autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
         clothoid_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
         common_parameters.ego_nearest_yaw_threshold);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -128,7 +128,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(
     // narrow place.
 
     const size_t start_segment_idx =
-      autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
         shift_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
         common_parameters.ego_nearest_yaw_threshold);
 


### PR DESCRIPTION
## Descriptions
https://github.com/autowarefoundation/autoware_universe/pull/11107 のbackport

## Related Links
https://tier4.atlassian.net/browse/RT0-38657

## Tests Perfomed
[Evaluator](https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac_UttrHL4OoC4WIuemgshf6hsg1o5R9WUOmWrdYUFQJSM.4kDPeMvj9e9M1Z9rumPQvVkXoCevOyVOzYAEqNWtonw&scope=openid+profile+email+offline_access&state=b8b18b290489492dbaa09ea950e15068)
にて該当シナリオでyaw_deviationおよびlon_distance_deviationが発生して発進できないことがなくなったのを確認した
該当シナリオについてはRelated Links記載のチケットを参照してください

