### PR TITLE
feat: change planning output topic name to /planning/trajectory (#11135)

### DIFF
--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
@@ -66,7 +66,7 @@ struct LaneletRoute
 struct Trajectory
 {
   using Message = autoware_planning_msgs::msg::Trajectory;
-  static constexpr char name[] = "/planning/scenario_planning/trajectory";
+  static constexpr char name[] = "/planning/trajectory";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;

--- a/control/autoware_control_performance_analysis/README.md
+++ b/control/autoware_control_performance_analysis/README.md
@@ -25,13 +25,13 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 ### Input topics
 
-| Name                                     | Type                                       | Description                                 |
-| ---------------------------------------- | ------------------------------------------ | ------------------------------------------- |
-| `/planning/scenario_planning/trajectory` | autoware_planning_msgs::msg::Trajectory    | Output trajectory from planning module.     |
-| `/control/command/control_cmd`           | autoware_control_msgs::msg::Control        | Output control command from control module. |
-| `/vehicle/status/steering_status`        | autoware_vehicle_msgs::msg::SteeringReport | Steering information from vehicle.          |
-| `/localization/kinematic_state`          | nav_msgs::msg::Odometry                    | Use twist from odometry.                    |
-| `/tf`                                    | tf2_msgs::msg::TFMessage                   | Extract ego pose from tf.                   |
+| Name                              | Type                                       | Description                                 |
+| --------------------------------- | ------------------------------------------ | ------------------------------------------- |
+| `/planning/trajectory`            | autoware_planning_msgs::msg::Trajectory    | Output trajectory from planning module.     |
+| `/control/command/control_cmd`    | autoware_control_msgs::msg::Control        | Output control command from control module. |
+| `/vehicle/status/steering_status` | autoware_vehicle_msgs::msg::SteeringReport | Steering information from vehicle.          |
+| `/localization/kinematic_state`   | nav_msgs::msg::Odometry                    | Use twist from odometry.                    |
+| `/tf`                             | tf2_msgs::msg::TFMessage                   | Extract ego pose from tf.                   |
 
 ### Output topics
 

--- a/control/autoware_control_performance_analysis/launch/control_performance_analysis.launch.xml
+++ b/control/autoware_control_performance_analysis/launch/control_performance_analysis.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="control_performance_analysis_param_path" default="$(find-pkg-share autoware_control_performance_analysis)/config/control_performance_analysis.param.yaml"/>
-  <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/reference_trajectory" default="/planning/trajectory"/>
   <arg name="input/control_raw" default="/control/command/control_cmd"/>
   <arg name="input/measured_steering" default="/vehicle/status/steering_status"/>
   <arg name="input/current_odometry" default="/localization/kinematic_state"/>

--- a/control/autoware_control_validator/launch/control_validator.launch.xml
+++ b/control/autoware_control_validator/launch/control_validator.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="control_validator_param_path" default="$(find-pkg-share autoware_control_validator)/config/control_validator.param.yaml"/>
-  <arg name="input_reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input_reference_trajectory" default="/planning/trajectory"/>
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
   <arg name="input_operational_mode_state" default="/api/operation_mode/state"/>
 

--- a/control/autoware_lane_departure_checker/README.md
+++ b/control/autoware_lane_departure_checker/README.md
@@ -51,7 +51,7 @@ This package includes the following features:
 - /localization/kinematic_state [`nav_msgs::msg::Odometry`]
 - /map/vector_map [`autoware_map_msgs::msg::LaneletMapBin`]
 - /planning/mission_planning/route [`autoware_planning_msgs::msg::LaneletRoute`]
-- /planning/scenario_planning/trajectory [`autoware_planning_msgs::msg::Trajectory`]
+- /planning/trajectory [`autoware_planning_msgs::msg::Trajectory`]
 - /control/trajectory_follower/predicted_trajectory [`autoware_planning_msgs::msg::Trajectory`]
 
 ### Output

--- a/control/autoware_lane_departure_checker/launch/lane_departure_checker.launch.xml
+++ b/control/autoware_lane_departure_checker/launch/lane_departure_checker.launch.xml
@@ -2,7 +2,7 @@
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/lanelet_map_bin" default="/map/vector_map"/>
   <arg name="input/route" default="/planning/mission_planning/route"/>
-  <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/reference_trajectory" default="/planning/trajectory"/>
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory"/>
   <arg name="config_file" default="$(find-pkg-share autoware_lane_departure_checker)/config/lane_departure_checker.param.yaml"/>
 

--- a/control/autoware_obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
+++ b/control/autoware_obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="input/lanelet_map_bin" default="/map/vector_map"/>
   <arg name="input/obstacle_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
-  <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/reference_trajectory" default="/planning/trajectory"/>
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="config_file" default="$(find-pkg-share autoware_obstacle_collision_checker)/config/obstacle_collision_checker.param.yaml"/>

--- a/control/autoware_operation_mode_transition_manager/README.md
+++ b/control/autoware_operation_mode_transition_manager/README.md
@@ -60,7 +60,7 @@ For the transition availability/completion check:
 
 - /control/command/control_cmd [`autoware_control_msgs/msg/Control`]: vehicle control signal
 - /localization/kinematic_state [`nav_msgs/msg/Odometry`]: ego vehicle state
-- /planning/scenario_planning/trajectory [`autoware_planning_msgs/msg/Trajectory`]: planning trajectory
+- /planning/trajectory [`autoware_planning_msgs/msg/Trajectory`]: planning trajectory
 - /vehicle/status/control_mode [`autoware_vehicle_msgs/msg/ControlModeReport`]: vehicle control mode (autonomous/manual)
 - /control/vehicle_cmd_gate/operation_mode [`autoware_adapi_v1_msgs/msg/OperationModeState`]: the operation mode in the `vehicle_cmd_gate`. (To be removed)
 

--- a/control/autoware_operation_mode_transition_manager/launch/autonomous_mode_transition_flag_node.launch.xml
+++ b/control/autoware_operation_mode_transition_manager/launch/autonomous_mode_transition_flag_node.launch.xml
@@ -11,7 +11,7 @@
     <!-- rename input topics -->
     <remap from="kinematics" to="/localization/kinematic_state"/>
     <remap from="steering" to="/vehicle/status/steering_status"/>
-    <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+    <remap from="trajectory" to="/planning/trajectory"/>
     <remap from="control_cmd" to="/control/command/control_cmd"/>
     <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
     <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>

--- a/control/autoware_operation_mode_transition_manager/launch/operation_mode_transition_manager.launch.xml
+++ b/control/autoware_operation_mode_transition_manager/launch/operation_mode_transition_manager.launch.xml
@@ -11,7 +11,7 @@
     <!-- rename input topics -->
     <remap from="kinematics" to="/localization/kinematic_state"/>
     <remap from="steering" to="/vehicle/status/steering_status"/>
-    <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+    <remap from="trajectory" to="/planning/trajectory"/>
     <remap from="control_cmd" to="/control/command/control_cmd"/>
     <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
     <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>

--- a/control/autoware_predicted_path_checker/launch/predicted_path_checker.launch.xml
+++ b/control/autoware_predicted_path_checker/launch/predicted_path_checker.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
-  <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/reference_trajectory" default="/planning/trajectory"/>
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/current_accel" default="/localization/acceleration"/>

--- a/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
+++ b/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="pure_pursuit_param_path" default="$(find-pkg-share autoware_pure_pursuit)/config/pure_pursuit.param.yaml"/>
 
-  <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/reference_trajectory" default="/planning/trajectory"/>
   <arg name="input/current_odometry" default="/localization/kinematic_state"/>
   <arg name="output/control_raw" default="lateral/control_cmd"/>
 

--- a/control/autoware_smart_mpc_trajectory_follower/scripts/pympc_trajectory_follower.py
+++ b/control/autoware_smart_mpc_trajectory_follower/scripts/pympc_trajectory_follower.py
@@ -79,7 +79,7 @@ class PyMPCTrajectoryFollower(Node):
 
         self.sub_trajectory_ = self.create_subscription(
             Trajectory,
-            "/planning/scenario_planning/trajectory",
+            "/planning/trajectory",
             self.onTrajectory,
             1,
         )

--- a/control/autoware_trajectory_follower_node/launch/simple_trajectory_follower.launch.xml
+++ b/control/autoware_trajectory_follower_node/launch/simple_trajectory_follower.launch.xml
@@ -8,7 +8,7 @@
     <param from="$(find-pkg-share autoware_trajectory_follower_node)/config/simple_trajectory_follower.param.yaml" allow_substs="true"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>
-    <remap from="input/trajectory" to="/planning/scenario_planning/trajectory"/>
+    <remap from="input/trajectory" to="/planning/trajectory"/>
     <remap from="output/control_cmd" to="/vehicle/command/manual_control_cmd"/>
   </node>
 </launch>

--- a/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
+++ b/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
@@ -2,7 +2,7 @@
   <arg name="output_metrics" default="false"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/acceleration" default="/localization/acceleration"/>
-  <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/trajectory" default="/planning/trajectory"/>
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="input/route" default="/planning/mission_planning/route"/>
   <arg name="input/behavior_path" default="/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id"/>

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -3,7 +3,7 @@
   <arg name="output_metrics" default="false"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/acceleration" default="/localization/acceleration"/>
-  <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input/trajectory" default="/planning/trajectory"/>
   <arg name="input/reference_trajectory" default="/planning/scenario_planning/lane_driving/motion_planning/path_optimizer/trajectory"/>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
   <arg name="input/modified_goal" default="/planning/scenario_planning/modified_goal"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -138,7 +138,7 @@
           <!-- input -->
           <remap from="kinematics" to="/localization/kinematic_state"/>
           <remap from="steering" to="/vehicle/status/steering_status"/>
-          <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="trajectory" to="/planning/trajectory"/>
           <remap from="control_cmd" to="/control/command/control_cmd"/>
           <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
           <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
@@ -157,7 +157,7 @@
       <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
         <load_composable_node target="/control/control_container">
           <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
             <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
             <remap from="~/input/current_accel" to="/localization/acceleration"/>
@@ -215,7 +215,7 @@
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
             <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
             <remap from="~/input/route" to="/planning/mission_planning/route"/>
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <param from="$(var nearest_search_param_path)"/>
             <param from="$(var lane_departure_checker_param_path)"/>
@@ -233,7 +233,7 @@
             <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
             <remap from="~/input/operational_mode_state" to="/api/operation_mode/state"/>
             <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <remap from="~/output/validation_status" to="~/validation_status"/>
             <param from="$(var control_validator_param_path)"/>
@@ -275,7 +275,7 @@
           <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
             <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
             <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-            <remap from="input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <remap from="input/odometry" to="/localization/kinematic_state"/>
             <param from="$(var obstacle_collision_checker_param_path)"/>
@@ -290,7 +290,7 @@
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_predicted_path_checker" plugin="autoware::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
             <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="~/input/current_accel" to="/localization/acceleration"/>
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>

--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -39,7 +39,7 @@
       <include file="$(find-pkg-share autoware_planning_validator)/launch/planning_validator.launch.xml">
         <arg name="container_type" value="component_container_mt"/>
         <arg name="input_trajectory" value="/planning/scenario_planning/velocity_smoother/trajectory"/>
-        <arg name="output_trajectory" value="/planning/scenario_planning/trajectory"/>
+        <arg name="output_trajectory" value="/planning/trajectory"/>
         <arg name="planning_validator_param_path" value="$(var planning_validator_param_path)"/>
         <arg name="planning_validator_latency_checker_param_path" value="$(var planning_validator_latency_checker_param_path)"/>
         <arg name="planning_validator_trajectory_checker_param_path" value="$(var planning_validator_trajectory_checker_param_path)"/>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/optimization_based_planner.cpp
@@ -51,7 +51,7 @@ OptimizationBasedPlanner::OptimizationBasedPlanner(
 : CruisePlannerInterface(node, common_param, cruise_planning_param)
 {
   smoothed_traj_sub_ = node.create_subscription<Trajectory>(
-    "/planning/scenario_planning/trajectory", rclcpp::QoS{1},
+    "/planning/trajectory", rclcpp::QoS{1},
     [this](const Trajectory::ConstSharedPtr msg) { smoothed_trajectory_ptr_ = msg; });
 
   // parameter

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -36,7 +36,7 @@
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="input_route_topic_name" default="/planning/mission_planning/route"/>
   <arg name="input_vector_map_topic_name" default="/map/vector_map"/>
-  <arg name="output_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="output_trajectory" default="/planning/trajectory"/>
 
   <group>
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="planning_validator_container" namespace="" args="" output="both">

--- a/simulator/autoware_simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/autoware_simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -52,7 +52,7 @@ def launch_setup(context, *args, **kwargs):
         ("input/manual_gear_command", "/vehicle/command/manual_gear_command"),
         ("input/turn_indicators_command", "/control/command/turn_indicators_cmd"),
         ("input/hazard_lights_command", "/control/command/hazard_lights_cmd"),
-        ("input/trajectory", "/planning/scenario_planning/trajectory"),
+        ("input/trajectory", "/planning/trajectory"),
         ("input/engage", "/vehicle/engage"),
         ("input/control_mode_request", "/control/control_mode_request"),
         ("output/twist", "/vehicle/status/velocity_status"),

--- a/system/autoware_component_state_monitor/config/topics.yaml
+++ b/system/autoware_component_state_monitor/config/topics.yaml
@@ -107,7 +107,7 @@
   type: autonomous
   args:
     node_name_suffix: scenario_planning_trajectory
-    topic: /planning/scenario_planning/trajectory
+    topic: /planning/trajectory
     topic_type: autoware_planning_msgs/msg/Trajectory
     best_effort: false
     transient_local: false

--- a/tools/reaction_analyzer/param/reaction_analyzer.param.yaml
+++ b/tools/reaction_analyzer/param/reaction_analyzer.param.yaml
@@ -64,8 +64,8 @@
           time_debug_topic_name: /planning/scenario_planning/motion_velocity_smoother/trajectory/debug/published_time
           message_type: autoware_planning_msgs/msg/Trajectory
         planning_validator:
-          topic_name: /planning/scenario_planning/trajectory
-          time_debug_topic_name: /planning/scenario_planning/trajectory/debug/published_time
+          topic_name: /planning/trajectory
+          time_debug_topic_name: /planning/trajectory/debug/published_time
           message_type: autoware_planning_msgs/msg/Trajectory
         trajectory_follower:
           topic_name: /control/trajectory_follower/control_cmd


### PR DESCRIPTION
* change planning output topic name to /planning/trajectory

Cherry-pick from https://github.com/autowarefoundation/autoware_universe/pull/11135