### PR TITLE
fix(boundary_departure): refactor merge_departure_intervals function to avoid crashes #11129

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -244,7 +244,6 @@ struct DepartureInterval
   double end_dist_on_traj;
 
   bool start_at_traj_front{false};
-  bool has_merged{false};
 
   DeparturePoints candidates;
 };

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -15,6 +15,7 @@
 #include "utils.hpp"
 
 #include <autoware/boundary_departure_checker/conversion.hpp>
+#include <autoware/boundary_departure_checker/data_structs.hpp>
 #include <autoware/trajectory/utils/closest.hpp>
 #include <magic_enum.hpp>
 #include <range/v3/algorithm/sort.hpp>
@@ -24,8 +25,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <limits>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -81,7 +80,7 @@ DepartureIntervals init_departure_intervals(
         continue;
       }
 
-      const auto & prev = departure_points[idx_end - 1];
+      const auto & prev = interval.candidates.back();
       const auto diff = std::abs(curr.dist_on_traj - prev.dist_on_traj);
 
       if (diff >= vehicle_length_m) {
@@ -95,14 +94,12 @@ DepartureIntervals init_departure_intervals(
       continue;
     }
 
-    std::sort(interval.candidates.begin(), interval.candidates.end());
-
     interval.start_dist_on_traj = interval.candidates.front().dist_on_traj - vehicle_length_m;
     interval.start = aw_ref_traj.compute(interval.start_dist_on_traj);
     interval.end_dist_on_traj = interval.candidates.back().dist_on_traj;
     interval.end = aw_ref_traj.compute(interval.end_dist_on_traj);
     departure_intervals.push_back(interval);
-    idx = idx_end + 1;
+    idx = idx_end;
   }
   return departure_intervals;
 }
@@ -198,45 +195,43 @@ void check_departure_points_between_intervals(
   }
 }
 
-DepartureIntervals merge_departure_intervals(DepartureIntervals & departure_intervals)
+void merge_departure_intervals(DepartureIntervals & departure_intervals)
 {
   if (departure_intervals.size() <= 1) {
-    return departure_intervals;
+    return;
   }
+  std::sort(
+    departure_intervals.begin(), departure_intervals.end(),
+    [](const auto & a, const auto & b) { return a.start_dist_on_traj < b.start_dist_on_traj; });
+
   DepartureIntervals merged;
+  merged.reserve(departure_intervals.size());
   merged.push_back(departure_intervals.front());
 
-  for (size_t i = 1; i < departure_intervals.size(); ++i) {
-    auto & next_interval_mut = departure_intervals[i];
-    auto & curr_interval_mut = merged.back();
-    const auto is_same_direction = curr_interval_mut.side_key == next_interval_mut.side_key;
-    if (!is_same_direction) {
-      merged.push_back(next_interval_mut);
-    }
+  std::optional<DepartureInterval> last_merged_left;
+  std::optional<DepartureInterval> last_merged_right;
 
-    const auto is_end_in_between =
-      curr_interval_mut.start_dist_on_traj <= next_interval_mut.end_dist_on_traj &&
-      next_interval_mut.end_dist_on_traj <= curr_interval_mut.end_dist_on_traj;
-    const auto is_start_in_between =
-      curr_interval_mut.start_dist_on_traj <= next_interval_mut.start_dist_on_traj &&
-      next_interval_mut.start_dist_on_traj <= curr_interval_mut.end_dist_on_traj;
+  for (auto & current : departure_intervals) {
+    auto & last_merged = current.side_key == SideKey::LEFT ? last_merged_left : last_merged_right;
 
-    if (is_start_in_between && !is_end_in_between) {
-      curr_interval_mut.end = next_interval_mut.end;
-      curr_interval_mut.end_dist_on_traj = next_interval_mut.end_dist_on_traj;
-      next_interval_mut.has_merged = true;
-    } else if (!is_start_in_between && is_end_in_between) {
-      curr_interval_mut.start = next_interval_mut.start;
-      curr_interval_mut.start_dist_on_traj = next_interval_mut.start_dist_on_traj;
-      next_interval_mut.has_merged = true;
-    } else if (is_start_in_between && is_end_in_between) {
-      next_interval_mut.has_merged = true;
-    } else {
-      merged.push_back(next_interval_mut);
+    bool is_overlapping = last_merged &&
+                          (last_merged->end_dist_on_traj >= current.start_dist_on_traj) &&
+                          (last_merged->side_key == current.side_key);
+
+    if (is_overlapping) {  // extend the previous interval
+      if (current.end_dist_on_traj > last_merged->end_dist_on_traj) {
+        last_merged->end = current.end;
+        last_merged->end_dist_on_traj = current.end_dist_on_traj;
+      }
+      last_merged->candidates.insert(
+        last_merged->candidates.end(), current.candidates.begin(), current.candidates.end());
+    } else {  // start a new merged interval
+      merged.push_back(current);
+      last_merged = current;
     }
   }
 
-  return merged;
+  departure_intervals = std::move(merged);
 }
 
 void update_departure_intervals(
@@ -272,7 +267,7 @@ void update_departure_intervals(
     new_departure_intervals.begin(), new_departure_intervals.end(),
     std::back_inserter(departure_intervals));
 
-  departure_intervals = merge_departure_intervals(departure_intervals);
+  merge_departure_intervals(departure_intervals);
 }
 
 void update_critical_departure_points(


### PR DESCRIPTION
Simplify the merge_departure_intervals and make sure the intervals on a same side are properly merged.

*This PR solved boundary departure node dying issue.

https://github.com/autowarefoundation/autoware_universe/pull/11129