### PR TITLE
feat(control_command_gate): add lateral jerk limit for steering rate in control command filter

### DIFF
--- a/control/autoware_control_command_gate/config/default.param.yaml
+++ b/control/autoware_control_command_gate/config/default.param.yaml
@@ -25,6 +25,7 @@
       lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting.
       lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
       lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
+      lat_jerk_lim_for_steer_rate: 10.0
       actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]
     transition_filter:
       vel_lim: 50.0
@@ -35,4 +36,5 @@
       lon_jerk_lim: [0.5, 0.4]
       lat_acc_lim: [2.0, 1.8]
       lat_jerk_lim: [7.0, 6.0]
+      lat_jerk_lim_for_steer_rate: 10.0
       actual_steer_diff_lim: [1.0, 0.8]

--- a/control/autoware_control_command_gate/src/common/control_command_filter.cpp
+++ b/control/autoware_control_command_gate/src/common/control_command_filter.cpp
@@ -145,12 +145,29 @@ void VehicleCmdFilter::limitLateralSteerRate(const double dt, Control & input) c
 {
   const float steer_rate_limit = getSteerRateLim();
 
-  // for steering angle rate
-  input.lateral.steering_tire_rotation_rate =
-    std::clamp(input.lateral.steering_tire_rotation_rate, -steer_rate_limit, steer_rate_limit);
+  // Calculate maximum allowable steering rate based on lateral jerk constraint
+  // Using the formula: j_y = (1/L) * V^2 * (dθ/dt)
+  // Where:
+  // - j_y: lateral jerk
+  // - L: wheel base
+  // - V: longitudinal velocity
+  // - dθ/dt: steering angle rate of change
+  // Rearranging: dθ/dt = j_y * L / V^2
+  const double lat_jerk_lim_for_steer_rate = getLatJerkLimForSteerRate();
+  const double velocity_sq = std::max(current_speed_ * current_speed_, 0.001);
+  const double max_steer_rate_from_jerk =
+    lat_jerk_lim_for_steer_rate * param_.wheel_base / velocity_sq;
 
-  // for steering angle
-  const float steer_diff_limit = steer_rate_limit * dt;
+  // Apply the more restrictive limit between basic rate limit and lateral jerk constraint
+  const float effective_steer_rate_lim =
+    std::min(static_cast<double>(steer_rate_limit), max_steer_rate_from_jerk);
+
+  // Limit steering angle rate
+  input.lateral.steering_tire_rotation_rate = std::clamp(
+    input.lateral.steering_tire_rotation_rate, -effective_steer_rate_lim, effective_steer_rate_lim);
+
+  // Limit steering angle change
+  const float steer_diff_limit = effective_steer_rate_lim * dt;
   float ds = input.lateral.steering_tire_angle - prev_cmd_.lateral.steering_tire_angle;
   ds = std::clamp(ds, -steer_diff_limit, steer_diff_limit);
   input.lateral.steering_tire_angle = prev_cmd_.lateral.steering_tire_angle + ds;
@@ -275,6 +292,11 @@ double VehicleCmdFilter::getSteerRateLim() const
 double VehicleCmdFilter::getSteerDiffLim() const
 {
   return interpolateFromSpeed(param_.actual_steer_diff_lim);
+}
+
+double VehicleCmdFilter::getLatJerkLimForSteerRate() const
+{
+  return param_.lat_jerk_lim_for_steer_rate;
 }
 
 }  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/common/control_command_filter.hpp
+++ b/control/autoware_control_command_gate/src/common/control_command_filter.hpp
@@ -41,6 +41,7 @@ struct VehicleCmdFilterParam
   LimitArray steer_lim;
   LimitArray steer_rate_lim;
   LimitArray actual_steer_diff_lim;
+  double lat_jerk_lim_for_steer_rate;
 };
 
 class VehicleCmdFilter
@@ -89,6 +90,7 @@ private:
   double getSteerLim() const;
   double getSteerRateLim() const;
   double getSteerDiffLim() const;
+  double getLatJerkLimForSteerRate() const;
 };
 
 }  // namespace autoware::control_command_gate

--- a/control/autoware_control_command_gate/src/control_command_gate.cpp
+++ b/control/autoware_control_command_gate/src/control_command_gate.cpp
@@ -43,6 +43,7 @@ VehicleCmdFilterParam declare_filter_params(rclcpp::Node & node, const std::stri
   p.lat_acc_lim = node.declare_parameter<LimitArray>(ns + "lat_acc_lim");
   p.lat_jerk_lim = node.declare_parameter<LimitArray>(ns + "lat_jerk_lim");
   p.actual_steer_diff_lim = node.declare_parameter<LimitArray>(ns + "actual_steer_diff_lim");
+  p.lat_jerk_lim_for_steer_rate = node.declare_parameter<double>(ns + "lat_jerk_lim_for_steer_rate");
   return p;
 }
 


### PR DESCRIPTION


v0.48 で vehicle_cmd_gate が実機においても使用される前提で以下 PR をバックポートしたが、control_command_gate が実機で作動することが分かったため、control_command_gate にもバックぽーと
https://github.com/autowarefoundation/autoware_universe/pull/11057