### PR TITLE
fix(path_optimizer): fix out_of_range die

### DIFF
--- a/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
+++ b/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
@@ -98,7 +98,7 @@ bool isFrontDrivableArea(
   const std::vector<geometry_msgs::msg::Point> & left_bound,
   const std::vector<geometry_msgs::msg::Point> & right_bound)
 {
-  if (left_bound.empty() || right_bound.empty()) {
+  if (left_bound.size() < 2 || right_bound.size() < 2) {
     return false;
   }
 
@@ -148,7 +148,7 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const bool use_footprint_polygon_for_outside_drivable_area_check)
 {
-  if (left_bound.empty() || right_bound.empty()) {
+  if (left_bound.size() < 2 || right_bound.size() < 2) {
     return false;
   }
 


### PR DESCRIPTION
Cherry-picked from https://github.com/autowarefoundation/autoware_universe/pull/11211

## Description

Fix path optimizer die due to bound out of range

```
[component_container_mt-37]   what():  vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
[component_container_mt-37] *** Aborted at 1755179481 (unix time) try "date -d @1755179481" if you are using GNU date ***
[component_container_mt-37] PC: @                0x0 (unknown)
[component_container_mt-37] *** SIGABRT (@0x3e80019d08c) received by PID 1691788 (TID 0x7f97417f2640) from PID 1691788; stack trace: ***
[component_container_mt-37]     @     0x7f97708b74d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-37]     @     0x7f976fc42520 (unknown)
[component_container_mt-37]     @     0x7f976fc969fc pthread_kill
[component_container_mt-37]     @     0x7f976fc42476 raise
[component_container_mt-37]     @     0x7f976fc287f3 abort
[component_container_mt-37]     @     0x7f97700a2b9e (unknown)
[component_container_mt-37]     @     0x7f97700ae20c (unknown)
[component_container_mt-37]     @     0x7f97700ae277 std::terminate()
[component_container_mt-37]     @     0x7f97700ae4d8 __cxa_throw
[component_container_mt-37]     @     0x7f97700a54cd (unknown)
[component_container_mt-37]     @     0x7f975c65dda5 autoware::path_optimizer::(anonymous namespace)::getStartPoint()
[component_container_mt-37]     @     0x7f975c65de17 autoware::path_optimizer::(anonymous namespace)::isFrontDrivableArea()
[component_container_mt-37]     @     0x7f975c65ef10 autoware::path_optimizer::geometry_utils::isOutsideDrivableAreaFromRectangleFootprint()
[component_container_mt-37]     @     0x7f975c5dcf4d autoware::path_optimizer::PathOptimizer::insertZeroVelocityOutsideDrivableArea()
[component_container_mt-37]     @     0x7f975c5dd25f autoware::path_optimizer::PathOptimizer::generateOptimizedTrajectory()
[component_container_mt-37]     @     0x7f975c5ddaf6 autoware::path_optimizer::PathOptimizer::onPath()
[component_container_mt-37]     @     0x7f975c5f89e8 std::_Function_handler<>::_M_invoke()
[component_container_mt-37]     @     0x7f976c1d5ad7 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN22autoware_planning_msgs3msg5Path_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
[component_container_mt-37]     @     0x7f975c625785 rclcpp::Subscription<>::handle_message()
[component_container_mt-37]     @     0x7f977055dba0 rclcpp::Executor::execute_subscription()
[component_container_mt-37]     @     0x7f977055f10e rclcpp::Executor::execute_any_executable()
[component_container_mt-37]     @     0x7f9770565432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-37]     @     0x7f97700dc253 (unknown)
[component_container_mt-37]     @     0x7f976fc94ac3 (unknown)
[component_container_mt-37]     @     0x7f976fd26850 (unknown)
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/7651e7a7-8bb0-52c8-bcd7-86f5d25185fe?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/e67b627b-17f3-5770-a4f3-cbbd897b1048?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/5ad0105d-44a6-54d6-a839-4445e2d9d35c?project_id=prd_jt)
  - 2tests failed, but not seem to be related to this PR
  - 
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
