### PR TITLE
chore: turn signal decider fix cherry-pick

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -599,11 +599,11 @@ geometry_msgs::msg::Pose TurnSignalDecider::get_required_end_point(
     autoware::motion_utils::resamplePoseVector(converted_centerline, resampling_arclength);
 
   const double terminal_yaw = tf2::getYaw(resampled_centerline.back().orientation);
-  for (size_t i = 0; i < resampled_centerline.size(); ++i) {
-    const double yaw = tf2::getYaw(resampled_centerline.at(i).orientation);
+  for (auto itr = resampled_centerline.rbegin(); itr != resampled_centerline.rend(); ++itr) {
+    const double yaw = tf2::getYaw(itr->orientation);
     const double yaw_diff = autoware_utils::normalize_radian(yaw - terminal_yaw);
-    if (std::fabs(yaw_diff) < autoware_utils::deg2rad(intersection_angle_threshold_deg_)) {
-      return resampled_centerline.at(i);
+    if (std::fabs(yaw_diff) >= autoware_utils::deg2rad(intersection_angle_threshold_deg_)) {
+      return *itr;
     }
   }
 


### PR DESCRIPTION
## Description

JIRA Link: https://tier4.atlassian.net/browse/RT0-38988

Slack: https://star4.slack.com/archives/C074CCKN35E/p1755677377546649

### **Problem Statement**
For merging lanes that appear geometrically straight, the required section becomes very small and is easily overwritten. However, these merging lanes are deliberately labeled with turning signals during map creation and should maintain high priority.

### **Proposed Solution**
This PR introduces modifications to the algorithm for determining the end index of turning lanelets.


----
https://github.com/tier4/autoware_universe/pull/2325

Thanks Daniel, for commenting. I cleaned up something in-correctly and make a new  single commit PR here


This is now a formal cherry-pick of
https://github.com/autowarefoundation/autoware_universe/pull/11288


---

## Algorithm Comparison

### **Original Design**
- **Direction**: Forward iteration (start → end)
- **Process**: 
  1. Loop from the start of the lanelet
  2. Find the index where route yaw angle becomes close to the end point
  3. Define sections:
     - **Required section**: `start → selected index`
     - **Desired section**: `selected index → end`
- **Edge case**: When all points deviate from the last index → entire lanelet becomes "required section"

### **Current Design** 
- **Direction**: Backward iteration (end → start)
- **Process**:
  1. Loop from the back of the lanelet
  2. Find the index where route yaw angle deviates from the end point
  3. Define sections:
     - **Required section**: `start → selected index`
     - **Desired section**: `selected index → end`
- **Edge case**: When all points do NOT deviate from the last index → entire lanelet becomes "required section"

### I am bad at drawing with mouse

![Drawing](https://github.com/user-attachments/assets/17b8a65b-0ba9-4d95-b340-f8afbf0c734b)