### PR TITLE
Cp blind spot

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -144,7 +144,7 @@ private:
    * @brief filter objects whose position is inside the attention_area and whose type is target type
    */
   std::vector<autoware_perception_msgs::msg::PredictedObject> filter_attention_objects(
-    const lanelet::BasicPolygon2d & attention_area) const;
+    const lanelet::BasicPolygon2d & attention_area, const double lateral_gap) const;
 
   /**
    * @brief Check if object is belong to targeted classes
@@ -152,6 +152,8 @@ private:
    * @return True when object belong to targeted classes
    */
   bool isTargetObjectType(const autoware_perception_msgs::msg::PredictedObject & object) const;
+
+  static bool is_vru_object_type(const autoware_perception_msgs::msg::PredictedObject & object);
 
   /**
    * @brief compute the deceleration and jerk for collision stop from `ttc`

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -149,6 +150,20 @@ std::optional<StopPoints> generate_stop_points(
   const double ego_nearest_yaw_threshold,
   autoware_internal_planning_msgs::msg::PathWithLaneId * path);
 
+/**
+ * @brief Calculate the minimum lateral gap from the ego vehicle's side to the relevant road
+ * boundary just before a turn.
+ * @param[in] ego_footprint The 2D geometric footprint of the ego vehicle.
+ * @param[in] last_lanelets_before_turning The lanelets the vehicle occupies just before the turn,
+ * used to define the blind spot area boundary.
+ * @param[in] turn_direction The direction of the upcoming turn (left/right), which determines the
+ * relevant vehicle side and road boundary.
+ * @return An optional value containing the minimum lateral distance in meters on success.
+ */
+std::optional<double> calc_ego_to_blind_spot_lanelet_lateral_gap(
+  const autoware_utils::LinearRing2d & footprint,
+  const lanelet::ConstLanelets & lanelets_before_turning,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_BLIND_SPOT_MODULE__UTIL_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -106,8 +106,8 @@ generate_blind_side_lanelets_before_turning(
  */
 lanelet::ConstLineString3d generate_virtual_blind_side_boundary_after_turning(
   const lanelet::ConstLanelet & outermost_lanelet,
-  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
-  const double extend_length);
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 
 /**
  * @brief generate virtual LineString which is normal to the entry line of `intersection_lanelet`,
@@ -120,6 +120,19 @@ std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_tu
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
   const double ego_width);
+
+/**
+ * @brief Clip a virtual line so it ends at the farthest intersected point with the given
+ * intersection lanelet’s bounds.
+ *
+ * @return lanelet::LineString3d A linestring containing the start point and either:
+ *         - the original end point (if no intersected points found), or
+ *         - the farthest intersected point with intersection lanelet's bounds.
+ */
+lanelet::LineString3d clip_virtual_line_to_intersection_bound(
+  const lanelet::BasicPoint3d & virtual_line_start, const lanelet::BasicPoint3d & virtual_line_end,
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 
 /**
  * @brief generate a polygon representing the Path along the intersection lane, with given

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -128,8 +128,7 @@ BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * pat
   const auto & last_blind_spot_lanelet_before_turning = blind_spot_lanelets_before_turning.back();
   if (!virtual_blind_lane_boundary_after_turning_) {
     virtual_blind_lane_boundary_after_turning_ = generate_virtual_blind_side_boundary_after_turning(
-      last_blind_spot_lanelet_before_turning, turn_direction_,
-      lanelet::utils::getLaneletLength3d(assigned_lanelet));
+      last_blind_spot_lanelet_before_turning, assigned_lanelet, turn_direction_);
   }
   const auto & virtual_blind_lane_boundary_after_turning =
     virtual_blind_lane_boundary_after_turning_.value();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -194,8 +194,15 @@ BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * pat
   const auto & ego_passage_time_interval = ego_passage_time_interval_opt.value();
   debug_data_.ego_passage_interval = ego_passage_time_interval;
 
-  const auto attention_objects =
-    filter_attention_objects(lanelet::utils::to2D(attention_area).basicPolygon());
+  const auto ego_footprint = autoware_utils::transform_vector(
+    planner_data_->vehicle_info_.createFootprint(),
+    autoware_utils::pose2transform(planner_data_->current_odometry->pose));
+  const auto ego_to_blind_side_lat_gap_opt = calc_ego_to_blind_spot_lanelet_lateral_gap(
+    ego_footprint, blind_spot_lanelets_before_turning, turn_direction_);
+
+  const auto attention_objects = filter_attention_objects(
+    lanelet::utils::to2D(attention_area).basicPolygon(),
+    ego_to_blind_side_lat_gap_opt.value_or(std::numeric_limits<double>::max()));
 
   const auto unsafe_objects = collect_unsafe_objects(
     attention_objects, ego_intersection_path_lanelet, ego_passage_time_interval);
@@ -373,7 +380,8 @@ std::vector<UnsafeObject> BlindSpotModule::collect_unsafe_objects(
 }
 
 std::vector<autoware_perception_msgs::msg::PredictedObject>
-BlindSpotModule::filter_attention_objects(const lanelet::BasicPolygon2d & attention_area) const
+BlindSpotModule::filter_attention_objects(
+  const lanelet::BasicPolygon2d & attention_area, const double lateral_gap) const
 {
   std::vector<autoware_perception_msgs::msg::PredictedObject> result;
   for (const auto & object : planner_data_->predicted_objects->objects) {
@@ -382,8 +390,13 @@ BlindSpotModule::filter_attention_objects(const lanelet::BasicPolygon2d & attent
     }
     const auto & position = object.kinematics.initial_pose_with_covariance.pose.position;
     // NOTE: use position of the object because vru object polygon around blind_spot is unstable
-    if (boost::geometry::within(
-          autoware_utils_geometry::Point2d{position.x, position.y}, attention_area)) {
+    const auto is_within_attention_area = boost::geometry::within(
+      autoware_utils_geometry::Point2d{position.x, position.y}, attention_area);
+
+    // if object is not VRU, check lateral clearance
+    if (
+      is_within_attention_area &&
+      (is_vru_object_type(object) || object.shape.dimensions.y < lateral_gap)) {
       result.push_back(object);
     }
   }
@@ -431,6 +444,17 @@ bool BlindSpotModule::isTargetObjectType(
     return true;
   }
   return false;
+}
+
+bool BlindSpotModule::is_vru_object_type(
+  const autoware_perception_msgs::msg::PredictedObject & object)
+{
+  return object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::BICYCLE ||
+         object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN ||
+         object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE;
 }
 
 std::pair<double, double> BlindSpotModule::compute_decel_and_jerk_from_ttc(const double ttc) const

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -115,16 +115,16 @@ Eigen::Vector3d linestring_normal_direction(
  * @brief extend the last part of given `line` by some length
  */
 lanelet::LineString3d generate_segment_beyond_linestring_end(
-  const lanelet::ConstLineString3d & line, const double extend_length)
+  const lanelet::ConstLineString3d & line, const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
 {
+  const auto extend_length = lanelet::utils::getLaneletLength3d(intersection_lanelet);
   const auto size = line.size();
   const auto & p1 = line[size - 2];
   const auto & p2 = line[size - 1];
   const auto p3 = autoware::experimental::lanelet2_utils::extrapolate_point(p1, p2, extend_length);
-  lanelet::Points3d points;
-  points.push_back(remove_const(p2));
-  points.push_back(remove_const(p3));
-  return lanelet::LineString3d{lanelet::InvalId, points};
+  return clip_virtual_line_to_intersection_bound(
+    remove_const(p2), remove_const(p3), intersection_lanelet, turn_direction);
 };
 
 template <typename L1, typename L2>
@@ -541,13 +541,14 @@ generate_blind_side_lanelets_before_turning(
 
 lanelet::ConstLineString3d generate_virtual_blind_side_boundary_after_turning(
   const lanelet::ConstLanelet & outermost_lanelet,
-  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
-  const double extend_length)
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
 {
   const auto & target_linestring = (turn_direction == TurnDirection::Left)
                                      ? outermost_lanelet.leftBound()
                                      : outermost_lanelet.rightBound();
-  return generate_segment_beyond_linestring_end(target_linestring, extend_length);
+  return generate_segment_beyond_linestring_end(
+    target_linestring, intersection_lanelet, turn_direction);
 }
 
 std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_turning(
@@ -592,9 +593,45 @@ std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_tu
   const Eigen::Vector3d virtual_straight_path_end =
     virtual_straight_path_start.basicPoint() +
     linestring_normal_direction(entry_line, extend_length);
+
+  return clip_virtual_line_to_intersection_bound(
+    virtual_straight_path_start, virtual_straight_path_end, intersection_lanelet, turn_direction);
+}
+
+lanelet::LineString3d clip_virtual_line_to_intersection_bound(
+  const lanelet::BasicPoint3d & virtual_line_start, const lanelet::BasicPoint3d & virtual_line_end,
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
+{
+  const auto virtual_line = to_bg2d(std::vector{virtual_line_start, virtual_line_end});
+
+  const auto & farthest_bound = (turn_direction == TurnDirection::Left)
+                                  ? intersection_lanelet.rightBound()
+                                  : intersection_lanelet.leftBound();
+
+  std::vector<Point2d> intersected_points;
+  for (size_t i = 0; i + 1 < farthest_bound.size(); ++i) {
+    const auto & p1 = farthest_bound[i];
+    const auto & p2 = farthest_bound[i + 1];
+
+    auto farthest_bound_segment = to_bg2d(std::vector{p1, p2});
+    boost::geometry::intersection(virtual_line, farthest_bound_segment, intersected_points);
+  }
+
   lanelet::Points3d points;
-  points.push_back(lanelet::Point3d{lanelet::InvalId, virtual_straight_path_start});
-  points.push_back(lanelet::Point3d{lanelet::InvalId, virtual_straight_path_end});
+  points.emplace_back(lanelet::InvalId, virtual_line_start);
+
+  if (intersected_points.empty()) {
+    points.emplace_back(lanelet::InvalId, virtual_line_end);
+    return lanelet::LineString3d{lanelet::InvalId, points};
+  }
+
+  lanelet::Point3d farthest_intersected_point{
+    lanelet::InvalId,
+    lanelet::BasicPoint3d{
+      intersected_points.front().x(), intersected_points.front().y(), virtual_line_end.z()}};
+  points.emplace_back(lanelet::InvalId, farthest_intersected_point);
+
   return lanelet::LineString3d{lanelet::InvalId, points};
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -20,17 +20,21 @@
 #include <autoware/lanelet2_utils/topology.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <range/v3/all.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/length.hpp>
+#include <boost/geometry/index/rtree.hpp>
 
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
 #include <algorithm>
+#include <limits>
 #include <list>
 #include <memory>
 #include <optional>
@@ -725,4 +729,56 @@ std::optional<StopPoints> generate_stop_points(
     std::nullopt, stop_points_list.instant_stopline, stop_points_list.critical_stopline};
 }
 
+std::optional<double> calc_ego_to_blind_spot_lanelet_lateral_gap(
+  const autoware_utils::LinearRing2d & ego_footprint,
+  const lanelet::ConstLanelets & last_lanelets_before_turning,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
+{
+  const auto front_idx = (turn_direction == TurnDirection::Left)
+                           ? vehicle_info_utils::VehicleInfo::FrontLeftIndex
+                           : vehicle_info_utils::VehicleInfo::FrontRightIndex;
+  const auto rear_idx = (turn_direction == TurnDirection::Left)
+                          ? vehicle_info_utils::VehicleInfo::RearLeftIndex
+                          : vehicle_info_utils::VehicleInfo::RearRightIndex;
+  const auto ego_side =
+    autoware_utils::Segment2d{ego_footprint[front_idx], ego_footprint[rear_idx]};
+
+  std::vector<autoware_utils::Point2d> line;
+  for (const auto & ll : last_lanelets_before_turning) {
+    const auto & attention_area_road_boundary = lanelet::utils::to2D(
+      (turn_direction == TurnDirection::Left) ? ll.leftBound() : ll.rightBound());
+    const auto ll_2d = lanelet::utils::to2D(attention_area_road_boundary);
+
+    for (const auto & ls : ll_2d) {
+      line.emplace_back(ls.x(), ls.y());
+    }
+  }
+
+  if (line.size() < 2) {
+    return std::nullopt;
+  }
+
+  std::vector<autoware_utils::Segment2d> segments;
+  segments.reserve(line.size() - 1);
+  for (const auto & [p1, p2] : ranges::views::zip(line, line | ranges::views::drop(1))) {
+    segments.emplace_back(p1, p2);
+  }
+
+  bg::index::rtree<autoware_utils::Segment2d, bg::index::rstar<16>> segments_before_turning{
+    segments.begin(), segments.end()};
+
+  std::vector<autoware_utils::Segment2d> candidate_segments;
+  constexpr size_t max_candidate_size = 5;
+  candidate_segments.reserve(max_candidate_size);
+  segments_before_turning.query(
+    bg::index::nearest(ego_side, max_candidate_size), std::back_inserter(candidate_segments));
+
+  auto min_blind_side_distance = std::numeric_limits<double>::max();
+  for (const auto & [candidate_segment, candidate_idx] : candidate_segments) {
+    min_blind_side_distance =
+      std::min(min_blind_side_distance, bg::distance(ego_side, candidate_segment));
+  }
+
+  return min_blind_side_distance;
+}
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -138,6 +138,11 @@ std::optional<Point2d> find_intersection_point(L1 && line1, L2 && line2)
   }
   return intersection_points.front();
 }
+
+bool is_private_lanelet(const lanelet::ConstLanelet & lanelet)
+{
+  return std::strcmp(lanelet.attributeOr("location", "else"), "private") == 0;
+}
 }  // namespace
 
 namespace helper
@@ -498,9 +503,18 @@ generate_blind_side_lanelets_before_turning(
   }
   */
   const auto intersection_lane = lanelet_map_ptr->laneletLayer.get(intersection_lane_id);
+
+  const auto is_private_intersection = is_private_lanelet(intersection_lane);
+  const auto validate_lane_attribute = [is_private_intersection](
+                                         const lanelet::ConstLanelet & lanelet) {
+    return is_private_intersection
+             ? is_private_lanelet(lanelet)  // If intersection is private, lane must also be private
+             : true;                        // ...otherwise, it's always true (allowed).
+  };
+
   const auto previous_lane_opt =
     helper::previous_lane_straight_priority(intersection_lane, routing_graph_ptr);
-  if (previous_lane_opt) {
+  if (previous_lane_opt && validate_lane_attribute(previous_lane_opt.value())) {
     const auto & previous_lane = previous_lane_opt.value();
     road_lanelets.push_back(previous_lane);
     blind_side_lanelets.push_back(blind_side_getter_function(route_handler, previous_lane));
@@ -513,7 +527,7 @@ generate_blind_side_lanelets_before_turning(
     const auto & last_road_lane = road_lanelets.front();
     const auto prev_lane_opt =
       helper::previous_lane_straight_priority(last_road_lane, routing_graph_ptr);
-    if (!prev_lane_opt) {
+    if (!prev_lane_opt || !validate_lane_attribute(prev_lane_opt.value())) {
       return std::make_pair(road_lanelets, blind_side_lanelets);
     }
     const auto & prev_lane = prev_lane_opt.value();


### PR DESCRIPTION
cherry-pick for experiment
[fix(blind_spot): filter non-vru based on lateral clearance #11265](https://github.com/autowarefoundation/autoware_universe/pull/11265)
[fix(blind_spot): cut virtual blind lines up to intersection lanelet's bound #11282](https://github.com/autowarefoundation/autoware_universe/pull/11282)
[fix(blind_spot): when intersection is private, attention area lanelets are also private #11283](https://github.com/autowarefoundation/autoware_universe/pull/11283)
