### PR TITLE
fix(boundary_departure): backport PRs to reduce possibility of random node crash

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -27,13 +27,14 @@
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware/trajectory/utils/closest.hpp>
 #include <magic_enum.hpp>
-#include <range/v3/algorithm/sort.hpp>
+#include <range/v3/algorithm.hpp>
 #include <range/v3/view.hpp>
 
 #include <algorithm>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace
@@ -68,33 +69,10 @@ void BoundaryDeparturePreventionModule::init(
   updater_ptr_->setHardwareID("motion_velocity_boundary_departure_prevention");
   updater_ptr_->add(
     "boundary_departure", [this](diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      const auto matches_type = [this](const DepartureType & type) -> bool {
-        return output_.diagnostic_output.find(type) != output_.diagnostic_output.end() &&
-               output_.diagnostic_output[type];
-      };
-
-      const auto type = std::invoke([&]() {
-        if (matches_type(DepartureType::CRITICAL_DEPARTURE)) {
-          return DepartureType::CRITICAL_DEPARTURE;
-        }
-        if (matches_type(DepartureType::APPROACHING_DEPARTURE)) {
-          return DepartureType::APPROACHING_DEPARTURE;
-        }
-        if (matches_type(DepartureType::NEAR_BOUNDARY)) {
-          return DepartureType::NEAR_BOUNDARY;
-        }
-        return DepartureType::NONE;
-      });
-
-      auto lvl = node_param_.diagnostic_level[type];
-      auto msg = to_string(type);
-
-      if (lvl != DiagStatus::OK && type != DepartureType::NONE) {
-        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 1000, "%s", msg.c_str());
-      }
-
+      const auto [lvl, msg] = output_.diag_status;
       stat.summary(lvl, msg);
     });
+
   last_abnormality_fp_no_overlap_bound_time_ = clock_ptr_->now().seconds();
   last_abnormality_fp_overlap_bound_time_ = clock_ptr_->now().seconds();
   last_no_critical_dpt_time_ = clock_ptr_->now().seconds();
@@ -738,9 +716,9 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
 
   toc_curr_watch("check_stopping_dist");
 
-  output_.diagnostic_output = get_diagnostics(ego_dist_on_traj_m, curr_vel);
+  output_.diag_status = get_diagnostic_status(ego_dist_on_traj_m, curr_vel);
 
-  toc_curr_watch("get_diagnostics");
+  toc_curr_watch("get_diagnostic_status");
 
   VelocityPlanningResult result;
   result.slowdown_intervals = slowdown_intervals;
@@ -795,38 +773,14 @@ void BoundaryDeparturePreventionModule::update_critical_departure_points(
   std::sort(output_.critical_departure_points.begin(), output_.critical_departure_points.end());
 }
 
-std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_diagnostics(
+std::pair<int8_t, std::string> BoundaryDeparturePreventionModule::get_diagnostic_status(
   const double ego_dist_on_traj, const double curr_vel)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  std::unordered_map<DepartureType, bool> diag{
-    {DepartureType::NEAR_BOUNDARY, false},
-    {DepartureType::APPROACHING_DEPARTURE, false},
-    {DepartureType::CRITICAL_DEPARTURE, false}};
-
-  const auto & th_trigger = node_param_.bdc_param.th_trigger;
-
-  const auto has_type = [&](const DepartureType type, const SideKey side_key) {
-    const auto is_type = [type](const DeparturePoint & pt) { return pt.departure_type == type; };
-
-    return std::any_of(
-      output_.departure_points[side_key].cbegin(), output_.departure_points[side_key].cend(),
-      is_type);
-  };
-
-  diag[DepartureType::NEAR_BOUNDARY] = std::any_of(
-    g_side_keys.begin(), g_side_keys.end(),
-    [&](const SideKey side_key) { return has_type(DepartureType::NEAR_BOUNDARY, side_key); });
-
-  diag[DepartureType::APPROACHING_DEPARTURE] =
-    std::any_of(g_side_keys.begin(), g_side_keys.end(), [&](const SideKey side_key) {
-      return has_type(DepartureType::APPROACHING_DEPARTURE, side_key);
-    });
-
-  diag[DepartureType::CRITICAL_DEPARTURE] = std::any_of(
-    output_.critical_departure_points.cbegin(), output_.critical_departure_points.cend(),
-    [&th_trigger, &curr_vel, &ego_dist_on_traj](const DeparturePoint & pt) {
+  const auto diag_type = std::invoke([&]() {
+    const auto is_within_braking_dist = [&](const DeparturePoint & pt) {
+      const auto & th_trigger = node_param_.bdc_param.th_trigger;
       const auto braking_start_vel =
         std::clamp(curr_vel, th_trigger.th_vel_mps.min, th_trigger.th_vel_mps.max);
       const auto braking_dist =
@@ -834,9 +788,39 @@ std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_d
           braking_start_vel, 0.0, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.max,
           th_trigger.brake_delay_s);
       return (pt.ego_dist_on_ref_traj - ego_dist_on_traj) <= braking_dist;
-    });
+    };
 
-  return diag;
+    if (ranges::any_of(output_.critical_departure_points, is_within_braking_dist)) {
+      return DepartureType::CRITICAL_DEPARTURE;
+    }
+
+    const auto has_type = [&](const DepartureType type) {
+      const auto is_type = [type](const DeparturePoint & pt) { return pt.departure_type == type; };
+
+      return ranges::any_of(g_side_keys, [&](const SideKey side_key) {
+        return ranges::any_of(output_.departure_points[side_key], is_type);
+      });
+    };
+
+    if (has_type(DepartureType::APPROACHING_DEPARTURE)) {
+      return DepartureType::APPROACHING_DEPARTURE;
+    }
+
+    if (has_type(DepartureType::NEAR_BOUNDARY)) {
+      return DepartureType::NEAR_BOUNDARY;
+    }
+
+    return DepartureType::NONE;
+  });
+
+  auto lvl = node_param_.diagnostic_level[diag_type];
+  auto msg = to_string(diag_type);
+
+  if (lvl != DiagStatus::OK && diag_type != DepartureType::NONE) {
+    RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, throttle_duration_ms, "%s", msg.c_str());
+  }
+
+  return {lvl, msg};
 }
 
 bool BoundaryDeparturePreventionModule::is_continuous_critical_departure()

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -44,6 +44,7 @@ public:
   {
     return RequiredSubscriptionInfo{};
   }
+  ~BoundaryDeparturePreventionModule() override { updater_ptr_.reset(); }
 
 private:
   // === Interface and inputs validation ====

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -58,6 +58,17 @@ private:
   bool is_autonomous_mode() const;
 
   // === Internal logic
+  /**
+   * @brief Main entry point for boundary departure-aware velocity planning.
+   *
+   * The function first verifies input validity, checks system state (e.g., route changes,
+   * autonomy status), and initializes planning components if needed. Then it performs slow down
+   * planning to prevent the vehicle from departing road boundaries.
+   */
+
+  tl::expected<VelocityPlanningResult, std::string> plan_velocities(
+    const TrajectoryPoints & raw_trajectory_points,
+    const std::shared_ptr<const PlannerData> & planner_data);
 
   tl::expected<VelocityPlanningResult, std::string> plan_slow_down_intervals(
     const TrajectoryPoints & raw_trajectory_points,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::motion_velocity_planner::experimental
@@ -89,7 +90,7 @@ private:
    * @param curr_vel Current velocity of the ego vehicle.
    * @return Map of `DepartureType` to boolean indicating active status.
    */
-  std::unordered_map<DepartureType, bool> get_diagnostics(
+  std::pair<int8_t, std::string> get_diagnostic_status(
     const double ego_dist_on_traj, const double curr_vel);
 
   /**

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #ifndef PARAMETERS_HPP_
@@ -47,10 +48,8 @@ struct Output
   DepartureIntervals departure_intervals;
   Side<DeparturePoints> departure_points;
   CriticalDeparturePoints critical_departure_points;
-  std::unordered_map<DepartureType, bool> diagnostic_output{
-    {DepartureType::NEAR_BOUNDARY, false},
-    {DepartureType::APPROACHING_DEPARTURE, false},
-    {DepartureType::CRITICAL_DEPARTURE, false}};
+
+  std::pair<int8_t, std::string> diag_status{DiagStatus::OK, "none"};
 };
 
 struct NodeParam


### PR DESCRIPTION
backport:
- https://github.com/autowarefoundation/autoware_universe/pull/11217
- https://github.com/autowarefoundation/autoware_universe/pull/11243
- https://github.com/autowarefoundation/autoware_universe/pull/11245


Related issues:

[TIER IV Internal Link - Issue RT1-10999](https://tier4.atlassian.net/browse/RT1-10999)
[TIER IV Internal link - P/C Inquiry](https://star4.slack.com/archives/C074CCKN35E/p1755840492837879)

⚠️ Additional note:
* The issue is not reproducible in the local environment and occurs randomly in the evaluator. * So far, it has only been reported during manual driving. As mentioned in the [TIER IV Internal link – P/C Inquiry](https://star4.slack.com/archives/C074CCKN35E/p1755840492837879), it is not reproducible with the rosbag.
* The module has been tested several times on the actual vehicle in autonomous mode, and the issue has not been observed.
* At this stage, the PRs represent the best effort to minimize the possibility of the issue occurring.