### PR TITLE
feat(pose instability detector): change diag level (#11095)

### DIFF
--- a/localization/autoware_pose_instability_detector/README.md
+++ b/localization/autoware_pose_instability_detector/README.md
@@ -13,8 +13,8 @@ The results of this comparison are then output to the `/diagnostics` topic.
 
 ![rqt_runtime_monitor](./media/rqt_runtime_monitor.png)
 
-If this node outputs WARN messages to `/diagnostics`, it means that the EKF output is significantly different from the integrated twist values.
-In other words, WARN outputs indicate that the vehicle has moved to a place outside the expected range based on the twist values.
+If this node outputs ERROR messages to `/diagnostics`, it means that the EKF output is significantly different from the integrated twist values.
+In other words, ERROR outputs indicate that the vehicle has moved to a place outside the expected range based on the twist values.
 This discrepancy suggests that there may be an issue with either the estimated pose or the input twist.
 
 The following diagram provides an overview of how the procedure looks like:

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -178,11 +178,11 @@ void PoseInstabilityDetector::callback_timer()
     kv.value = std::to_string(values[i]);
     status.values.push_back(kv);
     kv.key = labels[i] + ":status";
-    kv.value = (ok ? "OK" : "WARN");
+    kv.value = (ok ? "OK" : "ERROR");
     status.values.push_back(kv);
   }
-  status.level = (all_ok ? DiagnosticStatus::OK : DiagnosticStatus::WARN);
-  status.message = (all_ok ? "OK" : "WARN");
+  status.level = (all_ok ? DiagnosticStatus::OK : DiagnosticStatus::ERROR);
+  status.message = (all_ok ? "OK" : "ERROR");
 
   DiagnosticArray diagnostics;
   diagnostics.header.stamp = latest_odometry_time;

--- a/localization/autoware_pose_instability_detector/test/test.cpp
+++ b/localization/autoware_pose_instability_detector/test/test.cpp
@@ -120,7 +120,7 @@ TEST_F(TestPoseInstabilityDetector, output_ok_when_twist_matches_odometry)  // N
   EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::OK);
 }
 
-TEST_F(TestPoseInstabilityDetector, output_warn_when_twist_is_too_small)  // NOLINT
+TEST_F(TestPoseInstabilityDetector, output_error_when_twist_is_too_small)  // NOLINT
 {
   // send the first odometry message (start x = 10)
   builtin_interfaces::msg::Time timestamp{};
@@ -162,7 +162,7 @@ TEST_F(TestPoseInstabilityDetector, output_warn_when_twist_is_too_small)  // NOL
   // check result
   const diagnostic_msgs::msg::DiagnosticStatus & diagnostic_status =
     helper_->received_diagnostic_array.status[0];
-  EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR);
 }
 
 TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_data_comes)  // NOLINT


### PR DESCRIPTION
## Description

This PR changes the level of diagnostics of `pose_instability_detector` from `WARN` to `ERROR`.

Cherry-pick of https://github.com/autowarefoundation/autoware_universe/pull/11095