### PR TITLE
fix(gpu_monitor): explicitly qualify a function call to stop error from the cppcheck-differential workflow

### DIFF
--- a/system/autoware_system_monitor/include/system_monitor/gpu_monitor/gpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/gpu_monitor/gpu_monitor_base.hpp
@@ -66,6 +66,8 @@ protected:
    * @brief Terminate the node, log final statements. An independent function is preferred to allow
    * an explicit way to operate actions that require a valid rclcpp context. By default this method
    * does nothing.
+   * @note Derived classes should override this method and call their own version from the
+   * destructor to clean up the resources.
    */
   virtual void shut_down();
 

--- a/system/autoware_system_monitor/include/system_monitor/gpu_monitor/nvml_gpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/gpu_monitor/nvml_gpu_monitor.hpp
@@ -73,6 +73,8 @@ protected:
    * @brief Terminate the node, log final statements. An independent function is preferred to allow
    * an explicit way to operate actions that require a valid rclcpp context. By default this method
    * does nothing.
+   * @note This class uses the NVML library to get GPU information. The NVML library needs to be
+   * shut down in this function.
    */
   void shut_down() override;
 

--- a/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
@@ -57,7 +57,9 @@ GPUMonitorBase::GPUMonitorBase(const std::string & node_name, const rclcpp::Node
 
 GPUMonitorBase::~GPUMonitorBase()
 {
-  shut_down();
+  // Base class destructor can't call virtual functions defined by its derived classes.
+  // The CI workflow "cppcheck_differential" fails without this explicit qualification.
+  GPUMonitorBase::shut_down();
 }
 
 void GPUMonitorBase::update()

--- a/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -85,6 +85,9 @@ GPUMonitor::~GPUMonitor()
 
 void GPUMonitor::shut_down()
 {
+  // When this method is called from the destructor in the process of system shutdown,
+  // all nodes are guaranteed to be inactive.
+  // Therefore, it is safe to call the NVML library's shutdown function.
   nvmlReturn_t ret = nvmlShutdown();
   if (ret != NVML_SUCCESS) {
     RCLCPP_ERROR(this->get_logger(), "Failed to shut down NVML: %s", nvmlErrorString(ret));


### PR DESCRIPTION
This PR is a cherry-picking PR which backports the following PR to autowarefoundation/autoware_universe.
- [fix(gpu_monitor): explicitly qualify a function call to stop error from the cppcheck-differential CI workflow #11279](https://github.com/autowarefoundation/autoware_universe/pull/11279)

The preceding cherry-picking PR [feat(autoware_system_monitor): publish msgs for system_monitor API #2285](https://github.com/tier4/autoware_universe/pull/2285), which has already been merged, had a problem which may cause a CI workflow error (with cppcheck-differential) when "autoware_system_monitor" is modified.
This PR should be merged to avoid possible occurrence of the CI workflow error in near future.