### PR TITLE
feat: enhance bytracker classification management (#10898)

### DIFF
--- a/perception/autoware_bytetrack/config/bytetrack.param.yaml
+++ b/perception/autoware_bytetrack/config/bytetrack.param.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
     track_buffer_length: 30
+    classification_decay_constant: 0.95

--- a/perception/autoware_bytetrack/include/autoware/bytetrack/bytetrack.hpp
+++ b/perception/autoware_bytetrack/include/autoware/bytetrack/bytetrack.hpp
@@ -47,7 +47,8 @@ using ObjectArray = std::vector<Object>;
 class ByteTrack
 {
 public:
-  explicit ByteTrack(const int track_buffer_length = 30);
+  explicit ByteTrack(
+    const int track_buffer_length = 30, const double classification_decay_constant = 0.95);
 
   bool do_inference(ObjectArray & objects);
   ObjectArray update_tracker(ObjectArray & input_objects);

--- a/perception/autoware_bytetrack/lib/include/byte_tracker.h
+++ b/perception/autoware_bytetrack/lib/include/byte_tracker.h
@@ -54,8 +54,8 @@ class ByteTracker
 {
 public:
   ByteTracker(
-    int track_buffer = 30, float track_thresh = 0.5, float high_thresh = 0.6,
-    float match_thresh = 0.8);
+    int track_buffer = 30, double classification_decay_constant = 0.95, float track_thresh = 0.5,
+    float high_thresh = 0.6, float match_thresh = 0.8);
   ~ByteTracker();
 
   std::vector<STrack> update(const std::vector<ByteTrackObject> & objects);
@@ -88,6 +88,7 @@ private:
     float cost_limit = std::numeric_limits<float>::max(), bool return_cost = true);
 
 private:
+  double classification_decay_constant;
   float track_thresh;
   float high_thresh;
   float match_thresh;

--- a/perception/autoware_bytetrack/lib/include/strack.h
+++ b/perception/autoware_bytetrack/lib/include/strack.h
@@ -73,7 +73,7 @@ public:
 
   void activate(int frame_id);
   void re_activate(STrack & new_track, int frame_id, bool new_id = false);
-  void update(STrack & new_track, int frame_id);
+  void update(STrack & new_track, int frame_id, double classification_decay_constant);
   void predict(const int frame_id);
 
   void load_parameters(const std::string & filename);

--- a/perception/autoware_bytetrack/src/bytetrack.cpp
+++ b/perception/autoware_bytetrack/src/bytetrack.cpp
@@ -22,10 +22,10 @@
 
 namespace autoware::bytetrack
 {
-ByteTrack::ByteTrack(const int track_buffer_length)
+ByteTrack::ByteTrack(const int track_buffer_length, const double classification_decay_constant)
 {
   // Tracker initialization
-  tracker_ = std::make_unique<ByteTracker>(track_buffer_length);
+  tracker_ = std::make_unique<ByteTracker>(track_buffer_length, classification_decay_constant);
 }
 
 bool ByteTrack::do_inference(ObjectArray & objects)

--- a/perception/autoware_bytetrack/src/bytetrack_node.cpp
+++ b/perception/autoware_bytetrack/src/bytetrack_node.cpp
@@ -34,8 +34,10 @@ ByteTrackNode::ByteTrackNode(const rclcpp::NodeOptions & node_options)
   using std::chrono_literals::operator""ms;
 
   int track_buffer_length = declare_parameter("track_buffer_length", 30);
+  double classification_decay_constant = declare_parameter("classification_decay_constant", 0.95);
 
-  this->bytetrack_ = std::make_unique<autoware::bytetrack::ByteTrack>(track_buffer_length);
+  this->bytetrack_ = std::make_unique<autoware::bytetrack::ByteTrack>(
+    track_buffer_length, classification_decay_constant);
 
   timer_ =
     rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&ByteTrackNode::on_connect, this));


### PR DESCRIPTION
* feat: enhance bytracker classification management



* fix a bug in score reset after switching label



* feat: update the score rule for same label



---------

Cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/10898 into beta/v0.41

I found out Yolox-related problems in XX1 beta/v0.48 Solio run. This needs to be solved with new bytetrack update.
