### PR TITLE
fix(start_planner): check collision from start_pose (#11311)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -62,7 +62,7 @@ public:
 
 protected:
   bool isPullOutPathCollided(
-    autoware::behavior_path_planner::PullOutPath & pull_out_path,
+    const autoware::behavior_path_planner::PullOutPath & pull_out_path,
     const std::shared_ptr<const PlannerData> & planner_data,
     double collision_check_distance_from_end) const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1462,11 +1462,7 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
     // STEP 5-7: Collision check
     // ===================================================================
     // Create PullOutPath for collision check
-    PullOutPath temp_pull_out_path;
-    temp_pull_out_path.partial_paths.push_back(clothoid_path);
-    temp_pull_out_path.start_pose =
-      clothoid_path.points.empty() ? start_pose : clothoid_path.points.front().point.pose;
-    temp_pull_out_path.end_pose = target_pose;
+    const PullOutPath temp_pull_out_path{{clothoid_path}, {}, start_pose, target_pose};
 
     if (isPullOutPathCollided(
           temp_pull_out_path, planner_data,

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/pull_out_planner_base.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/pull_out_planner_base.cpp
@@ -19,7 +19,7 @@
 namespace autoware::behavior_path_planner
 {
 bool PullOutPlannerBase::isPullOutPathCollided(
-  autoware::behavior_path_planner::PullOutPath & pull_out_path,
+  const autoware::behavior_path_planner::PullOutPath & pull_out_path,
   const std::shared_ptr<const PlannerData> & planner_data,
   double collision_check_distance_from_end) const
 {


### PR DESCRIPTION
## Description

cherry pick pr for https://github.com/autowarefoundation/autoware_universe/pull/11311

https://tier4.atlassian.net/browse/RT0-38846?focusedCommentId=253338 に記載した通り、この変更を適用することで経路生成できるようになることを確認済み。

This PR refactors the creation of `PullOutPath` object in the clothoid pull-out planner to use aggregate initialization and fixes a safety-related issue in collision detection logic.

- Fixed collision detection logic that was causing unnecessary path generation failures
  - Previously, collision checking was performed on sections behind the start_pose, which sometimes prevented path generation even when it was safe to proceed
  - The empty check was deemed unnecessary as this validation is already performed upstream in the processing pipeline

**Comparison:**

| Before                        | After                        |
| ----------------------------- | ---------------------------- |
| <img width="2574" height="298" alt="Screenshot from 2025-09-03 10-51-55" src="https://github.com/user-attachments/assets/65a28083-5c7d-4457-8688-e21663afab6f" /> | <img width="2574" height="298" alt="Screenshot from 2025-09-03 10-52-51" src="https://github.com/user-attachments/assets/cffffa9d-f484-44b8-843d-a004b7da4b56" /> |

## Related links

**Private Links:**
- [TIERIV internal link](https://tier4.atlassian.net/browse/RT0-38846)

## How was this PR tested?

- [x] run psim

skip scenarios evaluation because default setting doesn't enable clothoid planner

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
