### PR TITLE
fix(hdd_monitor,cpu_monitor): use unix sockets for IPC with helper applications

### DIFF
--- a/system/autoware_system_monitor/README.md
+++ b/system/autoware_system_monitor/README.md
@@ -24,7 +24,7 @@ This package provides the following nodes for monitoring system:
 
 - PC system intel core i7
 
-The following "once confirmed" platforms (or their successor) need to be tested again with the latest environment.
+The following "once confirmed" platforms (or their successors) need to be tested again with the latest environment.
 
 - <del>NVIDIA Jetson AGX Xavier</del>
 - <del>Raspberry Pi4 Model B</del>

--- a/system/autoware_system_monitor/config/cpu_monitor.param.yaml
+++ b/system/autoware_system_monitor/config/cpu_monitor.param.yaml
@@ -5,4 +5,4 @@
     usage_warn_count: 1
     usage_error_count: 2
     usage_avg: true
-    msr_reader_port: 7634
+    msr_reader_socket_path: "/tmp/msr_reader.sock"

--- a/system/autoware_system_monitor/config/hdd_monitor.param.yaml
+++ b/system/autoware_system_monitor/config/hdd_monitor.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hdd_reader_port: 7635
+    hdd_reader_socket_path: "/tmp/hdd_reader.sock"
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:

--- a/system/autoware_system_monitor/docs/hdd_reader.md
+++ b/system/autoware_system_monitor/docs/hdd_reader.md
@@ -11,13 +11,13 @@ hdd_reader [OPTION]
 ## Description
 
 Read S.M.A.R.T. information for monitoring HDD temperature and life of HDD.<br>
-This runs as a daemon process and listens to a TCP/IP port (7635 by default).
+This runs as a daemon process and listens to a UNIX domain socket ("/tmp/hdd_reader.sock" by default).
 
 **Options:**<br>
 _-h, --help_<br>
 &nbsp;&nbsp;&nbsp;&nbsp;Display help<br>
-_-p, --port #_<br>
-&nbsp;&nbsp;&nbsp;&nbsp;Port number to listen to
+_-s, --socket PATH_<br>
+&nbsp;&nbsp;&nbsp;&nbsp;UNIX domain socket path
 
 **Exit status:**<br>
 Returns 0 if OK; non-zero otherwise.

--- a/system/autoware_system_monitor/docs/msr_reader.md
+++ b/system/autoware_system_monitor/docs/msr_reader.md
@@ -11,13 +11,13 @@ msr_reader [OPTION]
 ## Description
 
 Read MSR register for monitoring thermal throttling event.<br>
-This runs as a daemon process and listens to a TCP/IP port (7634 by default).
+This runs as a daemon process and listens to a UNIX domain socket ("/tmp/msr_reader.sock" by default).
 
 **Options:**<br>
 _-h, --help_<br>
 &nbsp;&nbsp;&nbsp;&nbsp;Display help<br>
-_-p, --port #_<br>
-&nbsp;&nbsp;&nbsp;&nbsp;Port number to listen to
+_-s, --socket PATH_<br>
+&nbsp;&nbsp;&nbsp;&nbsp;UNIX domain socket path
 
 **Exit status:**<br>
 Returns 0 if OK; non-zero otherwise.

--- a/system/autoware_system_monitor/docs/ros_parameters.md
+++ b/system/autoware_system_monitor/docs/ros_parameters.md
@@ -4,17 +4,17 @@
 
 cpu_monitor:
 
-| Name              | Type  |  Unit   | Default | Notes                                                                                                      |
-| :---------------- | :---: | :-----: | :-----: | :--------------------------------------------------------------------------------------------------------- |
-| temp_warn         | float |  DegC   |  90.0   | Generates warning when CPU temperature reaches a specified value or higher.                                |
-| temp_error        | float |  DegC   |  95.0   | Generates error when CPU temperature reaches a specified value or higher.                                  |
-| usage_warn        | float | %(1e-2) |  0.90   | Generates warning when CPU usage reaches a specified value or higher and last for usage_warn_count counts. |
-| usage_error       | float | %(1e-2) |  1.00   | Generates error when CPU usage reaches a specified value or higher and last for usage_error_count counts.  |
-| usage_warn_count  |  int  |   n/a   |    2    | Generates warning when CPU usage reaches usage_warn value or higher and last for a specified counts.       |
-| usage_error_count |  int  |   n/a   |    2    | Generates error when CPU usage reaches usage_error value or higher and last for a specified counts.        |
-| load1_warn        | float | %(1e-2) |  0.90   | Generates warning when load average 1min reaches a specified value or higher.                              |
-| load5_warn        | float | %(1e-2) |  0.80   | Generates warning when load average 5min reaches a specified value or higher.                              |
-| msr_reader_port   |  int  |   n/a   |  7634   | Port number to connect to msr_reader.                                                                      |
+| Name                   |  Type  |  Unit   |       Default        | Notes                                                                                                      |
+| :--------------------- | :----: | :-----: | :------------------: | :--------------------------------------------------------------------------------------------------------- |
+| temp_warn              | float  |  DegC   |         90.0         | Generates warning when CPU temperature reaches a specified value or higher.                                |
+| temp_error             | float  |  DegC   |         95.0         | Generates error when CPU temperature reaches a specified value or higher.                                  |
+| usage_warn             | float  | %(1e-2) |         0.90         | Generates warning when CPU usage reaches a specified value or higher and last for usage_warn_count counts. |
+| usage_error            | float  | %(1e-2) |         1.00         | Generates error when CPU usage reaches a specified value or higher and last for usage_error_count counts.  |
+| usage_warn_count       |  int   |   n/a   |          2           | Generates warning when CPU usage reaches usage_warn value or higher and last for a specified counts.       |
+| usage_error_count      |  int   |   n/a   |          2           | Generates error when CPU usage reaches usage_error value or higher and last for a specified counts.        |
+| load1_warn             | float  | %(1e-2) |         0.90         | Generates warning when load average 1min reaches a specified value or higher.                              |
+| load5_warn             | float  | %(1e-2) |         0.80         | Generates warning when load average 5min reaches a specified value or higher.                              |
+| msr_reader_socket_path | string |   n/a   | /tmp/msr_reader.sock | UNIX domain socket path to connect to msr_reader.                                                          |
 
 ## <u>HDD Monitor</u>
 
@@ -42,11 +42,11 @@ hdd_monitor:
 
 hdd_monitor:
 
-| Name            | Type  |  Unit   | Default | Notes                                                                  |
-| :-------------- | :---: | :-----: | :-----: | :--------------------------------------------------------------------- |
-| hdd_reader_port |  int  |   n/a   |  7635   | Port number to connect to hdd_reader.                                  |
-| usage_warn      | float | %(1e-2) |  0.95   | Generates warning when disk usage reaches a specified value or higher. |
-| usage_error     | float | %(1e-2) |  0.99   | Generates error when disk usage reaches a specified value or higher.   |
+| Name                   |  Type  |  Unit   |       Default        | Notes                                                                  |
+| :--------------------- | :----: | :-----: | :------------------: | :--------------------------------------------------------------------- |
+| hdd_reader_socket_path | string |   n/a   | /tmp/hdd_reader.sock | UNIX domain socket path to connect to hdd_reader.                      |
+| usage_warn             | float  | %(1e-2) |         0.95         | Generates warning when disk usage reaches a specified value or higher. |
+| usage_error            | float  | %(1e-2) |         0.99         | Generates error when disk usage reaches a specified value or higher.   |
 
 ## <u>Memory Monitor</u>
 

--- a/system/autoware_system_monitor/docs/traffic_reader.md
+++ b/system/autoware_system_monitor/docs/traffic_reader.md
@@ -11,13 +11,13 @@ traffic_reader [OPTION]
 ## Description
 
 Monitoring network traffic by process.<br>
-This runs as a daemon process and listens to a TCP/IP port (7636 by default).
+This runs as a daemon process and listens to a UNIX domain socket ("/tmp/traffic_reader" by default).
 
 **Options:**<br>
 _-h, --help_<br>
 &nbsp;&nbsp;&nbsp;&nbsp;Display help<br>
-_-p, --port #_<br>
-&nbsp;&nbsp;&nbsp;&nbsp;Port number to listen to
+_-s, --socket PATH_<br>
+&nbsp;&nbsp;&nbsp;&nbsp;UNIX domain socket path
 
 **Exit status:**<br>
 Returns 0 if OK; non-zero otherwise.

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
@@ -75,7 +75,7 @@ protected:
   // Therefore, Thermal Throttling report is implemented in each derived class.
 
   // Intel CPU uses msr_reader to get thermal throttling data.
-  int msr_reader_port_;  //!< @brief port number to connect to msr_reader
+  std::string msr_reader_socket_path_;  //!< @brief UNIX domain socket path to connect to msr_reader
 
   struct ThermalThrottlingData
   {

--- a/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
@@ -351,7 +351,8 @@ protected:
 
   char hostname_[HOST_NAME_MAX + 1];  //!< @brief host name
 
-  int hdd_reader_port_;                         //!< @brief port number to connect to hdd_reader
+  std::string
+    hdd_reader_socket_path_;  //!< @brief path of UNIX domain socket to connect to hdd_reader
   std::map<std::string, HddParam> hdd_params_;  //!< @brief list of error and warning levels
   std::map<std::string, bool>
     hdd_connected_flags_;  //!< @brief list of flag whether HDD is connected

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -30,6 +30,8 @@
 
 #include <fmt/format.h>
 #include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 #include <algorithm>
 #include <cstdio>
@@ -40,6 +42,8 @@
 
 namespace
 {
+
+constexpr const char * DEFAULT_SOCKET_PATH = "/tmp/hdd_reader.sock";
 
 bool is_non_scsi_device(const std::string & device_name)
 {
@@ -58,7 +62,8 @@ namespace bp = boost::process;
 HddMonitor::HddMonitor(const rclcpp::NodeOptions & options)
 : Node("hdd_monitor", options),
   updater_(this),
-  hdd_reader_port_(declare_parameter<int>("hdd_reader_port", 7635)),
+  hdd_reader_socket_path_(
+    declare_parameter<std::string>("hdd_reader_socket_path", DEFAULT_SOCKET_PATH)),
   last_hdd_stat_update_time_{0, 0, this->get_clock()->get_clock_type()}
 {
   using namespace std::literals::chrono_literals;
@@ -649,7 +654,7 @@ void HddMonitor::updateHddInfoList()
   connect_diag_.clearSummary();
 
   // Create a new socket
-  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  int sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {
     connect_diag_.summary(DiagStatus::ERROR, "socket error");
     connect_diag_.add("socket", strerror(errno));
@@ -668,12 +673,10 @@ void HddMonitor::updateHddInfoList()
     return;
   }
 
-  // Connect the socket referred to by the file descriptor
-  sockaddr_in addr;
-  memset(&addr, 0, sizeof(sockaddr_in));
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(hdd_reader_port_);
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, hdd_reader_socket_path_.c_str(), sizeof(addr.sun_path) - 1);
   // cppcheck-suppress cstyleCast
   ret = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
   if (ret < 0) {
@@ -891,7 +894,7 @@ void HddMonitor::updateHddConnections()
 int HddMonitor::unmountDevice(std::string & device)
 {
   // Create a new socket
-  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  int sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {
     RCLCPP_ERROR(get_logger(), "socket create error. %s", strerror(errno));
     return -1;
@@ -909,11 +912,10 @@ int HddMonitor::unmountDevice(std::string & device)
   }
 
   // Connect the socket referred to by the file descriptor
-  sockaddr_in addr;
-  memset(&addr, 0, sizeof(sockaddr_in));
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(hdd_reader_port_);
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, hdd_reader_socket_path_.c_str(), sizeof(addr.sun_path) - 1);
   // cppcheck-suppress cstyleCast
   ret = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
   if (ret < 0) {

--- a/system/autoware_system_monitor/test/config/test_hdd_monitor.param.yaml
+++ b/system/autoware_system_monitor/test/config/test_hdd_monitor.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hdd_reader_port: 7635
+    hdd_reader_socket_path: "/tmp/hdd_reader.sock"
     disks:
     - name: /dev/sda
       temp_warn: 55.0


### PR DESCRIPTION
This PR is a cherry-picking PR which backports the following PR to tier4/autoware_universe.
- https://github.com/autowarefoundation/autoware_universe/pull/11199

This PR consists of the following changes:
* Use AF_UNIX socket for IPC between cpu_monitor (for x86_64) and msr_reader.
  * Add the "msr_reader_socket_path" parameter to the "cpu_monitor" node (Intel/AMD x86_64)
  * Remove the "port" parameter from the "cpu_monitor" node.
* Use AF_UNIX socket for IPC between hdd_monitor and hdd_reader.
  * Add the "hdd_reader_socket_path" parameter to the "hdd_monitor" node.
  * Remove the "port" parameter from the "hdd_monitor" node.
* Update configuration ".yaml" files about parameters.
* Update autoware_system_monitor documents for changes of node parameters.

**NOTE:**
The related cherry-picking PR to the "autoware_launch" repository (https://github.com/tier4/autoware_launch/pull/1124) should be merged simultaneously with this PR.