### PR TITLE
feat(diagnostic_graph_utils): use raw level for leaf node (backport #11327)

### DIFF
--- a/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
@@ -109,6 +109,17 @@ void LoggingNode::dump_unit(DiagNode * node, int depth, const std::string & inde
     return "-----";
   };
 
+  const auto leaf_level = [](const DiagNode * node) {
+    if (node->type() != "diag") {
+      return node->level();
+    }
+    const auto children = node->child_units();
+    if (children.empty()) {
+      return node->level();
+    }
+    return children.front()->level();
+  };
+
   if (max_depth_ < depth) {
     return;
   }
@@ -124,7 +135,7 @@ void LoggingNode::dump_unit(DiagNode * node, int depth, const std::string & inde
     path = "[anonymous group]";
   }
 
-  dump_text_ << indent << "- " + path << " " << text_level(node->level()) << std::endl;
+  dump_text_ << indent << "- " + path << " " << text_level(leaf_level(node)) << std::endl;
   for (const auto & child : node->child_nodes()) {
     dump_unit(child, depth + 1, indent + "    ");
   }


### PR DESCRIPTION
## Descriptions
backport from https://github.com/autowarefoundation/autoware_universe/pull/11327

## Related Links
https://tier4.atlassian.net/browse/RT0-39004

## Tests Perfomed
I confirmed it works when stale diags exist.
<img width="1793" height="1430" alt="image" src="https://github.com/user-attachments/assets/353a802b-b957-4209-ab53-10d4ebe57687" />
