### PR TITLE
feat(lane_change): improving lane change safety check (#2365)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -1314,6 +1314,19 @@ The following parameters are used to configure terminal lane change path feature
 | `collision_check.yaw_diff_threshold`                     | [rad] | double  | Maximum yaw difference between predicted ego pose and predicted object pose when executing rss-based collision checking                                                                                    | 3.1416        |
 | `collision_check.th_incoming_object_yaw`                 | [rad] | double  | Maximum yaw difference between current ego pose and current object pose. Objects with a yaw difference exceeding this value are excluded from the safety check.                                            | 2.3562        |
 
+#### safety constraints when ego is in prepare phase
+
+| Name                                                       | Unit    | Type   | Description                                                                                                                                                    | Default value |
+| :--------------------------------------------------------- | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `safety_check.prepare.expected_front_deceleration`         | [m/s^2] | double | The front object's maximum deceleration when the front vehicle perform sudden braking. (\*1)                                                                   | -1.0          |
+| `safety_check.prepare.expected_rear_deceleration`          | [m/s^2] | double | The rear object's maximum deceleration when the rear vehicle perform sudden braking. (\*1)                                                                     | -1.0          |
+| `safety_check.prepare.rear_vehicle_reaction_time`          | [s]     | double | The reaction time of the rear vehicle driver which starts from the driver noticing the sudden braking of the front vehicle until the driver step on the brake. | 1.0           |
+| `safety_check.prepare.rear_vehicle_safety_time_margin`     | [s]     | double | The time buffer for the rear vehicle to come into complete stop when its driver perform sudden braking.                                                        | 0.8           |
+| `safety_check.prepare.lateral_distance_max_threshold`      | [m]     | double | The lateral distance threshold that is used to determine whether lateral distance between two object is enough and whether lane change is safe.                | 0.5           |
+| `safety_check.prepare.longitudinal_distance_min_threshold` | [m]     | double | The longitudinal distance threshold that is used to determine whether longitudinal distance between two object is enough and whether lane change is safe.      | 1.0           |
+| `safety_check.prepare.longitudinal_velocity_delta_time`    | [m]     | double | The time multiplier that is used to compute the actual gap between vehicle at each predicted points (not RSS distance)                                         | 0.0           |
+| `safety_check.prepare.extended_polygon_policy`             | [-]     | string | Policy used to determine the polygon shape for the safety check. Available options are: `rectangle` or `along-path`.                                           | `rectangle`   |
+
 #### safety constraints during lane change path is computed
 
 | Name                                                         | Unit    | Type   | Description                                                                                                                                                    | Default value |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -52,6 +52,15 @@
         allow_loose_check_for_cancel: true
         enable_target_lane_bound_check: true
         stopped_object_velocity_threshold: 1.0 # [m/s]
+        prepare:                                        # RSS parameters used during the prepare phase, regardless of whether the ego is searching for a safe path, canceling, or transitioning to another state.
+          expected_front_deceleration: -1.0             # [m/s2]
+          expected_rear_deceleration: -1.0              # [m/s2]
+          rear_vehicle_reaction_time: 1.0               # [s]
+          rear_vehicle_safety_time_margin: 0.8          # [s]
+          lateral_distance_max_threshold: 0.5           # [m]
+          longitudinal_distance_min_threshold: 1.0      # [m]
+          longitudinal_velocity_delta_time: 0.0         # [s]
+          extended_polygon_policy: "along-path"         # [-] available options are `rectangle` or `along-path`
         execution:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -124,10 +133,6 @@
 
       # collision check
       collision_check:
-        enable_for_prepare_phase:
-          general_lanes: false
-          intersection: true
-          turns: true
         prediction_time_resolution: 0.5
         th_incoming_object_yaw: 2.3562 # [rad]
         yaw_diff_threshold: 3.1416 # [rad]

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -166,15 +166,12 @@ protected:
 
   bool is_colliding(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
-    const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
-    const RSSparams & selected_rss_param, const bool check_prepare_phase,
+    const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
     CollisionCheckDebugMap & debug_data) const;
 
   double get_max_velocity_for_safety_check() const;
 
   bool is_ego_stuck() const;
-
-  bool check_prepare_phase() const;
 
   void set_stop_pose(
     const double arc_length_to_stop_pose, PathWithLaneId & path, const std::string & reason = "");

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
@@ -88,9 +88,6 @@ struct CancelParameters
 
 struct CollisionCheckParameters
 {
-  bool enable_for_prepare_phase_in_general_lanes{false};
-  bool enable_for_prepare_phase_in_intersection{true};
-  bool enable_for_prepare_phase_in_turns{true};
   bool check_current_lane{true};
   bool check_other_lanes{true};
   bool use_all_predicted_paths{false};
@@ -110,6 +107,7 @@ struct SafetyParameters
   RSSparams rss_params_for_parked{};
   RSSparams rss_params_for_abort{};
   RSSparams rss_params_for_stuck{};
+  RSSparams rss_params_for_prepare{};
   ObjectTypesToCheck target_object_types{};
   CollisionCheckParameters collision_check{};
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -137,14 +137,6 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
       *node, parameter("safety_check.lane_expansion.right_offset"));
 
     // collision check
-    p.safety.collision_check.enable_for_prepare_phase_in_general_lanes =
-      get_or_declare_parameter<bool>(
-        *node, parameter("collision_check.enable_for_prepare_phase.general_lanes"));
-    p.safety.collision_check.enable_for_prepare_phase_in_intersection =
-      get_or_declare_parameter<bool>(
-        *node, parameter("collision_check.enable_for_prepare_phase.intersection"));
-    p.safety.collision_check.enable_for_prepare_phase_in_turns = get_or_declare_parameter<bool>(
-      *node, parameter("collision_check.enable_for_prepare_phase.turns"));
     p.safety.collision_check.check_current_lane =
       get_or_declare_parameter<bool>(*node, parameter("collision_check.check_current_lanes"));
     p.safety.collision_check.check_other_lanes =
@@ -177,6 +169,7 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
       params.extended_polygon_policy = get_or_declare_parameter<std::string>(
         *node, parameter(prefix + ".extended_polygon_policy"));
     };
+    set_rss_params(p.safety.rss_params_for_prepare, "safety_check.prepare");
     set_rss_params(p.safety.rss_params, "safety_check.execution");
     set_rss_params(p.safety.rss_params_for_parked, "safety_check.parked");
     set_rss_params(p.safety.rss_params_for_abort, "safety_check.cancel");
@@ -458,15 +451,6 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   {
     const std::string ns = "lane_change.collision_check.";
     update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.general_lanes",
-      p->safety.collision_check.enable_for_prepare_phase_in_general_lanes);
-    update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.intersection",
-      p->safety.collision_check.enable_for_prepare_phase_in_intersection);
-    update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.turns",
-      p->safety.collision_check.enable_for_prepare_phase_in_turns);
-    update_param<bool>(
       parameters, ns + "check_current_lanes", p->safety.collision_check.check_current_lane);
     update_param<bool>(
       parameters, ns + "check_other_lanes", p->safety.collision_check.check_other_lanes);
@@ -554,6 +538,7 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
     }
   };
 
+  update_rss_params("lane_change.safety_check.prepare.", p->safety.rss_params_for_prepare);
   update_rss_params("lane_change.safety_check.execution.", p->safety.rss_params);
   update_rss_params("lane_change.safety_check.parked.", p->safety.rss_params_for_parked);
   update_rss_params("lane_change.safety_check.cancel.", p->safety.rss_params_for_abort);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -72,11 +72,11 @@ bool isTargetObjectFront(
 Polygon2d createExtendedPolygon(
   const Pose & base_link_pose, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const double lon_length, const double lat_margin, const bool is_stopped_obj,
-  CollisionCheckDebug & debug);
+  CollisionCheckDebug * debug = nullptr);
 
 Polygon2d createExtendedPolygon(
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const double lon_length,
-  const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug & debug);
+  const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug * debug = nullptr);
 
 /**
  * @brief Converts path (path with velocity stamped) to predicted path.
@@ -195,6 +195,13 @@ bool checkCollision(
   const PredictedPathWithPolygon & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const RSSparams & rss_parameters,
   const double hysteresis_factor, const double yaw_difference_th, CollisionCheckDebug & debug);
+
+std::optional<Polygon2d> check_collision(
+  const PathWithLaneId & planned_path, const VehicleInfo & vehicle_info,
+  const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
+  const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const RSSparams & rss_parameters,
+  const double yaw_difference_th, const double max_velocity_limit, const double hysteresis_factor,
+  CollisionCheckDebug * debug = nullptr);
 
 /**
  * @brief Iterate the points in the ego and target's predicted path and

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -261,19 +261,22 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
   return std::make_pair(target_objects, other_objects);
 }
 
-std::vector<PredictedPathWithPolygon> getPredictedPathFromObj(
-  const ExtendedPredictedObject & obj, const bool & is_use_all_predicted_path)
-{
-  if (!is_use_all_predicted_path) {
-    const auto max_confidence_path = std::max_element(
-      obj.predicted_paths.begin(), obj.predicted_paths.end(),
-      [](const auto & path1, const auto & path2) { return path1.confidence < path2.confidence; });
-    if (max_confidence_path != obj.predicted_paths.end()) {
-      return {*max_confidence_path};
-    }
-  }
+template std::vector<PredictedPathWithPolygon> get_highest_confidence_paths(
+  std::vector<PredictedPathWithPolygon> predicted_paths);
+template std::vector<autoware_perception_msgs::msg::PredictedPath> get_highest_confidence_paths(
+  std::vector<autoware_perception_msgs::msg::PredictedPath> predicted_paths);
 
-  return obj.predicted_paths;
+template std::vector<PredictedPathWithPolygon> get_object_predicted_paths(
+  const std::vector<PredictedPathWithPolygon> & predicted_paths,
+  const bool is_use_all_predicted_path);
+template std::vector<autoware_perception_msgs::msg::PredictedPath> get_object_predicted_paths(
+  const std::vector<autoware_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const bool is_use_all_predicted_path);
+
+std::vector<PredictedPathWithPolygon> getPredictedPathFromObj(
+  const ExtendedPredictedObject & obj, const bool is_use_all_predicted_path)
+{
+  return get_object_predicted_paths(obj.predicted_paths, is_use_all_predicted_path);
 }
 
 std::vector<PoseWithVelocityStamped> createPredictedPath(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
@@ -175,7 +175,6 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
   vehicle_info.max_longitudinal_offset_m = 4.0;
   vehicle_info.vehicle_width_m = 2.0;
   vehicle_info.rear_overhang_m = 1.0;
-  CollisionCheckDebug debug;
 
   {
     Pose ego_pose;
@@ -186,8 +185,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -214,8 +213,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -242,8 +241,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -291,12 +290,10 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    CollisionCheckDebug debug;
-
     PoseWithVelocityAndPolygonStamped obj_pose_with_poly(
       0.0, obj_pose, 0.0, autoware_utils::to_polygon2d(obj_pose, shape));
     const auto polygon =
-      createExtendedPolygon(obj_pose_with_poly, lon_length, lat_margin, is_stopped_object, debug);
+      createExtendedPolygon(obj_pose_with_poly, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 


### PR DESCRIPTION
* fix(bpp_common, lane_change): generate extended objects directly with highest confidence path. (#11304)

* fix(bpp_common, lane_change): generate extended objects directly with highest confidence path.

Cherry-pick lane change for experiment

The change is already merged into `beta/v0.48`, but since this branch was created before that merge, I manually cherry-picked it.

https://github.com/tier4/autoware_launch.x2/pull/1540 → launcher's 