### PR TITLE
fix(gpu_monitor): stop false warning messages reported by gpu_monitor when the GPU is idle

### DIFF
--- a/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -237,9 +237,12 @@ void GPUMonitor::addProcessUsage(
   utils = std::make_unique<nvmlProcessUtilizationSample_t[]>(util_count);
   ret = nvmlDeviceGetProcessUtilization(device, utils.get(), &util_count, current_timestamp_);
   if (ret != NVML_SUCCESS) {
-    RCLCPP_WARN(
-      this->get_logger(), "Failed to nvmlDeviceGetProcessUtilization(2nd) NVML: %s",
-      nvmlErrorString(ret));
+    // NVML_ERROR_NOT_FOUND is expected when no process is running on the GPU.
+    if (ret != NVML_ERROR_NOT_FOUND) {
+      RCLCPP_WARN(
+        this->get_logger(), "Failed to nvmlDeviceGetProcessUtilization(2nd) NVML: %s",
+        nvmlErrorString(ret));
+    }
     return;
   }
 


### PR DESCRIPTION
This PR is a cherry-picking PR which backports the following PR to tier4/autoware_universe.

* https://github.com/autowarefoundation/autoware_universe/pull/11291

This PR stops the false warning "Failed to nvmlDeviceGetProcessUtilization(2nd) NVML: Not Found" from being reported when the GPU is idle.
When the GPU is idle, the error code NVML_ERROR_NOT_FOUND is returned from nvmlDeviceGetProcessUtilization(), but it is one of the expected results and it should be ignored.