### PR TITLE
fix(gpu_monitor): report gpu usage successfully on nvidia jetson agx orin

### DIFF
--- a/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
@@ -170,7 +170,12 @@ void GPUMonitor::getTempNames()
 
 void GPUMonitor::getLoadNames()
 {
-  const fs::path root("/sys/devices");
+  // Both Jetson AGX Xavier and Orin provide a symbolic link with the same name
+  // "/sys/devices/platform/gpu.0", which points to a platform-specific
+  // device file.
+  // Xavier also provides another symbolic link "/sys/devices/gpu.0",
+  // but Orin does not.
+  const fs::path root("/sys/devices/platform");
 
   for (const fs::path & path :
        boost::make_iterator_range(fs::directory_iterator(root), fs::directory_iterator())) {


### PR DESCRIPTION
This PR is a cherry-picking PR which backports the following PR to tier4/autoware_universe.

* https://github.com/autowarefoundation/autoware_universe/pull/11326

Read GPU load from "/sys/devices/platform/gpu.0" instead of "/sys/devices/gpu.0" because Jetson AGX Orin doesn't have the latter and gpu_monitor fails to read "GPU Usage" on Orin.