### PR TITLE
fix(crosswalk, traffic_light): correct distance calculation by swapping src and dst (#11393)

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1546,7 +1546,7 @@ void CrosswalkModule::planStop(
   const bool suppress_restart = checkRestartSuppression(ego_path, stop_factor);
   if (suppress_restart) {
     const auto & ego_pos = planner_data_->current_odometry->pose.position;
-    const double dist = calcSignedArcLength(ego_path.points, ego_pos, 0L);
+    const double dist = calcSignedArcLength(ego_path.points, 0L, ego_pos);
     const auto pose_opt = calcLongitudinalOffsetPose(ego_path.points, 0L, dist);
     if (pose_opt.has_value()) stop_factor->stop_pose = pose_opt.value();
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -150,7 +150,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
         RCLCPP_DEBUG(logger_, "Suppressing restart due to proximity to stop line.");
         const auto & ego_pos = planner_data_->current_odometry->pose.position;
         const double dist =
-          autoware::motion_utils::calcSignedArcLength(input_path.points, ego_pos, 0L);
+          autoware::motion_utils::calcSignedArcLength(input_path.points, 0L, ego_pos);
         const auto pose_opt =
           autoware::motion_utils::calcLongitudinalOffsetPose(input_path.points, 0L, dist);
         if (pose_opt.has_value()) {


### PR DESCRIPTION
See original PR: https://github.com/autowarefoundation/autoware_universe/pull/11393