### PR TITLE
fix(velocity_smoother): prevent access when vector is empty (cherry-pick)

### DIFF
--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -57,6 +57,9 @@ TrajectoryPoints resampleTrajectory(
   for (double ds = 0.0; ds <= front_arclength_value; ds += front_ds) {
     out_arclength.push_back(ds);
   }
+  if (out_arclength.empty()) {
+    return input;
+  }
   if (std::fabs(out_arclength.back() - front_arclength_value) < 1e-3) {
     out_arclength.back() = front_arclength_value;
   } else {
@@ -181,6 +184,9 @@ TrajectoryPoints resampleTrajectory(
   const auto front_arclength_value = std::fabs(negative_front_arclength_value);
   for (double s = 0.0; s <= front_arclength_value; s += nominal_ds) {
     out_arclength.push_back(s);
+  }
+  if (out_arclength.empty()) {
+    return input;
   }
   if (std::fabs(out_arclength.back() - front_arclength_value) < 1e-3) {
     out_arclength.back() = front_arclength_value;


### PR DESCRIPTION
This commit is cherry-picked from https://github.com/autowarefoundation/autoware_core/pull/438 .
related jira ticket: https://tier4.atlassian.net/browse/T4DEV-31520