### PR TITLE
feat(raw_vehicle_cmd_converter): subscribe to slip_detector K_us when enabled

### DIFF
--- a/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
@@ -31,5 +31,7 @@
     vgr_coef_b: 0.053
     vgr_coef_c: 0.042
     understeer_gradient: 0.0
+    use_dynamic_understeer_gradient: false
+    max_estimated_understeer_gradient_age_sec: 1.0
     convert_actuation_to_steering_status: false
     use_vehicle_adaptor: false

--- a/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/node.hpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/node.hpp
@@ -36,10 +36,12 @@
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_debug_msgs/msg/float64_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/actuation_status_stamped.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -104,6 +106,9 @@ public:
   // control_horizon is an experimental topic, but vehicle_adaptor uses it to improve performance,
   autoware_utils::InterProcessPollingSubscriber<ControlHorizon> sub_control_horizon_{
     this, "~/input/control_horizon"};
+  std::optional<
+    autoware_utils::InterProcessPollingSubscriber<tier4_debug_msgs::msg::Float64Stamped>>
+    sub_estimated_understeer_gradient_;
 
   rclcpp::TimerBase::SharedPtr timer_;
 
@@ -143,6 +148,9 @@ public:
   // For example, receive the steering wheel angle and calculate the steering wheel angle based on
   // the gear ratio. If false, the vehicle interface must publish steering_status.
   bool convert_actuation_to_steering_status_{false};  // !< @brief use actuation_status or not
+  bool use_dynamic_understeer_gradient_{false};
+  double static_understeer_gradient_{0.0};
+  double max_estimated_understeer_gradient_age_sec_{1.0};
 
   double calculateAccelMap(
     const double current_velocity, const double desired_acc, bool & accel_cmd_is_zero);
@@ -152,6 +160,7 @@ public:
   void onSteering(const Steering::ConstSharedPtr msg);
   void onActuationStatus(const ActuationStatusStamped::ConstSharedPtr msg);
   void publishActuationCmd();
+  void updateUndersteerGradient();
   // for debugging
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr debug_pub_steer_pid_;
   DebugValues debug_steer_;

--- a/vehicle/autoware_raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
@@ -7,6 +7,7 @@
   <arg name="input_actuation_status" default="/vehicle/status/actuation_status"/>
   <arg name="input_operation_mode_state" default="/system/operation_mode/state"/>
   <arg name="input_control_horizon" default="/control/trajectory_follower/controller_node_exe/debug/control_cmd_horizon"/>
+  <arg name="input_estimated_understeer_gradient" default="/l4_toolkit/slip_detector/estimated_understeer_gradient"/>
   <arg name="output_actuation_cmd" default="/control/command/actuation_cmd"/>
   <arg name="output_steering_status" default="/vehicle/status/steering_status"/>
   <arg name="output_control_component_latency" default="/control/control_component_latency"/>
@@ -22,6 +23,7 @@
     <remap from="~/input/actuation_status" to="$(var input_actuation_status)"/>
     <remap from="~/input/operation_mode_state" to="$(var input_operation_mode_state)"/>
     <remap from="~/input/control_horizon" to="$(var input_control_horizon)"/>
+    <remap from="~/input/estimated_understeer_gradient" to="$(var input_estimated_understeer_gradient)"/>
     <remap from="~/output/actuation_cmd" to="$(var output_actuation_cmd)"/>
     <remap from="~/output/steering_status" to="$(var output_steering_status)"/>
     <remap from="~/output/control_component_latency" to="$(var output_control_component_latency)"/>

--- a/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
@@ -33,6 +33,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
 
   <exec_depend>rclpy</exec_depend>

--- a/vehicle/autoware_raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
@@ -186,6 +186,17 @@
           "default": "0.0",
           "description": "Understeer gradient [rad·s²/m]"
         },
+        "use_dynamic_understeer_gradient": {
+          "type": "boolean",
+          "default": "false",
+          "description": "When true and convert_steer_cmd_method is understeer_compensation, use ~/input/estimated_understeer_gradient instead of the static understeer_gradient parameter"
+        },
+        "max_estimated_understeer_gradient_age_sec": {
+          "type": "number",
+          "default": "1.0",
+          "minimum": 0.0,
+          "description": "Maximum age [s] of the estimated understeer gradient topic before falling back to the static understeer_gradient parameter"
+        },
         "convert_actuation_to_steering_status": {
           "type": "boolean",
           "default": "true",

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
@@ -69,6 +69,7 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
       vgr_with_us_.setUndersteerParams(k_us, vehicle_info_.wheel_base_m);
     } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
       const double k_us = declare_parameter<double>("understeer_gradient");
+      static_understeer_gradient_ = k_us;
       understeer_comp_.setUndersteerParams(k_us, vehicle_info_.wheel_base_m);
     } else if (convert_steer_cmd_method_.value() == "steer_map") {
       const auto csv_path_steer_map = declare_parameter<std::string>("csv_path_steer_map");
@@ -96,6 +97,22 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
       steer_pid_.setInitialized();
     } else {
       throw std::invalid_argument("Invalid steer conversion method.");
+    }
+
+    use_dynamic_understeer_gradient_ =
+      declare_parameter<bool>("use_dynamic_understeer_gradient", false);
+    max_estimated_understeer_gradient_age_sec_ =
+      declare_parameter<double>("max_estimated_understeer_gradient_age_sec", 1.0);
+    if (use_dynamic_understeer_gradient_) {
+      if (convert_steer_cmd_method_.value() != "understeer_compensation") {
+        RCLCPP_WARN(
+          get_logger(),
+          "use_dynamic_understeer_gradient is ignored unless convert_steer_cmd_method is "
+          "understeer_compensation");
+        use_dynamic_understeer_gradient_ = false;
+      } else {
+        sub_estimated_understeer_gradient_.emplace(this, "~/input/estimated_understeer_gradient");
+      }
     }
   }
 
@@ -139,6 +156,25 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
   }
 
   logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+}
+
+void RawVehicleCommandConverterNode::updateUndersteerGradient()
+{
+  if (!use_dynamic_understeer_gradient_) {
+    return;
+  }
+
+  const auto estimated_understeer_gradient = sub_estimated_understeer_gradient_->take_data();
+  if (
+    estimated_understeer_gradient &&
+    (now() - rclcpp::Time(estimated_understeer_gradient->stamp)).seconds() <=
+      max_estimated_understeer_gradient_age_sec_) {
+    const double k_us = std::max(estimated_understeer_gradient->data, 0.0);
+    understeer_comp_.setUndersteerParams(k_us, vehicle_info_.wheel_base_m);
+    return;
+  }
+
+  understeer_comp_.setUndersteerParams(static_understeer_gradient_, vehicle_info_.wheel_base_m);
 }
 
 void RawVehicleCommandConverterNode::publishActuationCmd()
@@ -218,6 +254,7 @@ void RawVehicleCommandConverterNode::publishActuationCmd()
       vgr_with_us_.calculateVariableGearRatio(vel, current_steer_wheel);
     desired_steer_cmd = steer * adaptive_gear_ratio;
   } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
+    updateUndersteerGradient();
     desired_steer_cmd = steer * understeer_comp_.calculateUndersteerRatio(vel);
     const double max_steer_tire_angle = vehicle_info_.max_steer_angle_rad;
     desired_steer_cmd = std::clamp(desired_steer_cmd, -max_steer_tire_angle, max_steer_tire_angle);
@@ -349,6 +386,7 @@ void RawVehicleCommandConverterNode::onActuationStatus(
       steering_msg.steering_tire_angle = *current_steer_ptr_;
       pub_steering_status_->publish(steering_msg);
     } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
+      updateUndersteerGradient();
       current_steer_ptr_ = std::make_unique<double>(understeer_comp_.calculateSteeringTireState(
         current_odometry_->twist.twist.linear.x, actuation_status_ptr_->status.steer_status));
       Steering steering_msg{};


### PR DESCRIPTION
## Summary
- Wire `slip_detector`'s smoothed `/l4_toolkit/slip_detector/estimated_understeer_gradient` into `autoware_raw_vehicle_cmd_converter` when `convert_steer_cmd_method` is `understeer_compensation`.
- Add `use_dynamic_understeer_gradient` (default `false`) and `max_estimated_understeer_gradient_age_sec` (default `1.0`) parameters; static `understeer_gradient` remains the fallback before first message or when the topic is stale.
- Poll `~/input/estimated_understeer_gradient` (`tier4_debug_msgs/Float64Stamped`) and update `UndersteerCompensation` on both forward (actuation cmd) and inverse (steering status) paths.

## Test plan
- [x] `colcon build --packages-select autoware_raw_vehicle_cmd_converter`
- [x] Existing unit tests pass (`test_autoware_raw_vehicle_cmd_converter`, 10/10)
- [ ] Runtime: enable `use_dynamic_understeer_gradient: true` with slip_detector running and verify compensated steer tracks estimated K_us

## Notes for reviewers
- Feature is opt-in (`use_dynamic_understeer_gradient: false` by default); existing static behavior unchanged.
- Only applies to `understeer_compensation` mode (not `vgr_with_understeer_compensation`).
- Launch remap default: `/l4_toolkit/slip_detector/estimated_understeer_gradient`.

## Interface changes

### Topic changes

| Change type | Topic Type | Topic Name | Message Type | Description |
|:------------|:-----------|:-----------|:-------------|:------------|
| Added (input) | Sub | `~/input/estimated_understeer_gradient` | `tier4_debug_msgs/Float64Stamped` | Optional dynamic K_us from slip_detector (only when `use_dynamic_understeer_gradient: true`) |

### ROS Parameter Changes

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `use_dynamic_understeer_gradient` | `bool` | `false` | Use slip_detector estimated K_us instead of static param |
| Added | `max_estimated_understeer_gradient_age_sec` | `double` | `1.0` | Max topic age before falling back to static `understeer_gradient` |


Made with [Cursor](https://cursor.com)