### PR TITLE
feat(diffusion_planner): force takeoff via synthetic ego history

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -176,7 +176,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       test/lanelet_edge_case_test.cpp
       test/diffusion_planner_integration_test.cpp
       test/rtc_prefix_test.cpp
-      test/planning_factor_utils_test.cpp)
+      test/planning_factor_utils_test.cpp
+      test/force_takeoff_test.cpp)
 
     target_link_libraries(test_diffusion_planner autoware_diffusion_planner_component)
     ament_target_dependencies(test_diffusion_planner

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -164,6 +164,14 @@ ros2 launch autoware_launch planning_simulator.launch.xml \
 
 - **ONNX Runtime** inference for fast neural network execution
 - **ROS 2 publishers** for planned trajectories, predicted objects, and debug markers
+- **Force takeoff**: when the Autoware state transitions to `DRIVING` (engage) while the ego has
+  been stationary for more than `force_takeoff.stationary_duration_s` and no tracked object is
+  within `force_takeoff.min_agent_distance_m`, the ego history and current state fed to the model
+  are replaced with a synthetic straight-line motion at `force_takeoff.synthetic_speed_mps`
+  (zero acceleration) to help the model start moving. The override is released once the real ego
+  speed reaches `force_takeoff.release_speed_mps`, and aborted immediately if an agent enters the
+  radius. Configurable via the `force_takeoff.*` parameters; requires the `~/input/autoware_state`
+  topic (remapped to `/autoware/state` by default).
 
 ---
 
@@ -186,6 +194,7 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 | `~/input/vector_map`      | autoware_map_msgs/msg/LaneletMapBin                 | Lanelet2 map               |
 | `~/input/route`           | autoware_planning_msgs/msg/LaneletRoute             | Route information          |
 | `~/input/turn_indicators` | autoware_vehicle_msgs/msg/TurnIndicatorsReport      | Turn indicator information |
+| `~/input/autoware_state`  | autoware_system_msgs/msg/AutowareState              | Autoware state (engage detection for force takeoff) |
 
 ## Outputs
 

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -164,14 +164,15 @@ ros2 launch autoware_launch planning_simulator.launch.xml \
 
 - **ONNX Runtime** inference for fast neural network execution
 - **ROS 2 publishers** for planned trajectories, predicted objects, and debug markers
-- **Force takeoff**: when the Autoware state transitions to `DRIVING` (engage) while the ego has
-  been stationary for more than `force_takeoff.stationary_duration_s` and no tracked object is
-  within `force_takeoff.min_agent_distance_m`, the ego history and current state fed to the model
-  are replaced with a synthetic straight-line motion at `force_takeoff.synthetic_speed_mps`
-  (zero acceleration) to help the model start moving. The override is released once the real ego
-  speed reaches `force_takeoff.release_speed_mps`, and aborted immediately if an agent enters the
-  radius. Configurable via the `force_takeoff.*` parameters; requires the `~/input/autoware_state`
-  topic (remapped to `/autoware/state` by default).
+- **Force takeoff**: when the Autoware state transitions to `DRIVING` (engage), a stall timer
+  starts. If the ego still has not started moving `force_takeoff.stationary_duration_s` after the
+  engage and no tracked object is within `force_takeoff.min_agent_distance_m`, the ego history and
+  current state fed to the model are replaced with a synthetic straight-line motion at
+  `force_takeoff.synthetic_speed_mps` (zero acceleration) to help the model start moving. The
+  override is released once the real ego speed reaches `force_takeoff.release_speed_mps`, and
+  aborted immediately if an agent enters the radius. Configurable via the `force_takeoff.*`
+  parameters; requires the `~/input/autoware_state` topic (remapped to `/autoware/state` by
+  default).
 
 ---
 

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -166,7 +166,8 @@ ros2 launch autoware_launch planning_simulator.launch.xml \
 - **ROS 2 publishers** for planned trajectories, predicted objects, and debug markers
 - **Force takeoff**: when the Autoware state transitions to `DRIVING` (engage), a stall timer
   starts. If the ego still has not started moving `force_takeoff.stationary_duration_s` after the
-  engage and no tracked object is within `force_takeoff.min_agent_distance_m`, the ego history and
+  engage, the ego is within `force_takeoff.max_distance_to_start_m` of the route start pose, and
+  no tracked object is within `force_takeoff.min_agent_distance_m`, the ego history and
   current state fed to the model are replaced with a synthetic straight-line motion at
   `force_takeoff.synthetic_speed_mps` (zero acceleration) to help the model start moving. The
   override is released once the real ego speed reaches `force_takeoff.release_speed_mps`, and

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -43,6 +43,7 @@
       stationary_duration_s: 3.0 # [s] activate if the ego has not started moving this long after engage
       release_speed_mps: 0.5 # [m/s] deactivate once the real ego speed reaches this
       min_agent_distance_m: 20.0 # [m] no tracked object may be within this radius
+      max_distance_to_start_m: 5.0 # [m] do not override if the ego is farther than this from the route start pose
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -37,6 +37,12 @@
     use_time_interpolation: false
     use_mppi_optimizer: false
     shadow_mode: false
+    force_takeoff:
+      enable: true
+      synthetic_speed_mps: 1.5 # [m/s] simulated constant speed for the synthetic ego history
+      stationary_duration_s: 3.0 # [s] ego must have been stationary at least this long at engage
+      release_speed_mps: 0.5 # [m/s] deactivate once the real ego speed reaches this
+      min_agent_distance_m: 20.0 # [m] no tracked object may be within this radius
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -40,7 +40,7 @@
     force_takeoff:
       enable: true
       synthetic_speed_mps: 1.5 # [m/s] simulated constant speed for the synthetic ego history
-      stationary_duration_s: 3.0 # [s] ego must have been stationary at least this long at engage
+      stationary_duration_s: 3.0 # [s] activate if the ego has not started moving this long after engage
       release_speed_mps: 0.5 # [m/s] deactivate once the real ego speed reaches this
       min_agent_distance_m: 20.0 # [m] no tracked object may be within this radius
     planning_factor:

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -197,7 +197,7 @@ public:
    * @param traffic_signals Traffic signal information
    * @param turn_indicators Current turn indicator state
    * @param route_ptr Route information
-   * @param autoware_state Latest autoware state (nullptr if no new message)
+   * @param autoware_state Latest cached autoware state (nullptr only before the first message)
    * @param current_time Current timestamp
    * @return FrameContext containing preprocessed data, or nullopt if data is incomplete
    */
@@ -240,6 +240,31 @@ public:
    * @return true if map is loaded, false otherwise
    */
   bool is_map_loaded() const { return lane_segment_context_ != nullptr; }
+
+  /**
+   * @brief Update the force-takeoff state machine for the current frame.
+   *
+   * When the autoware state transitions to DRIVING (engage), starts a stall timer. If the ego
+   * still has not started moving stationary_duration_s after the engage and no tracked object is
+   * within the configured radius, activates the ego history/state override. Deactivates once the
+   * ego reaches the release speed; aborts immediately if an agent enters the radius while active,
+   * if the autoware state leaves DRIVING, or if force_takeoff.enable is set to false.
+   *
+   * Public for direct unit testing; called every frame by create_frame_context.
+   *
+   * @param kinematic_state Current ego odometry
+   * @param objects Tracked objects (unfiltered)
+   * @param autoware_state Latest cached autoware state (nullptr only before the first message)
+   * @param current_time Current timestamp
+   */
+  void update_force_takeoff_state(
+    const Odometry & kinematic_state, const TrackedObjects & objects,
+    const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time);
+
+  /**
+   * @brief Whether the force takeoff override is currently active.
+   */
+  bool is_force_takeoff_active() const { return force_takeoff_active_; }
 
   /**
    * @brief Enable or disable start guidance.
@@ -347,23 +372,6 @@ private:
    *        apply the latest hold duration / keep offset parameters to each of them.
    */
   void sync_turn_indicator_managers();
-
-  /**
-   * @brief Update the force-takeoff state machine for the current frame.
-   *
-   * When the autoware state transitions to DRIVING (engage), starts a stall timer. If the ego
-   * still has not started moving stationary_duration_s after the engage and no tracked object is
-   * within the configured radius, activates the ego history/state override. Deactivates once the
-   * ego reaches the release speed, or aborts if an agent enters the radius while active.
-   *
-   * @param kinematic_state Current ego odometry
-   * @param objects Tracked objects (unfiltered)
-   * @param autoware_state Latest autoware state (nullptr if no new message)
-   * @param current_time Current timestamp
-   */
-  void update_force_takeoff_state(
-    const Odometry & kinematic_state, const TrackedObjects & objects,
-    const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time);
 
   // Force takeoff state
   std::optional<uint8_t> previous_autoware_state_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -35,6 +35,7 @@
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -61,6 +62,7 @@ using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::TrackedObjects;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::Trajectory;
+using autoware_system_msgs::msg::AutowareState;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using autoware_vehicle_msgs::msg::TurnIndicatorsReport;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
@@ -106,6 +108,7 @@ struct FrameContext
   Eigen::Matrix4d ego_to_map_transform;
   std::vector<AgentHistory> ego_centric_neighbor_histories;
   rclcpp::Time frame_time;
+  bool force_takeoff_active{false};
 };
 
 struct DiffusionPlannerParams
@@ -141,6 +144,11 @@ struct DiffusionPlannerParams
   double centerline_guidance_start_time_s;
   bool use_mppi_optimizer;
   bool shadow_mode;
+  bool force_takeoff_enable;
+  double force_takeoff_synthetic_speed_mps;
+  double force_takeoff_stationary_duration_s;
+  double force_takeoff_release_speed_mps;
+  double force_takeoff_min_agent_distance_m;
 };
 
 /**
@@ -189,6 +197,7 @@ public:
    * @param traffic_signals Traffic signal information
    * @param turn_indicators Current turn indicator state
    * @param route_ptr Route information
+   * @param autoware_state Latest autoware state (nullptr if no new message)
    * @param current_time Current timestamp
    * @return FrameContext containing preprocessed data, or nullopt if data is incomplete
    */
@@ -200,7 +209,8 @@ public:
       std::shared_ptr<const autoware_perception_msgs::msg::TrafficLightGroupArray>> &
       traffic_signals,
     const std::shared_ptr<const TurnIndicatorsReport> & turn_indicators,
-    const LaneletRoute::ConstSharedPtr & route_ptr, const rclcpp::Time & current_time);
+    const LaneletRoute::ConstSharedPtr & route_ptr,
+    const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time);
 
   /**
    * @brief Build model input tensors from frame context.
@@ -337,6 +347,28 @@ private:
    *        apply the latest hold duration / keep offset parameters to each of them.
    */
   void sync_turn_indicator_managers();
+
+  /**
+   * @brief Update the force-takeoff state machine for the current frame.
+   *
+   * Activates the ego history/state override when the autoware state transitions to DRIVING
+   * (engage) while the ego has been stationary for longer than the configured duration and no
+   * tracked object is within the configured radius. Deactivates once the ego reaches the release
+   * speed, or aborts if an agent enters the radius while active.
+   *
+   * @param kinematic_state Current ego odometry
+   * @param objects Tracked objects (unfiltered)
+   * @param autoware_state Latest autoware state (nullptr if no new message)
+   * @param current_time Current timestamp
+   */
+  void update_force_takeoff_state(
+    const Odometry & kinematic_state, const TrackedObjects & objects,
+    const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time);
+
+  // Force takeoff state
+  std::optional<uint8_t> previous_autoware_state_;
+  std::optional<rclcpp::Time> last_moving_time_;
+  bool force_takeoff_active_{false};
 
   // History data
   std::deque<nav_msgs::msg::Odometry> ego_history_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -149,6 +149,7 @@ struct DiffusionPlannerParams
   double force_takeoff_stationary_duration_s;
   double force_takeoff_release_speed_mps;
   double force_takeoff_min_agent_distance_m;
+  double force_takeoff_max_distance_to_start_m;
 };
 
 /**
@@ -245,21 +246,24 @@ public:
    * @brief Update the force-takeoff state machine for the current frame.
    *
    * When the autoware state transitions to DRIVING (engage), starts a stall timer. If the ego
-   * still has not started moving stationary_duration_s after the engage and no tracked object is
-   * within the configured radius, activates the ego history/state override. Deactivates once the
-   * ego reaches the release speed; aborts immediately if an agent enters the radius while active,
-   * if the autoware state leaves DRIVING, or if force_takeoff.enable is set to false.
+   * still has not started moving stationary_duration_s after the engage, is within
+   * max_distance_to_start_m of the route start pose, and no tracked object is within the
+   * configured radius, activates the ego history/state override. Deactivates once the ego reaches
+   * the release speed; aborts immediately if an agent enters the radius while active, if the
+   * autoware state leaves DRIVING, or if force_takeoff.enable is set to false.
    *
    * Public for direct unit testing; called every frame by create_frame_context.
    *
    * @param kinematic_state Current ego odometry
    * @param objects Tracked objects (unfiltered)
    * @param autoware_state Latest cached autoware state (nullptr only before the first message)
+   * @param route_start_pose Start pose of the current route
    * @param current_time Current timestamp
    */
   void update_force_takeoff_state(
     const Odometry & kinematic_state, const TrackedObjects & objects,
-    const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time);
+    const std::shared_ptr<const AutowareState> & autoware_state,
+    const geometry_msgs::msg::Pose & route_start_pose, const rclcpp::Time & current_time);
 
   /**
    * @brief Whether the force takeoff override is currently active.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -351,10 +351,10 @@ private:
   /**
    * @brief Update the force-takeoff state machine for the current frame.
    *
-   * Activates the ego history/state override when the autoware state transitions to DRIVING
-   * (engage) while the ego has been stationary for longer than the configured duration and no
-   * tracked object is within the configured radius. Deactivates once the ego reaches the release
-   * speed, or aborts if an agent enters the radius while active.
+   * When the autoware state transitions to DRIVING (engage), starts a stall timer. If the ego
+   * still has not started moving stationary_duration_s after the engage and no tracked object is
+   * within the configured radius, activates the ego history/state override. Deactivates once the
+   * ego reaches the release speed, or aborts if an agent enters the radius while active.
    *
    * @param kinematic_state Current ego odometry
    * @param objects Tracked objects (unfiltered)
@@ -367,7 +367,7 @@ private:
 
   // Force takeoff state
   std::optional<uint8_t> previous_autoware_state_;
-  std::optional<rclcpp::Time> last_moving_time_;
+  std::optional<rclcpp::Time> engage_time_;
   bool force_takeoff_active_{false};
 
   // History data

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -40,6 +40,7 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
@@ -259,6 +260,8 @@ private:
     sub_traffic_signals_{this, "~/input/traffic_signals", rclcpp::QoS{10}};
   autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsReport> sub_turn_indicators_{
     this, "~/input/turn_indicators"};
+  autoware_utils::InterProcessPollingSubscriber<autoware_system_msgs::msg::AutowareState>
+    sub_autoware_state_{this, "~/input/autoware_state"};
   autoware_utils::InterProcessPollingSubscriber<
     LaneletRoute, autoware_utils::polling_policy::Newest>
     route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp
@@ -85,6 +85,26 @@ std::vector<float> create_ego_agent_past(
   const std::optional<rclcpp::Time> & reference_time = std::nullopt);
 
 /**
+ * @brief Creates a synthetic ego history simulating straight-line motion at constant speed.
+ *
+ * Generates num_timesteps odometry messages ending at current_pose (the last entry), with
+ * preceding poses shifted backwards along the pose heading by speed_mps * time_step_s each
+ * step. All entries carry a constant longitudinal twist of speed_mps and timestamps spaced
+ * time_step_s apart, ending at current_time. Used by the force-takeoff feature to make the
+ * model believe the ego is already moving.
+ *
+ * @param[in] current_pose  Current ego pose in map frame (most recent history entry)
+ * @param[in] current_time  Timestamp of the most recent history entry
+ * @param[in] num_timesteps Number of history entries to generate
+ * @param[in] speed_mps     Simulated constant longitudinal speed [m/s]
+ * @param[in] time_step_s   Time step between consecutive history entries [s]
+ * @return Deque of odometry messages, oldest first
+ */
+std::deque<nav_msgs::msg::Odometry> create_synthetic_ego_history(
+  const geometry_msgs::msg::Pose & current_pose, const rclcpp::Time & current_time,
+  size_t num_timesteps, double speed_mps, double time_step_s);
+
+/**
  * @brief Creates random sampled trajectories for diffusion model input.
  *
  * This function generates a set of random sampled trajectories based on the specified

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input_tracked_objects" default="~/input/tracked_objects"/>
   <arg name="input_vector_map" default="~/input/vector_map"/>
   <arg name="input_turn_indicators" default="~/input/turn_indicators"/>
+  <arg name="input_autoware_state" default="/autoware/state"/>
   <arg name="build_only" default="false" description="shutdown node after model initialization"/>
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="both">
@@ -39,6 +40,7 @@
     <remap from="~/input/tracked_objects" to="$(var input_tracked_objects)"/>
     <remap from="~/input/vector_map" to="$(var input_vector_map)"/>
     <remap from="~/input/turn_indicators" to="$(var input_turn_indicators)"/>
+    <remap from="~/input/autoware_state" to="$(var input_autoware_state)"/>
     <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -29,6 +29,7 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>autoware_tensorrt_common</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_trajectory</depend>

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -336,7 +336,8 @@
         "turn_indicator_hold_duration",
         "planning_factor",
         "debug_params",
-        "guidance"
+        "guidance",
+        "force_takeoff"
       ]
     }
   },

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -292,6 +292,12 @@
               "default": 20.0,
               "minimum": 0,
               "description": "No tracked object may be within this radius of the ego for the override to activate or stay active [m]"
+            },
+            "max_distance_to_start_m": {
+              "type": "number",
+              "default": 5.0,
+              "minimum": 0,
+              "description": "Do not activate the override if the ego is farther than this from the route start pose [m]"
             }
           },
           "required": [
@@ -299,7 +305,8 @@
             "synthetic_speed_mps",
             "stationary_duration_s",
             "release_speed_mps",
-            "min_agent_distance_m"
+            "min_agent_distance_m",
+            "max_distance_to_start_m"
           ]
         },
         "debug_params": {

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -261,6 +261,47 @@
             "slowdown_accel_threshold"
           ]
         },
+        "force_takeoff": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable the force takeoff feature (synthetic ego history override at engage)"
+            },
+            "synthetic_speed_mps": {
+              "type": "number",
+              "default": 1.5,
+              "minimum": 0,
+              "description": "Simulated constant longitudinal speed for the synthetic ego history [m/s]"
+            },
+            "stationary_duration_s": {
+              "type": "number",
+              "default": 3.0,
+              "minimum": 0,
+              "description": "Minimum duration the ego must have been stationary at engage to activate [s]"
+            },
+            "release_speed_mps": {
+              "type": "number",
+              "default": 0.5,
+              "minimum": 0,
+              "description": "Real ego speed at which the synthetic override is released [m/s]"
+            },
+            "min_agent_distance_m": {
+              "type": "number",
+              "default": 20.0,
+              "minimum": 0,
+              "description": "No tracked object may be within this radius of the ego for the override to activate or stay active [m]"
+            }
+          },
+          "required": [
+            "enable",
+            "synthetic_speed_mps",
+            "stationary_duration_s",
+            "release_speed_mps",
+            "min_agent_distance_m"
+          ]
+        },
         "debug_params": {
           "type": "object",
           "properties": {

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -279,7 +279,7 @@
               "type": "number",
               "default": 3.0,
               "minimum": 0,
-              "description": "Minimum duration the ego must have been stationary at engage to activate [s]"
+              "description": "Activate if the ego has not started moving this long after the engage transition [s]"
             },
             "release_speed_mps": {
               "type": "number",

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -248,7 +248,8 @@ void DiffusionPlannerCore::set_map(
 
 void DiffusionPlannerCore::update_force_takeoff_state(
   const Odometry & kinematic_state, const TrackedObjects & objects,
-  const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time)
+  const std::shared_ptr<const AutowareState> & autoware_state,
+  const geometry_msgs::msg::Pose & route_start_pose, const rclcpp::Time & current_time)
 {
   const auto logger = rclcpp::get_logger("diffusion_planner_core");
   static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
@@ -343,6 +344,22 @@ void DiffusionPlannerCore::update_force_takeoff_state(
   if (stalled_duration_s <= params_.force_takeoff_stationary_duration_s) {
     return;
   }
+
+  // The synthetic override is only meant for the takeoff at the route start: a stall far from the
+  // start pose (e.g. re-engage after manual intervention mid-route) must not be overridden. The
+  // ego is stationary, so the distance cannot recover: cancel the timer instead of staying pending.
+  const double distance_to_start = std::hypot(
+    ego_position.x - route_start_pose.position.x, ego_position.y - route_start_pose.position.y);
+  if (distance_to_start > params_.force_takeoff_max_distance_to_start_m) {
+    RCLCPP_INFO(
+      logger,
+      "Force takeoff cancelled: ego is %.2f m from the route start pose (max %.2f m), not a "
+      "takeoff situation",
+      distance_to_start, params_.force_takeoff_max_distance_to_start_m);
+    engage_time_.reset();
+    return;
+  }
+
   if (agent_nearby) {
     RCLCPP_INFO_THROTTLE(
       logger, steady_clock, 1000,
@@ -401,7 +418,8 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   // Update force takeoff state (uses the unfiltered object list so that the proximity gate is
   // not bypassed by ignore_neighbors)
   if (objects) {
-    update_force_takeoff_state(*ego_kinematic_state, *objects, autoware_state, current_time);
+    update_force_takeoff_state(
+      *ego_kinematic_state, *objects, autoware_state, route_ptr_->start_pose, current_time);
   }
 
   // Update ego history

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -253,6 +253,38 @@ void DiffusionPlannerCore::update_force_takeoff_state(
   const auto logger = rclcpp::get_logger("diffusion_planner_core");
   static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
 
+  // Track the autoware state and detect the engage transition first, so state bookkeeping stays
+  // correct regardless of the enable switch below.
+  bool engage_transition = false;
+  if (autoware_state) {
+    engage_transition = previous_autoware_state_.has_value() &&
+                        *previous_autoware_state_ != AutowareState::DRIVING &&
+                        autoware_state->state == AutowareState::DRIVING;
+    previous_autoware_state_ = autoware_state->state;
+  }
+  const bool driving = previous_autoware_state_.has_value() &&
+                       *previous_autoware_state_ == AutowareState::DRIVING;
+
+  // Dynamic kill switch: disabling the parameter clears the armed timer and any active override.
+  if (!params_.force_takeoff_enable) {
+    engage_time_.reset();
+    if (force_takeoff_active_) {
+      force_takeoff_active_ = false;
+      RCLCPP_INFO(logger, "Force takeoff released: force_takeoff.enable set to false while active");
+    }
+    return;
+  }
+
+  // Leaving DRIVING (disengage, emergency, goal reached) aborts both armed and active states.
+  if (!driving) {
+    engage_time_.reset();
+    if (force_takeoff_active_) {
+      force_takeoff_active_ = false;
+      RCLCPP_WARN(logger, "Force takeoff aborted: autoware state left DRIVING");
+    }
+    return;
+  }
+
   const auto & linear = kinematic_state.twist.twist.linear;
   const double speed = std::hypot(linear.x, linear.y);
 
@@ -263,17 +295,6 @@ void DiffusionPlannerCore::update_force_takeoff_state(
       return std::hypot(object_position.x - ego_position.x, object_position.y - ego_position.y) <
              params_.force_takeoff_min_agent_distance_m;
     });
-
-  bool engage_transition = false;
-  if (autoware_state) {
-    engage_transition = previous_autoware_state_.has_value() &&
-                        *previous_autoware_state_ != AutowareState::DRIVING &&
-                        autoware_state->state == AutowareState::DRIVING;
-    if (autoware_state->state != AutowareState::DRIVING) {
-      engage_time_.reset();
-    }
-    previous_autoware_state_ = autoware_state->state;
-  }
 
   if (force_takeoff_active_) {
     if (agent_nearby) {
@@ -296,7 +317,7 @@ void DiffusionPlannerCore::update_force_takeoff_state(
     return;
   }
 
-  if (engage_transition && params_.force_takeoff_enable) {
+  if (engage_transition) {
     engage_time_ = current_time;
     RCLCPP_INFO(
       logger,

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -251,12 +251,10 @@ void DiffusionPlannerCore::update_force_takeoff_state(
   const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time)
 {
   const auto logger = rclcpp::get_logger("diffusion_planner_core");
+  static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
 
   const auto & linear = kinematic_state.twist.twist.linear;
   const double speed = std::hypot(linear.x, linear.y);
-  if (!last_moving_time_ || speed >= constants::MOVING_VELOCITY_THRESHOLD_MPS) {
-    last_moving_time_ = current_time;
-  }
 
   const auto & ego_position = kinematic_state.pose.pose.position;
   const bool agent_nearby =
@@ -271,6 +269,9 @@ void DiffusionPlannerCore::update_force_takeoff_state(
     engage_transition = previous_autoware_state_.has_value() &&
                         *previous_autoware_state_ != AutowareState::DRIVING &&
                         autoware_state->state == AutowareState::DRIVING;
+    if (autoware_state->state != AutowareState::DRIVING) {
+      engage_time_.reset();
+    }
     previous_autoware_state_ = autoware_state->state;
   }
 
@@ -285,31 +286,57 @@ void DiffusionPlannerCore::update_force_takeoff_state(
       RCLCPP_INFO(
         logger, "Force takeoff released: ego speed %.2f m/s reached release threshold %.2f m/s",
         speed, params_.force_takeoff_release_speed_mps);
+    } else {
+      RCLCPP_INFO_THROTTLE(
+        logger, steady_clock, 1000,
+        "Force takeoff active: overriding ego history/state with synthetic %.2f m/s motion (real "
+        "ego speed %.2f m/s)",
+        params_.force_takeoff_synthetic_speed_mps, speed);
     }
     return;
   }
 
-  if (!params_.force_takeoff_enable || !engage_transition) {
+  if (engage_transition && params_.force_takeoff_enable) {
+    engage_time_ = current_time;
+    RCLCPP_INFO(
+      logger,
+      "Engage transition detected (autoware state -> DRIVING). Force takeoff will activate if the "
+      "ego does not move within %.2f s",
+      params_.force_takeoff_stationary_duration_s);
+  }
+
+  if (!engage_time_) {
     return;
   }
 
-  const double stationary_duration_s = (current_time - *last_moving_time_).seconds();
-  if (stationary_duration_s <= params_.force_takeoff_stationary_duration_s) {
+  const double stalled_duration_s = (current_time - *engage_time_).seconds();
+
+  if (speed >= constants::MOVING_VELOCITY_THRESHOLD_MPS) {
+    RCLCPP_INFO(
+      logger, "Force takeoff not needed: ego started moving %.2f s after engage (speed %.2f m/s)",
+      stalled_duration_s, speed);
+    engage_time_.reset();
+    return;
+  }
+
+  if (stalled_duration_s <= params_.force_takeoff_stationary_duration_s) {
     return;
   }
   if (agent_nearby) {
-    RCLCPP_INFO(
-      logger, "Force takeoff not activated at engage: agent within %.1f m",
-      params_.force_takeoff_min_agent_distance_m);
+    RCLCPP_INFO_THROTTLE(
+      logger, steady_clock, 1000,
+      "Force takeoff pending: ego stalled for %.2f s since engage but an agent is within %.1f m",
+      stalled_duration_s, params_.force_takeoff_min_agent_distance_m);
     return;
   }
 
   force_takeoff_active_ = true;
+  engage_time_.reset();
   RCLCPP_INFO(
     logger,
-    "Force takeoff activated: ego stationary for %.1f s, overriding ego history with synthetic "
-    "%.2f m/s motion",
-    stationary_duration_s, params_.force_takeoff_synthetic_speed_mps);
+    "Force takeoff activated: ego stalled for %.2f s since engage, overriding ego history with "
+    "synthetic %.2f m/s motion",
+    stalled_duration_s, params_.force_takeoff_synthetic_speed_mps);
 }
 
 std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
 
+#include "autoware/diffusion_planner/constants.hpp"
 #include "autoware/diffusion_planner/conversion/agent.hpp"
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/guidance/centerline_guidance.hpp"
@@ -28,6 +29,8 @@
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ONNXRUNTIME
 #include "autoware/diffusion_planner/inference/onnxruntime_inference.hpp"
 #endif
+
+#include <rclcpp/logging.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
 #include <autoware_internal_planning_msgs/msg/generator_info.hpp>
@@ -243,6 +246,72 @@ void DiffusionPlannerCore::set_map(
     lanelet_map_ptr, params_.line_string_max_step_m);
 }
 
+void DiffusionPlannerCore::update_force_takeoff_state(
+  const Odometry & kinematic_state, const TrackedObjects & objects,
+  const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time)
+{
+  const auto logger = rclcpp::get_logger("diffusion_planner_core");
+
+  const auto & linear = kinematic_state.twist.twist.linear;
+  const double speed = std::hypot(linear.x, linear.y);
+  if (!last_moving_time_ || speed >= constants::MOVING_VELOCITY_THRESHOLD_MPS) {
+    last_moving_time_ = current_time;
+  }
+
+  const auto & ego_position = kinematic_state.pose.pose.position;
+  const bool agent_nearby =
+    std::any_of(objects.objects.begin(), objects.objects.end(), [&](const auto & object) {
+      const auto & object_position = object.kinematics.pose_with_covariance.pose.position;
+      return std::hypot(object_position.x - ego_position.x, object_position.y - ego_position.y) <
+             params_.force_takeoff_min_agent_distance_m;
+    });
+
+  bool engage_transition = false;
+  if (autoware_state) {
+    engage_transition = previous_autoware_state_.has_value() &&
+                        *previous_autoware_state_ != AutowareState::DRIVING &&
+                        autoware_state->state == AutowareState::DRIVING;
+    previous_autoware_state_ = autoware_state->state;
+  }
+
+  if (force_takeoff_active_) {
+    if (agent_nearby) {
+      force_takeoff_active_ = false;
+      RCLCPP_INFO(
+        logger, "Force takeoff aborted: agent detected within %.1f m",
+        params_.force_takeoff_min_agent_distance_m);
+    } else if (speed >= params_.force_takeoff_release_speed_mps) {
+      force_takeoff_active_ = false;
+      RCLCPP_INFO(
+        logger, "Force takeoff released: ego speed %.2f m/s reached release threshold %.2f m/s",
+        speed, params_.force_takeoff_release_speed_mps);
+    }
+    return;
+  }
+
+  if (!params_.force_takeoff_enable || !engage_transition) {
+    return;
+  }
+
+  const double stationary_duration_s = (current_time - *last_moving_time_).seconds();
+  if (stationary_duration_s <= params_.force_takeoff_stationary_duration_s) {
+    return;
+  }
+  if (agent_nearby) {
+    RCLCPP_INFO(
+      logger, "Force takeoff not activated at engage: agent within %.1f m",
+      params_.force_takeoff_min_agent_distance_m);
+    return;
+  }
+
+  force_takeoff_active_ = true;
+  RCLCPP_INFO(
+    logger,
+    "Force takeoff activated: ego stationary for %.1f s, overriding ego history with synthetic "
+    "%.2f m/s motion",
+    stationary_duration_s, params_.force_takeoff_synthetic_speed_mps);
+}
+
 std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   const std::shared_ptr<const Odometry> & ego_kinematic_state,
   const std::shared_ptr<const AccelWithCovarianceStamped> & ego_acceleration,
@@ -250,7 +319,8 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   const std::vector<std::shared_ptr<const autoware_perception_msgs::msg::TrafficLightGroupArray>> &
     traffic_signals,
   const std::shared_ptr<const TurnIndicatorsReport> & turn_indicators,
-  const LaneletRoute::ConstSharedPtr & route_ptr, const rclcpp::Time & current_time)
+  const LaneletRoute::ConstSharedPtr & route_ptr,
+  const std::shared_ptr<const AutowareState> & autoware_state, const rclcpp::Time & current_time)
 {
   route_ptr_ = (!route_ptr_ || route_ptr) ? route_ptr : route_ptr_;
 
@@ -280,6 +350,12 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   const Eigen::Matrix4d ego_to_map_transform = utils::pose_to_matrix4d(pose_base_link);
   const Eigen::Matrix4d map_to_ego_transform = utils::inverse(ego_to_map_transform);
 
+  // Update force takeoff state (uses the unfiltered object list so that the proximity gate is
+  // not bypassed by ignore_neighbors)
+  if (objects) {
+    update_force_takeoff_state(*ego_kinematic_state, *objects, autoware_state, current_time);
+  }
+
   // Update ego history
   ego_history_.push_back(kinematic_state);
   if (ego_history_.size() > static_cast<size_t>(EGO_HISTORY_SHAPE[1])) {
@@ -304,9 +380,9 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
 
   // Create frame context
   const rclcpp::Time frame_time(ego_kinematic_state->header.stamp);
-  const FrameContext frame_context{
-    *ego_kinematic_state, *ego_acceleration, ego_to_map_transform, processed_neighbor_histories,
-    frame_time};
+  const FrameContext frame_context{*ego_kinematic_state, *ego_acceleration,
+                                   ego_to_map_transform, processed_neighbor_histories,
+                                   frame_time,           force_takeoff_active_};
 
   return frame_context;
 }
@@ -370,16 +446,31 @@ InputDataMap DiffusionPlannerCore::create_input_data(const FrameContext & frame_
   {
     const std::optional<rclcpp::Time> reference_time =
       params_.use_time_interpolation ? std::make_optional(frame_context.frame_time) : std::nullopt;
+    std::deque<nav_msgs::msg::Odometry> synthetic_history;
+    if (frame_context.force_takeoff_active) {
+      synthetic_history = preprocess::create_synthetic_ego_history(
+        pose_center, frame_context.frame_time, EGO_HISTORY_SHAPE[1],
+        params_.force_takeoff_synthetic_speed_mps, constants::PREDICTION_TIME_STEP_S);
+    }
+    const auto & history_source =
+      frame_context.force_takeoff_active ? synthetic_history : ego_history_;
     const std::vector<float> single_ego_agent_past = preprocess::create_ego_agent_past(
-      ego_history_, EGO_HISTORY_SHAPE[1], map_to_ego_transform, reference_time);
+      history_source, EGO_HISTORY_SHAPE[1], map_to_ego_transform, reference_time);
     input_data_map["ego_agent_past"] =
       utils::replicate_for_batch(single_ego_agent_past, params_.batch_size);
   }
   // Ego state
   {
+    auto kinematic_state = frame_context.ego_kinematic_state;
+    auto acceleration = frame_context.ego_acceleration;
+    if (frame_context.force_takeoff_active) {
+      // Simulate the ego already moving straight at constant speed with zero acceleration
+      kinematic_state.twist.twist = geometry_msgs::msg::Twist{};
+      kinematic_state.twist.twist.linear.x = params_.force_takeoff_synthetic_speed_mps;
+      acceleration.accel.accel = geometry_msgs::msg::Accel{};
+    }
     const auto ego_current_state = preprocess::create_ego_current_state(
-      frame_context.ego_kinematic_state, frame_context.ego_acceleration,
-      static_cast<float>(vehicle_spec_.wheel_base));
+      kinematic_state, acceleration, static_cast<float>(vehicle_spec_.wheel_base));
     input_data_map["ego_current_state"] =
       utils::replicate_for_batch(ego_current_state, params_.batch_size);
   }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -225,6 +225,8 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("force_takeoff.release_speed_mps", 0.5);
   params_.force_takeoff_min_agent_distance_m =
     this->declare_parameter<double>("force_takeoff.min_agent_distance_m", 20.0);
+  params_.force_takeoff_max_distance_to_start_m =
+    this->declare_parameter<double>("force_takeoff.max_distance_to_start_m", 5.0);
   autoware::mppi_optimizer::declare_first_order_dubins_mppi_cost_params(*this);
   autoware::mppi_optimizer::declare_first_order_dubins_mppi_vehicle_dynamics_params(*this);
 
@@ -395,6 +397,9 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "force_takeoff.min_agent_distance_m",
       temp_params.force_takeoff_min_agent_distance_m);
+    update_param<double>(
+      parameters, "force_takeoff.max_distance_to_start_m",
+      temp_params.force_takeoff_max_distance_to_start_m);
     const bool args_path_changed = temp_params.args_path != previous_args_path;
     const bool model_paths_changed =
       temp_params.model_type != previous_model_type ||

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -216,6 +216,15 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("guidance.centerline_guidance.start_time_s", 2.0);
   params_.use_mppi_optimizer = this->declare_parameter<bool>("use_mppi_optimizer", false);
   params_.shadow_mode = this->declare_parameter<bool>("shadow_mode", false);
+  params_.force_takeoff_enable = this->declare_parameter<bool>("force_takeoff.enable", true);
+  params_.force_takeoff_synthetic_speed_mps =
+    this->declare_parameter<double>("force_takeoff.synthetic_speed_mps", 1.5);
+  params_.force_takeoff_stationary_duration_s =
+    this->declare_parameter<double>("force_takeoff.stationary_duration_s", 3.0);
+  params_.force_takeoff_release_speed_mps =
+    this->declare_parameter<double>("force_takeoff.release_speed_mps", 0.5);
+  params_.force_takeoff_min_agent_distance_m =
+    this->declare_parameter<double>("force_takeoff.min_agent_distance_m", 20.0);
   autoware::mppi_optimizer::declare_first_order_dubins_mppi_cost_params(*this);
   autoware::mppi_optimizer::declare_first_order_dubins_mppi_vehicle_dynamics_params(*this);
 
@@ -374,6 +383,18 @@ SetParametersResult DiffusionPlanner::on_parameter(
     }
     update_param<bool>(parameters, "use_mppi_optimizer", temp_params.use_mppi_optimizer);
     update_param<bool>(parameters, "shadow_mode", temp_params.shadow_mode);
+    update_param<bool>(parameters, "force_takeoff.enable", temp_params.force_takeoff_enable);
+    update_param<double>(
+      parameters, "force_takeoff.synthetic_speed_mps",
+      temp_params.force_takeoff_synthetic_speed_mps);
+    update_param<double>(
+      parameters, "force_takeoff.stationary_duration_s",
+      temp_params.force_takeoff_stationary_duration_s);
+    update_param<double>(
+      parameters, "force_takeoff.release_speed_mps", temp_params.force_takeoff_release_speed_mps);
+    update_param<double>(
+      parameters, "force_takeoff.min_agent_distance_m",
+      temp_params.force_takeoff_min_agent_distance_m);
     const bool args_path_changed = temp_params.args_path != previous_args_path;
     const bool model_paths_changed =
       temp_params.model_type != previous_model_type ||
@@ -530,11 +551,12 @@ void DiffusionPlanner::on_timer()
   auto traffic_signals = sub_traffic_signals_.take_data();
   auto temp_route_ptr = route_subscriber_.take_data();
   auto turn_indicators_ptr = sub_turn_indicators_.take_data();
+  auto autoware_state_ptr = sub_autoware_state_.take_data();
 
   // Prepare frame context using core
   const std::optional<FrameContext> frame_context = core_->create_frame_context(
     ego_kinematic_state, ego_acceleration, objects, traffic_signals, turn_indicators_ptr,
-    temp_route_ptr, this->now());
+    temp_route_ptr, autoware_state_ptr, this->now());
 
   if (!frame_context) {
     // Log detailed information about missing inputs

--- a/planning/autoware_diffusion_planner/src/preprocessing/preprocessing_utils.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/preprocessing_utils.cpp
@@ -19,6 +19,7 @@
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
 #include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/duration.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -201,6 +202,25 @@ std::vector<float> create_ego_agent_past(
   }
 
   return ego_agent_past;
+}
+
+std::deque<nav_msgs::msg::Odometry> create_synthetic_ego_history(
+  const geometry_msgs::msg::Pose & current_pose, const rclcpp::Time & current_time,
+  const size_t num_timesteps, const double speed_mps, const double time_step_s)
+{
+  std::deque<nav_msgs::msg::Odometry> synthetic_history;
+
+  for (size_t t = 0; t < num_timesteps; ++t) {
+    const auto steps_back = static_cast<double>(num_timesteps - 1 - t);
+    nav_msgs::msg::Odometry odometry;
+    odometry.header.stamp = current_time - rclcpp::Duration::from_seconds(steps_back * time_step_s);
+    odometry.header.frame_id = "map";
+    odometry.pose.pose = utils::shift_x(current_pose, -steps_back * time_step_s * speed_mps);
+    odometry.twist.twist.linear.x = speed_mps;
+    synthetic_history.push_back(odometry);
+  }
+
+  return synthetic_history;
 }
 
 std::vector<float> create_sampled_trajectories(const double temperature)

--- a/planning/autoware_diffusion_planner/test/force_takeoff_test.cpp
+++ b/planning/autoware_diffusion_planner/test/force_takeoff_test.cpp
@@ -1,0 +1,201 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/diffusion_planner_core.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_system_msgs/msg/autoware_state.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace autoware::diffusion_planner::test
+{
+
+class ForceTakeoffTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    DiffusionPlannerParams params{};
+    params.batch_size = 1;
+    params.turn_indicator_hold_duration = 0.0;
+    params.turn_indicator_keep_offset = 0.0f;
+    params.force_takeoff_enable = true;
+    params.force_takeoff_synthetic_speed_mps = 1.5;
+    params.force_takeoff_stationary_duration_s = 3.0;
+    params.force_takeoff_release_speed_mps = 0.5;
+    params.force_takeoff_min_agent_distance_m = 20.0;
+    params_ = params;
+
+    VehicleInfo vehicle_info{};
+    core_ = std::make_unique<DiffusionPlannerCore>(params_, vehicle_info);
+  }
+
+  static std::shared_ptr<const AutowareState> make_state(const uint8_t state)
+  {
+    auto msg = std::make_shared<AutowareState>();
+    msg->state = state;
+    return msg;
+  }
+
+  static Odometry make_odometry(const double speed_mps)
+  {
+    Odometry odometry;
+    odometry.twist.twist.linear.x = speed_mps;
+    return odometry;
+  }
+
+  static TrackedObjects make_objects(const std::vector<double> & distances_m)
+  {
+    TrackedObjects objects;
+    for (const double distance : distances_m) {
+      autoware_perception_msgs::msg::TrackedObject object;
+      object.kinematics.pose_with_covariance.pose.position.x = distance;
+      objects.objects.push_back(object);
+    }
+    return objects;
+  }
+
+  rclcpp::Time at(const double seconds) const
+  {
+    return rclcpp::Time(0, 0, RCL_ROS_TIME) + rclcpp::Duration::from_seconds(seconds);
+  }
+
+  void tick(
+    const double t, const double speed_mps, const uint8_t state,
+    const std::vector<double> & agent_distances_m = {})
+  {
+    core_->update_force_takeoff_state(
+      make_odometry(speed_mps), make_objects(agent_distances_m), make_state(state), at(t));
+  }
+
+  // Engage at t=0 (WAITING_FOR_ENGAGE -> DRIVING) with the ego stopped.
+  void engage()
+  {
+    tick(0.0, 0.0, AutowareState::WAITING_FOR_ENGAGE);
+    tick(0.1, 0.0, AutowareState::DRIVING);
+  }
+
+  DiffusionPlannerParams params_;
+  std::unique_ptr<DiffusionPlannerCore> core_;
+};
+
+TEST_F(ForceTakeoffTest, ActivatesAfterStallAndReleasesOnSpeed)
+{
+  engage();
+  tick(2.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "must not activate before the stall duration";
+
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  EXPECT_TRUE(core_->is_force_takeoff_active()) << "must activate after stalling > 3 s post engage";
+
+  tick(4.0, 0.3, AutowareState::DRIVING);
+  EXPECT_TRUE(core_->is_force_takeoff_active()) << "must stay active below the release speed";
+
+  tick(4.5, 0.6, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "must release once the release speed is reached";
+}
+
+TEST_F(ForceTakeoffTest, DoesNotActivateWhenEgoMovesInTime)
+{
+  engage();
+  tick(1.0, 0.5, AutowareState::DRIVING);  // ego starts moving within the stall window
+  tick(5.0, 0.0, AutowareState::DRIVING);  // later stop without a new engage
+  tick(20.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active())
+    << "a stop without a fresh engage transition must not trigger the override";
+}
+
+TEST_F(ForceTakeoffTest, DoesNotActivateWithAgentNearby)
+{
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING, {10.0});
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "agent within 20 m must gate activation";
+
+  tick(4.0, 0.0, AutowareState::DRIVING, {30.0});
+  EXPECT_TRUE(core_->is_force_takeoff_active()) << "activation may proceed once the agent leaves";
+}
+
+TEST_F(ForceTakeoffTest, AbortsWhenAgentEntersWhileActive)
+{
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  ASSERT_TRUE(core_->is_force_takeoff_active());
+
+  tick(4.0, 0.0, AutowareState::DRIVING, {5.0});
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "agent entering the radius must abort";
+}
+
+TEST_F(ForceTakeoffTest, AbortsWhenLeavingDriving)
+{
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  ASSERT_TRUE(core_->is_force_takeoff_active());
+
+  tick(4.0, 0.0, AutowareState::WAITING_FOR_ENGAGE);
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "disengage must abort the active override";
+
+  // Re-engaging arms a fresh timer instead of resuming the old override.
+  tick(5.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active());
+  tick(8.5, 0.0, AutowareState::DRIVING);
+  EXPECT_TRUE(core_->is_force_takeoff_active());
+}
+
+TEST_F(ForceTakeoffTest, DisableParameterIsImmediateKillSwitch)
+{
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  ASSERT_TRUE(core_->is_force_takeoff_active());
+
+  auto disabled_params = params_;
+  disabled_params.force_takeoff_enable = false;
+  core_->update_params(disabled_params);
+  tick(4.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active()) << "disabling must release the active override";
+
+  // Re-enabling must not resurrect the old engage timer.
+  core_->update_params(params_);
+  tick(10.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active())
+    << "re-enabling without a fresh engage must stay inactive";
+}
+
+TEST_F(ForceTakeoffTest, DisableWhileArmedClearsTimer)
+{
+  engage();
+
+  auto disabled_params = params_;
+  disabled_params.force_takeoff_enable = false;
+  core_->update_params(disabled_params);
+  tick(1.0, 0.0, AutowareState::DRIVING);
+
+  core_->update_params(params_);
+  tick(5.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active())
+    << "an armed timer must be cleared by the kill switch, not resumed on re-enable";
+}
+
+TEST_F(ForceTakeoffTest, NoActivationWithoutEngageTransition)
+{
+  // First observed state is already DRIVING: no transition, so never activates.
+  tick(0.0, 0.0, AutowareState::DRIVING);
+  tick(10.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active());
+}
+
+}  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/force_takeoff_test.cpp
+++ b/planning/autoware_diffusion_planner/test/force_takeoff_test.cpp
@@ -17,6 +17,7 @@
 #include <rclcpp/time.hpp>
 
 #include <autoware_system_msgs/msg/autoware_state.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 
 #include <gtest/gtest.h>
 
@@ -39,6 +40,7 @@ protected:
     params.force_takeoff_stationary_duration_s = 3.0;
     params.force_takeoff_release_speed_mps = 0.5;
     params.force_takeoff_min_agent_distance_m = 20.0;
+    params.force_takeoff_max_distance_to_start_m = 5.0;
     params_ = params;
 
     VehicleInfo vehicle_info{};
@@ -79,8 +81,13 @@ protected:
     const double t, const double speed_mps, const uint8_t state,
     const std::vector<double> & agent_distances_m = {})
   {
+    // The ego odometry in these tests sits at the origin, so the route start pose is placed
+    // route_start_distance_m_ away from it along x.
+    geometry_msgs::msg::Pose route_start_pose;
+    route_start_pose.position.x = route_start_distance_m_;
     core_->update_force_takeoff_state(
-      make_odometry(speed_mps), make_objects(agent_distances_m), make_state(state), at(t));
+      make_odometry(speed_mps), make_objects(agent_distances_m), make_state(state),
+      route_start_pose, at(t));
   }
 
   // Engage at t=0 (WAITING_FOR_ENGAGE -> DRIVING) with the ego stopped.
@@ -92,6 +99,7 @@ protected:
 
   DiffusionPlannerParams params_;
   std::unique_ptr<DiffusionPlannerCore> core_;
+  double route_start_distance_m_{0.0};
 };
 
 TEST_F(ForceTakeoffTest, ActivatesAfterStallAndReleasesOnSpeed)
@@ -188,6 +196,28 @@ TEST_F(ForceTakeoffTest, DisableWhileArmedClearsTimer)
   tick(5.0, 0.0, AutowareState::DRIVING);
   EXPECT_FALSE(core_->is_force_takeoff_active())
     << "an armed timer must be cleared by the kill switch, not resumed on re-enable";
+}
+
+TEST_F(ForceTakeoffTest, DoesNotActivateFarFromRouteStart)
+{
+  route_start_distance_m_ = 6.0;  // beyond max_distance_to_start_m (5.0)
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active())
+    << "a stall far from the route start pose must not be overridden";
+
+  // The timer is cancelled, not pending: it must not fire later either.
+  tick(20.0, 0.0, AutowareState::DRIVING);
+  EXPECT_FALSE(core_->is_force_takeoff_active());
+}
+
+TEST_F(ForceTakeoffTest, ActivatesWithinMaxDistanceToStart)
+{
+  route_start_distance_m_ = 4.0;  // within max_distance_to_start_m (5.0)
+  engage();
+  tick(3.5, 0.0, AutowareState::DRIVING);
+  EXPECT_TRUE(core_->is_force_takeoff_active())
+    << "a stall within the route-start radius must still activate";
 }
 
 TEST_F(ForceTakeoffTest, NoActivationWithoutEngageTransition)

--- a/planning/autoware_diffusion_planner/test/pre_processing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/pre_processing_utils_test.cpp
@@ -170,4 +170,65 @@ TEST_F(PreprocessingUtilsTest, CreateEgoCurrentState)
   EXPECT_FLOAT_EQ(result[9], 0.1f);
 }
 
+TEST_F(PreprocessingUtilsTest, CreateSyntheticEgoHistoryStraightLine)
+{
+  const size_t num_timesteps = 31;
+  const double speed_mps = 1.5;
+  const double time_step_s = 0.1;
+  const rclcpp::Time current_time(123, 0, RCL_ROS_TIME);
+
+  geometry_msgs::msg::Pose current_pose;
+  current_pose.position.x = 10.0;
+  current_pose.position.y = -5.0;
+  current_pose.orientation.w = 1.0;  // identity: heading along +x
+
+  const auto history = preprocess::create_synthetic_ego_history(
+    current_pose, current_time, num_timesteps, speed_mps, time_step_s);
+
+  ASSERT_EQ(history.size(), num_timesteps);
+
+  // Last entry is the current pose at the current time
+  EXPECT_DOUBLE_EQ(history.back().pose.pose.position.x, current_pose.position.x);
+  EXPECT_DOUBLE_EQ(history.back().pose.pose.position.y, current_pose.position.y);
+  EXPECT_EQ(rclcpp::Time(history.back().header.stamp), current_time);
+
+  for (size_t t = 0; t < num_timesteps; ++t) {
+    const auto & odom = history[t];
+    const double steps_back = static_cast<double>(num_timesteps - 1 - t);
+    // Poses are shifted backwards along the heading by speed * dt each step
+    EXPECT_NEAR(
+      odom.pose.pose.position.x, current_pose.position.x - steps_back * speed_mps * time_step_s,
+      1e-9);
+    EXPECT_NEAR(odom.pose.pose.position.y, current_pose.position.y, 1e-9);
+    // Timestamps are spaced time_step_s apart, ending at current_time
+    EXPECT_NEAR(
+      (current_time - rclcpp::Time(odom.header.stamp)).seconds(), steps_back * time_step_s, 1e-9);
+    // Constant longitudinal speed
+    EXPECT_DOUBLE_EQ(odom.twist.twist.linear.x, speed_mps);
+  }
+}
+
+TEST_F(PreprocessingUtilsTest, CreateSyntheticEgoHistoryFollowsHeading)
+{
+  const size_t num_timesteps = 5;
+  const double speed_mps = 2.0;
+  const double time_step_s = 0.1;
+  const rclcpp::Time current_time(10, 0);
+
+  geometry_msgs::msg::Pose current_pose;
+  // Heading along +y (yaw = pi/2)
+  current_pose.orientation.z = std::sin(M_PI_4);
+  current_pose.orientation.w = std::cos(M_PI_4);
+
+  const auto history = preprocess::create_synthetic_ego_history(
+    current_pose, current_time, num_timesteps, speed_mps, time_step_s);
+
+  ASSERT_EQ(history.size(), num_timesteps);
+  // Oldest entry is shifted backwards along +y
+  EXPECT_NEAR(history.front().pose.pose.position.x, 0.0, 1e-9);
+  EXPECT_NEAR(
+    history.front().pose.pose.position.y,
+    -static_cast<double>(num_timesteps - 1) * speed_mps * time_step_s, 1e-9);
+}
+
 }  // namespace autoware::diffusion_planner::test


### PR DESCRIPTION
## Description

Adds a **force takeoff** feature to `autoware_diffusion_planner`: when the vehicle is engaged (AutowareState transition `!= DRIVING -> DRIVING`) but the ego does not start moving within a configurable duration, the planner temporarily overrides the ego history and current state fed to the model with synthetic straight-line constant-speed data, pushing the model out of the stopped state. The override is released as soon as the real ego speed reaches the release threshold.

**The feature is enabled by default** (`force_takeoff.enable: true` in the code default and in `config/diffusion_planner.param.yaml`).

## Behavior

- Subscribes to `/autoware/state` (`~/input/autoware_state`) and arms a stall timer exactly at the engage transition (mid-route stops do not re-trigger).
- If the ego has not moved within `force_takeoff.stationary_duration_s` (default 3.0 s) after engage, the override activates:
  - ego history replaced with a synthetic straight-line trajectory at `force_takeoff.synthetic_speed_mps` (default 1.5 m/s) built with `utils::shift_x`
  - ego current state speed set to the same value, acceleration zeroed
- Released once real ego speed reaches `force_takeoff.release_speed_mps` (default 0.5 m/s); real ego history keeps updating underneath so the handover is seamless.
- Safety gate: activation requires no tracked object within `force_takeoff.min_agent_distance_m` (default 20 m); if an agent enters the radius while active, the override aborts immediately.
- All values are ROS params and dynamically reconfigurable.
- INFO/WARN logs for armed / activated / released / aborted transitions.

## Tests

- Unit tests added for `preprocess::create_synthetic_ego_history`.
- Verified end-to-end in local webauto planning sims (`planning_sim_v2_j6_gen2`): engage detected, override activated after 3 s stall, ego accelerated 0.00 -> 0.55 m/s and override released; also verified the cancel path when the ego starts moving by itself.


## Related PR

- tier4/autoware_launch.x2#2738: force_takeoff params for the deployed config
