### PR TITLE
feat(traffic_light_compliance_checker): improve amber rejection stability

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -82,6 +82,7 @@ struct Violation
 struct ComplianceResult
 {
   std::vector<Violation> violations;
+  std::vector<int64_t> detected_stop_amber_ids;
 };
 
 /// @brief parameters for traffic light signal status tracking
@@ -104,16 +105,18 @@ struct Parameters
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
   double min_lookahead_distance;
-  double stable_duration_threshold_red;
-  double stable_duration_threshold_amber;
-  double stable_duration_threshold_unknown;
-  double amber_rejection_hysteresis_duration;
   double ego_stopped_velocity_threshold;
+  StatusTrackerParameters status_tracker_parameters;
   struct CheckedTrajectoryLength
   {
     double deceleration_limit;
     double jerk_limit;
   } checked_trajectory_length;
+  struct AmberRejection
+  {
+    double hysteresis_duration;
+    bool reject_if_stop_detected;
+  } amber_rejection;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -77,12 +77,12 @@ struct Violation
     return arc_length_to_cross_point < other.arc_length_to_cross_point;
   }
 };
+using Violations = std::vector<Violation>;
 
 /// @brief result of compliance check
 struct ComplianceResult
 {
-  std::vector<Violation> violations;
-  std::vector<int64_t> detected_stop_amber_ids;
+  Violations violations;
 };
 
 /// @brief parameters for traffic light signal status tracking

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -70,29 +70,26 @@ private:
   [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
     const rclcpp::Time & current_time, bool is_ego_stopped) const;
 
-  void update_amber_rejection_history(
-    const ComplianceResult & result, const rclcpp::Time & current_time,
-    const std::vector<int64_t> & force_reject_amber_ids);
-
   void cleanup_amber_rejection_history(const rclcpp::Time & current_time);
 
-  [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
+  [[nodiscard]] ComplianceResult check_with_filtered_signals(
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-    const bool check_amber_lights) const;
+    const bool check_amber_lights);
 
-  ComplianceResult get_red_light_violations(
+  Violations get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
     const double distance_offset = 0.0) const;
-  ComplianceResult get_amber_light_violations(
+  Violations get_amber_light_violations(
     const std::vector<StopLineInfo> & amber_stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
-    const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset = 0.0) const;
+    const std::vector<int64_t> & force_reject_amber_ids, const rclcpp::Time & current_time,
+    const double distance_offset = 0.0) const;
 
   /// @brief return the red and amber stop lines related to the given traffic light groups
   [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
@@ -110,10 +107,13 @@ private:
     const double distance_to_stop_line, const double current_velocity,
     const double current_acceleration, const double time_to_cross_stop_line) const;
 
+  bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
+
   Parameters params_;
   vehicle_info_utils::VehicleInfo vehicle_info_;
   std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
-  std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  mutable std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  std::optional<double> ego_stopping_distance_;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -76,7 +76,7 @@ private:
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-    const bool check_amber_lights);
+    const bool check_amber_lights) const;
 
   Violations get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -82,12 +82,12 @@ private:
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
     const bool check_amber_lights) const;
 
-  std::vector<Violation> get_red_light_violations(
+  ComplianceResult get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
     const double distance_offset = 0.0) const;
-  std::vector<Violation> get_amber_light_violations(
+  ComplianceResult get_amber_light_violations(
     const std::vector<StopLineInfo> & amber_stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const lanelet::BasicLineString2d & trajectory_ls,

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -104,8 +104,9 @@ private:
 
   /// @brief return true if ego can safely pass an amber traffic light
   [[nodiscard]] bool can_pass_amber_light(
-    const double distance_to_stop_line, const double current_velocity,
-    const double current_acceleration, const double time_to_cross_stop_line) const;
+    const int64_t traffic_light_id, const double distance_to_stop_line,
+    const double current_velocity, const double current_acceleration,
+    const double time_to_cross_stop_line) const;
 
   bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
 

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -46,6 +46,13 @@ public:
     const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
     const rclcpp::Time & current_time, bool is_ego_stopped);
 
+  [[nodiscard]] double get_duration(const int64_t traffic_light_id) const
+  {
+    const auto it = signal_history_.find(traffic_light_id);
+    if (it == signal_history_.end()) return 0.0;
+    return (it->second.last_seen_time - it->second.first_seen_time).seconds();
+  }
+
 private:
   void cleanup_signal_history(const rclcpp::Time & current_time);
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -36,16 +36,6 @@
 
 namespace
 {
-autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tracker_parameters(
-  const autoware::traffic_light_compliance_checker::Parameters & parameters)
-{
-  autoware::traffic_light_compliance_checker::StatusTrackerParameters p{};
-  p.stable_duration_threshold_red = parameters.stable_duration_threshold_red;
-  p.stable_duration_threshold_amber = parameters.stable_duration_threshold_amber;
-  p.stable_duration_threshold_unknown = parameters.stable_duration_threshold_unknown;
-  return p;
-}
-
 using autoware::traffic_light_compliance_checker::StopLineInfo;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
@@ -102,8 +92,7 @@ TrafficLightComplianceChecker::TrafficLightComplianceChecker(
   const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
 : params_(parameters),
   vehicle_info_(vehicle_info),
-  status_tracker_(
-    std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
+  status_tracker_(std::make_unique<TrafficLightStatusTracker>(parameters.status_tracker_parameters))
 {
 }
 
@@ -112,7 +101,7 @@ TrafficLightComplianceChecker::~TrafficLightComplianceChecker() = default;
 void TrafficLightComplianceChecker::update_parameters(const Parameters & parameters)
 {
   params_ = parameters;
-  status_tracker_->update_parameters(to_status_tracker_parameters(parameters));
+  status_tracker_->update_parameters(parameters.status_tracker_parameters);
 }
 
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
@@ -146,7 +135,7 @@ std::vector<int64_t> TrafficLightComplianceChecker::get_force_reject_amber_ids(
     return force_reject_amber_ids;
   }
   for (const auto & [id, rejected_time] : amber_rejection_history_) {
-    if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+    if ((current_time - rejected_time).seconds() <= params_.amber_rejection.hysteresis_duration) {
       force_reject_amber_ids.push_back(id);
     }
   }
@@ -168,13 +157,22 @@ void TrafficLightComplianceChecker::update_amber_rejection_history(
       amber_rejection_history_[violation.traffic_light_id] = current_time;
     }
   }
+
+  for (const auto & detected_stop_amber_id : result.detected_stop_amber_ids) {
+    if (
+      std::find(
+        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), detected_stop_amber_id) ==
+      force_reject_amber_ids.end()) {
+      amber_rejection_history_[detected_stop_amber_id] = current_time;
+    }
+  }
 }
 
 void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   const rclcpp::Time & current_time)
 {
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
-    if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
+    if ((current_time - it->second).seconds() > params_.amber_rejection.hysteresis_duration) {
       it = amber_rejection_history_.erase(it);
     } else {
       ++it;
@@ -182,12 +180,12 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   }
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
+ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
   const std::vector<StopLineInfo> & red_stop_lines,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
 {
-  std::vector<Violation> violations;
+  ComplianceResult result;
   for (const auto & red_stop_line : red_stop_lines) {
     auto distance_to_stop_line = 0.0;
     lanelet::BasicPoints2d intersection_points;
@@ -205,21 +203,21 @@ std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
       intersection_points.empty() ||
       is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
       continue;
-    violations.emplace_back(
+    result.violations.emplace_back(
       ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
       intersection_points.front(), distance_to_stop_line + distance_offset);
   }
-  return violations;
+  return result;
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations(
+ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
   const std::vector<StopLineInfo> & amber_stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point,
   const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
 {
-  std::vector<Violation> violations;
+  ComplianceResult result;
   for (const auto & amber_stop_line : amber_stop_lines) {
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
@@ -246,8 +244,11 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
 
     if (
       !amber_stop_line_crossing_time ||
-      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line))
+      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
+      if (stop_point.has_value())
+        result.detected_stop_amber_ids.push_back(amber_stop_line.traffic_light_id);
       continue;
+    }
 
     const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
     const auto current_acceleration = trajectory.front().acceleration_mps2;
@@ -260,12 +261,12 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
       is_force_reject || !can_pass_amber_light(
                            distance_to_stop_line, current_velocity, current_acceleration,
                            *amber_stop_line_crossing_time)) {
-      violations.emplace_back(
+      result.violations.emplace_back(
         ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
         intersection_point, distance_to_stop_line + distance_offset);
     }
   }
-  return violations;
+  return result;
 }
 
 tl::expected<ComplianceResult, std::string>
@@ -338,15 +339,16 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   ComplianceResult result;
   if (check_red_lights) {
-    result.violations =
-      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+    result = get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
   }
   if (check_amber_lights) {
-    const auto amber_light_violations = get_amber_light_violations(
+    const auto amber_light_result = get_amber_light_violations(
       amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
       backward_length);
     result.violations.insert(
-      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+      result.violations.end(), amber_light_result.violations.begin(),
+      amber_light_result.violations.end());
+    result.detected_stop_amber_ids = amber_light_result.detected_stop_amber_ids;
   }
 
   if (ego_stopping_distance.has_value() && params_.allow_if_cannot_stop_distance > 0.0) {

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -239,8 +239,8 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
                              amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
 
     bool can_pass = can_pass_amber_light(
-      distance_to_stop_line, current_velocity, current_acceleration,
-      *amber_stop_line_crossing_time);
+      amber_stop_line.traffic_light_id, distance_to_stop_line, current_velocity,
+      current_acceleration, *amber_stop_line_crossing_time);
 
     if (!is_force_reject && can_pass) continue;
 
@@ -379,7 +379,7 @@ bool TrafficLightComplianceChecker::is_stop_point_within_margin_from_stop_line(
 }
 
 bool TrafficLightComplianceChecker::can_pass_amber_light(
-  const double distance_to_stop_line, const double current_velocity,
+  const int64_t traffic_light_id, const double distance_to_stop_line, const double current_velocity,
   const double current_acceleration, const double time_to_cross_stop_line) const
 {
   const double decel_limit = params_.deceleration_limit;
@@ -388,9 +388,12 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
   const auto distance_for_ego_to_stop = autoware::motion_utils::calculate_stop_distance(
     current_velocity, current_acceleration, decel_limit, jerk_limit, delay_response_time);
 
+  const auto crossing_time_limit =
+    std::max(0.0, params_.crossing_time_limit - status_tracker_->get_duration(traffic_light_id));
+
   const bool can_stop =
     distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_to_stop_line;
-  const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
+  const bool can_pass_in_time = time_to_cross_stop_line <= crossing_time_limit;
   const bool can_pass = !can_stop && can_pass_in_time;
   return can_pass;
 }

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -119,6 +119,11 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
   const auto force_reject_amber_ids =
     get_force_reject_amber_ids(input.current_time, is_ego_stopped);
 
+  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
+    input.current_velocity, input.current_acceleration,
+    params_.checked_trajectory_length.deceleration_limit,
+    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+
   auto result = check_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
 
@@ -257,7 +262,7 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-  const bool check_amber_lights)
+  const bool check_amber_lights) const
 {
   if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
@@ -265,10 +270,7 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
-    input.current_velocity, input.current_acceleration,
-    params_.checked_trajectory_length.deceleration_limit,
-    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+
   // Floor by min_lookahead_distance so low ego speed still covers nearby stop lines,
   // while keeping the comfortable-stop cap so far lights are not over-checked
   // (important for traffic_light_filter which rejects trajectories).

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -107,6 +107,10 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
   const Inputs & input, const bool check_red_lights, const bool check_amber_lights)
 {
+  if (input.map == nullptr) {
+    return tl::make_unexpected("Lanelet map is not set");
+  }
+
   const bool is_ego_stopped =
     std::abs(input.current_velocity) < params_.ego_stopped_velocity_threshold;
   const auto filtered_signals =
@@ -117,11 +121,7 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
 
   auto result = check_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
-  if (!result) {
-    return result;
-  }
 
-  update_amber_rejection_history(*result, input.current_time, force_reject_amber_ids);
   cleanup_amber_rejection_history(input.current_time);
 
   return result;
@@ -142,32 +142,6 @@ std::vector<int64_t> TrafficLightComplianceChecker::get_force_reject_amber_ids(
   return force_reject_amber_ids;
 }
 
-void TrafficLightComplianceChecker::update_amber_rejection_history(
-  const ComplianceResult & result, const rclcpp::Time & current_time,
-  const std::vector<int64_t> & force_reject_amber_ids)
-{
-  for (const auto & violation : result.violations) {
-    if (violation.type != ViolationType::AMBER_LIGHT) {
-      continue;
-    }
-    if (
-      std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), violation.traffic_light_id) ==
-      force_reject_amber_ids.end()) {
-      amber_rejection_history_[violation.traffic_light_id] = current_time;
-    }
-  }
-
-  for (const auto & detected_stop_amber_id : result.detected_stop_amber_ids) {
-    if (
-      std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), detected_stop_amber_id) ==
-      force_reject_amber_ids.end()) {
-      amber_rejection_history_[detected_stop_amber_id] = current_time;
-    }
-  }
-}
-
 void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   const rclcpp::Time & current_time)
 {
@@ -180,12 +154,12 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   }
 }
 
-ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
+Violations TrafficLightComplianceChecker::get_red_light_violations(
   const std::vector<StopLineInfo> & red_stop_lines,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
 {
-  ComplianceResult result;
+  Violations violations;
   for (const auto & red_stop_line : red_stop_lines) {
     auto distance_to_stop_line = 0.0;
     lanelet::BasicPoints2d intersection_points;
@@ -201,23 +175,26 @@ ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
     }
     if (
       intersection_points.empty() ||
-      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
+      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line) ||
+      is_allow_if_cannot_stop(distance_to_stop_line))
       continue;
-    result.violations.emplace_back(
+
+    violations.emplace_back(
       ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
       intersection_points.front(), distance_to_stop_line + distance_offset);
   }
-  return result;
+  return violations;
 }
 
-ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
+Violations TrafficLightComplianceChecker::get_amber_light_violations(
   const std::vector<StopLineInfo> & amber_stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point,
-  const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
+  const std::vector<int64_t> & force_reject_amber_ids, const rclcpp::Time & current_time,
+  const double distance_offset) const
 {
-  ComplianceResult result;
+  Violations violations;
   for (const auto & amber_stop_line : amber_stop_lines) {
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
@@ -246,7 +223,11 @@ ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
       !amber_stop_line_crossing_time ||
       is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
       if (stop_point.has_value())
-        result.detected_stop_amber_ids.push_back(amber_stop_line.traffic_light_id);
+        amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
+      continue;
+    }
+
+    if (is_allow_if_cannot_stop(distance_to_stop_line)) {
       continue;
     }
 
@@ -257,24 +238,26 @@ ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
                              force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
                              amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
 
-    if (
-      is_force_reject || !can_pass_amber_light(
-                           distance_to_stop_line, current_velocity, current_acceleration,
-                           *amber_stop_line_crossing_time)) {
-      result.violations.emplace_back(
-        ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
-        intersection_point, distance_to_stop_line + distance_offset);
-    }
+    bool can_pass = can_pass_amber_light(
+      distance_to_stop_line, current_velocity, current_acceleration,
+      *amber_stop_line_crossing_time);
+
+    if (!is_force_reject && can_pass) continue;
+
+    if (!can_pass) amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
+
+    violations.emplace_back(
+      ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
+      intersection_point, distance_to_stop_line + distance_offset);
   }
-  return result;
+  return violations;
 }
 
-tl::expected<ComplianceResult, std::string>
-TrafficLightComplianceChecker::check_with_filtered_signals(
+ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-  const bool check_amber_lights) const
+  const bool check_amber_lights)
 {
   if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
@@ -282,7 +265,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
+  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
     input.current_velocity, input.current_acceleration,
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
@@ -292,7 +275,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   // stop_overshoot_margin extends the scan so a stop just past the line is not truncated.
   const auto max_trajectory_length = std::max(
     params_.min_lookahead_distance,
-    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin);
+    ego_stopping_distance_.value_or(0.0) + params_.stop_overshoot_margin);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -339,30 +322,15 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   ComplianceResult result;
   if (check_red_lights) {
-    result = get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+    result.violations =
+      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
   }
   if (check_amber_lights) {
-    const auto amber_light_result = get_amber_light_violations(
+    const auto amber_light_violations = get_amber_light_violations(
       amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
-      backward_length);
+      input.current_time, backward_length);
     result.violations.insert(
-      result.violations.end(), amber_light_result.violations.begin(),
-      amber_light_result.violations.end());
-    result.detected_stop_amber_ids = amber_light_result.detected_stop_amber_ids;
-  }
-
-  if (ego_stopping_distance.has_value() && params_.allow_if_cannot_stop_distance > 0.0) {
-    result.violations.erase(
-      std::remove_if(
-        result.violations.begin(), result.violations.end(),
-        [&](const auto & violation) {
-          const auto distance_from_ego_front = violation.arc_length_to_cross_point -
-                                               backward_length -
-                                               vehicle_info_.max_longitudinal_offset_m;
-          return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
-                 distance_from_ego_front < *ego_stopping_distance - params_.stop_overshoot_margin;
-        }),
-      result.violations.end());
+      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
   }
 
   return result;
@@ -425,6 +393,17 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
   const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
   const bool can_pass = !can_stop && can_pass_in_time;
   return can_pass;
+}
+
+bool TrafficLightComplianceChecker::is_allow_if_cannot_stop(
+  const double distance_to_cross_point) const
+{
+  if (!ego_stopping_distance_.has_value() || params_.allow_if_cannot_stop_distance < 1e-3)
+    return false;
+  const auto distance_from_ego_front =
+    distance_to_cross_point - vehicle_info_.max_longitudinal_offset_m;
+  return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
+         distance_from_ego_front < *ego_stopping_distance_ - params_.stop_overshoot_margin;
 }
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -222,7 +222,7 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
     if (
       !amber_stop_line_crossing_time ||
       is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
-      if (stop_point.has_value())
+      if (stop_point.has_value() && params_.amber_rejection.reject_if_stop_detected)
         amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
       continue;
     }

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -95,7 +95,6 @@
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
       th_stable_duration_unknown: 0.5 # [s]
-      th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
       amber_rejection:
         th_hysteresis: 0.5 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -88,14 +88,18 @@
       stop_for_red_light: true
       stop_for_amber_light: false
       treat_amber_light_as_red: false
-      treat_unknown_light_as_red: false
-      overshoot_tolerance: 0.0 # [m]
-      allow_if_cannot_stop_distance: 0.0 # [m]
+      treat_unknown_light_as_red: true
+      overshoot_tolerance: 0.5 # [m]
+      allow_if_cannot_stop_distance: 1.0 # [m]
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
+      th_stable_duration_unknown: 0.5 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
+      amber_rejection:
+        th_hysteresis: 0.5 # [s]
+        reject_if_stop_detected: true # reject if we detect a previous stop attempt from input trajectory
 
     # Surround Obstacle Stop Plugin Parameters
     surround_obstacle_stop:

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -408,7 +408,7 @@ trajectory_modifier_params:
       read_only: false
     treat_unknown_light_as_red:
       type: bool
-      default_value: false
+      default_value: true
       description: Treat unknown light as red light
       read_only: false
     overshoot_tolerance:
@@ -420,7 +420,7 @@ trajectory_modifier_params:
       read_only: false
     allow_if_cannot_stop_distance:
       type: double
-      default_value: 0.0
+      default_value: 1.0
       description: allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]
       validation:
         bounds<>: [0.0, 100.0]
@@ -446,10 +446,10 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
-    th_amber_rejection_hysteresis:
+    th_stable_duration_unknown:
       type: double
       default_value: 0.5
-      description: Threshold for amber rejection hysteresis [s]
+      description: Threshold for stable duration of unknown light [s]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
@@ -460,6 +460,19 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    amber_rejection:
+      th_hysteresis:
+        type: double
+        default_value: 0.5
+        description: Threshold for amber rejection hysteresis [s]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      reject_if_stop_detected:
+        type: bool
+        default_value: true
+        description: Reject if we detect a previous stop attempt from input trajectory
+        read_only: false
 
   surround_obstacle_stop:
     use_objects:

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -451,18 +451,18 @@
             "treat_unknown_light_as_red": {
               "type": "boolean",
               "description": "Treat unknown light as red light",
-              "default": false
+              "default": true
             },
             "overshoot_tolerance": {
               "type": "number",
               "description": "Overshoot tolerance [m]",
-              "default": 0.0,
+              "default": 0.5,
               "minimum": 0.0
             },
             "allow_if_cannot_stop_distance": {
               "type": "number",
               "description": "allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]",
-              "default": 0.0,
+              "default": 1.0,
               "minimum": 0.0
             },
             "min_lookahead_distance": {
@@ -483,9 +483,9 @@
               "default": 0.2,
               "minimum": 0.0
             },
-            "th_amber_rejection_hysteresis": {
+            "th_stable_duration_unknown": {
               "type": "number",
-              "description": "Threshold for amber rejection hysteresis [s]",
+              "description": "Threshold for stable duration of unknown light [s]",
               "default": 0.5,
               "minimum": 0.0
             },
@@ -494,6 +494,24 @@
               "description": "Crossing time limit [s]",
               "default": 2.75,
               "minimum": 0.0
+            },
+            "amber_rejection": {
+              "type": "object",
+              "properties": {
+                "th_hysteresis": {
+                  "type": "number",
+                  "description": "Threshold for amber rejection hysteresis [s]",
+                  "default": 0.5,
+                  "minimum": 0.0
+                },
+                "reject_if_stop_detected": {
+                  "type": "boolean",
+                  "description": "Reject if we detect a previous stop attempt from input trajectory",
+                  "default": true
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -118,7 +118,11 @@ bool TrafficLightStop::check_traffic_lights(
 
   const auto result =
     checker_->check(inputs, params_.stop_for_red_light, params_.stop_for_amber_light);
-  if (!result) return false;
+  if (!result) {
+    RCLCPP_ERROR(
+      get_node_ptr()->get_logger(), "Failed to check traffic lights: %s", result.error().c_str());
+    return false;
+  }
 
   if (result->violations.empty()) return false;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -28,15 +28,17 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
 {
   const auto tl_stop_p = params.traffic_light_stop;
   const auto stopping_params = params.stopping_constraints;
-  autoware::traffic_light_compliance_checker::Parameters p;
+  autoware::traffic_light_compliance_checker::Parameters p{};
   p.deceleration_limit = stopping_params.maximum_deceleration;
   p.jerk_limit = stopping_params.jerk_limit;
+  p.delay_response_time = 0.0;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
+  p.ego_stopped_velocity_threshold = 0.01;
   p.status_tracker_parameters.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.status_tracker_parameters.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.status_tracker_parameters.stable_duration_threshold_unknown =

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -37,9 +37,12 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
-  p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
-  p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
-  p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;
+  p.status_tracker_parameters.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
+  p.status_tracker_parameters.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
+  p.status_tracker_parameters.stable_duration_threshold_unknown =
+    tl_stop_p.th_stable_duration_unknown;
+  p.amber_rejection.hysteresis_duration = tl_stop_p.amber_rejection.th_hysteresis;
+  p.amber_rejection.reject_if_stop_detected = tl_stop_p.amber_rejection.reject_if_stop_detected;
   p.checked_trajectory_length.deceleration_limit = stopping_params.nominal_deceleration;
   p.checked_trajectory_length.jerk_limit = stopping_params.jerk_limit;
   return p;

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -89,6 +89,17 @@ TrajectoryPoints create_straight_trajectory(
   return trajectory;
 }
 
+/// Trajectory that cruises then ends with zero velocity at stop_x (stop attempt).
+TrajectoryPoints create_trajectory_with_stop_at(
+  double start_x, double stop_x, double cruise_velocity, double spacing = 1.0)
+{
+  auto trajectory = create_straight_trajectory(start_x, stop_x, cruise_velocity, spacing);
+  if (!trajectory.empty()) {
+    trajectory.back().longitudinal_velocity_mps = 0.0F;
+  }
+  return trajectory;
+}
+
 Odometry::ConstSharedPtr make_odometry(
   double x, double y, double velocity, const rclcpp::Time & stamp)
 {
@@ -231,6 +242,7 @@ protected:
     tl.min_lookahead_distance = 20.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
+    tl.th_stable_duration_unknown = 0.0;
     tl.amber_rejection.th_hysteresis = 0.0;
     tl.amber_rejection.reject_if_stop_detected = false;
     tl.crossing_time_limit = 2.75;
@@ -474,4 +486,59 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithUnknownLightAsRedL
   const bool modified = plugin_->modify_trajectory(trajectory, make_default_input(10.0));
   EXPECT_TRUE(modified)
     << "Unknown treated as red should insert stop point even when not stoppable";
+}
+
+TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithAmberLightWhenPreviousStopIsDetected)
+{
+  const lanelet::Id light_id = 400;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  params_.traffic_light_stop.amber_rejection.reject_if_stop_detected = true;
+  params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
+  params_.traffic_light_stop.overshoot_tolerance = 0.5;
+  params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
+  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  plugin_->update_params(params_);
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  auto stopping_trajectory = create_trajectory_with_stop_at(0.0, stop_x - ego_front_offset, 5.0);
+  expect_not_modified(
+    stopping_trajectory, make_default_input(5.0),
+    "Input trajectory should not be modified when it already contains a valid stop point");
+
+  auto crossing_trajectory = create_straight_trajectory(0.0, 10.0, 10.0);
+  const bool modified = plugin_->modify_trajectory(crossing_trajectory, make_default_input(10.0));
+  EXPECT_TRUE(modified) << "Should modify trajectory when a prior stop attempt is detected and "
+                           "reject_if_stop_detected is true";
+  EXPECT_FLOAT_EQ(crossing_trajectory.back().longitudinal_velocity_mps, 0.0F);
+}
+
+TEST_F(TrafficLightStopIntegrationTest, TrajectoryNotModifiedWhenRejectIfStopDetectedIsDisabled)
+{
+  const lanelet::Id light_id = 401;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  params_.traffic_light_stop.amber_rejection.reject_if_stop_detected = false;
+  params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
+  params_.traffic_light_stop.overshoot_tolerance = 0.5;
+  params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
+  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  plugin_->update_params(params_);
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  auto stopping_trajectory = create_trajectory_with_stop_at(0.0, stop_x - ego_front_offset, 5.0);
+  expect_not_modified(
+    stopping_trajectory, make_default_input(5.0),
+    "Input trajectory should not be modified when it already contains a valid stop point");
+
+  auto crossing_trajectory = create_straight_trajectory(0.0, 10.0, 10.0);
+  expect_not_modified(
+    crossing_trajectory, make_default_input(10.0),
+    "Input trajectory should not be modified when reject_if_stop_detected is false");
 }

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -231,7 +231,8 @@ protected:
     tl.min_lookahead_distance = 20.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
-    tl.th_amber_rejection_hysteresis = 0.0;
+    tl.amber_rejection.th_hysteresis = 0.0;
+    tl.amber_rejection.reject_if_stop_detected = false;
     tl.crossing_time_limit = 2.75;
   }
 

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -137,11 +137,13 @@
       stable_duration_threshold_red: 0.0 # [s] minimum duration a red light must be seen before it is considered active
       stable_duration_threshold_amber: 0.0 # [s] minimum duration an amber light must be seen before it is considered active
       stable_duration_threshold_unknown: 0.0 # [s] minimum duration an unknown light must be seen before it is considered active
-      amber_rejection_hysteresis_duration: 0.0 # [s] duration to persist an amber rejection
       ego_stopped_velocity_threshold: 0.01 # [m/s] velocity below which ego is considered fully stopped
       checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
         deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
         jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+      amber_rejection:
+        hysteresis_duration: 0.0 # [s] hysteresis duration to persist an AMBER rejection
+        reject_if_stop_detected: false # reject if we detect a previous stop attempt from input trajectory
 
     boundary_departure:
       boundary_types: ["road_border"]

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -468,11 +468,6 @@ validator:
       default_value: 0.0
       description: Minimum duration an UNKNOWN signal must be seen before it is considered active (seconds)
       read_only: false
-    amber_rejection_hysteresis_duration:
-      type: double
-      default_value: 0.0
-      description: Hysteresis duration to persist an AMBER rejection (seconds)
-      read_only: false
     ego_stopped_velocity_threshold:
       type: double
       default_value: 0.01
@@ -488,6 +483,17 @@ validator:
         type: double
         default_value: 2.0
         description: jerk limit to calculate the stop distance used as trajectory length limit
+        read_only: false
+    amber_rejection:
+      hysteresis_duration:
+        type: double
+        default_value: 0.0
+        description: Hysteresis duration to persist an AMBER rejection (seconds)
+        read_only: false
+      reject_if_stop_detected:
+        type: bool
+        default_value: false
+        description: Reject if we detect a previous stop attempt from input trajectory
         read_only: false
 
   boundary_departure:

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -634,12 +634,6 @@
               "default": 0.0,
               "minimum": 0.0
             },
-            "amber_rejection_hysteresis_duration": {
-              "type": "number",
-              "description": "Duration to persist an AMBER rejection state to prevent flipping [s].",
-              "default": 0.0,
-              "minimum": 0.0
-            },
             "ego_stopped_velocity_threshold": {
               "type": "number",
               "description": "Velocity threshold below which stability and hysteresis filters are bypassed [m/s].",
@@ -658,6 +652,24 @@
                   "type": "number",
                   "description": "Jerk limit used together with `deceleration_limit` to compute the trajectory scan length [m/s³].",
                   "default": 2.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "amber_rejection": {
+              "type": "object",
+              "properties": {
+                "hysteresis_duration": {
+                  "type": "number",
+                  "description": "Hysteresis duration to persist an AMBER rejection [s].",
+                  "default": 0.0,
+                  "minimum": 0.0
+                },
+                "reject_if_stop_detected": {
+                  "type": "boolean",
+                  "description": "Reject if we detect a previous stop attempt from input trajectory.",
+                  "default": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -85,14 +85,17 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.stop_overshoot_margin = params.stop_overshoot_margin;
   p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = params.min_lookahead_distance;
-  p.stable_duration_threshold_red = params.stable_duration_threshold_red;
-  p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
-  p.stable_duration_threshold_unknown = params.stable_duration_threshold_unknown;
-  p.amber_rejection_hysteresis_duration = params.amber_rejection_hysteresis_duration;
+  p.status_tracker_parameters.stable_duration_threshold_red = params.stable_duration_threshold_red;
+  p.status_tracker_parameters.stable_duration_threshold_amber =
+    params.stable_duration_threshold_amber;
+  p.status_tracker_parameters.stable_duration_threshold_unknown =
+    params.stable_duration_threshold_unknown;
   p.ego_stopped_velocity_threshold = params.ego_stopped_velocity_threshold;
   p.checked_trajectory_length.deceleration_limit =
     params.checked_trajectory_length.deceleration_limit;
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
+  p.amber_rejection.hysteresis_duration = params.amber_rejection.hysteresis_duration;
+  p.amber_rejection.reject_if_stop_detected = params.amber_rejection.reject_if_stop_detected;
   return p;
 }
 }  // namespace

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -162,6 +162,17 @@ protected:
     return points;
   }
 
+  /// Trajectory that cruises then ends with zero velocity at stop_x (stop attempt).
+  static std::vector<TrajectoryPoint> create_trajectory_with_stop_at(
+    double start_x, double stop_x, float cruise_velocity = 5.0)
+  {
+    auto points = create_trajectory(start_x, stop_x, cruise_velocity);
+    if (!points.empty()) {
+      points.back().longitudinal_velocity_mps = 0.0F;
+    }
+    return points;
+  }
+
   void set_ego_motion(const double velocity, const double acceleration)
   {
     auto odometry = std::make_shared<nav_msgs::msg::Odometry>(*context_.odometry);
@@ -779,6 +790,59 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
 
   // Now it should be feasible if it cannot stop
   expect_feasibility(points2, true, "Should be feasible after hysteresis duration");
+}
+
+TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightWhenPreviousStopIsDetected)
+{
+  const lanelet::Id light_id = 501;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  auto params = params_;
+  params.traffic_light.amber_rejection.reject_if_stop_detected = true;
+  params.traffic_light.amber_rejection.hysteresis_duration = 5.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
+  params.traffic_light.crossing_time_limit = 100.0;
+  filter_->update_parameters(params);
+
+  auto stopping_points = create_trajectory_with_stop_at(0.0, stop_x, 5.0);
+  expect_feasibility(
+    stopping_points, true, "Should be feasible when trajectory stops within threshold");
+
+  set_ego_motion(10.0, 0.0);
+  auto crossing_points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    crossing_points, false,
+    "Should be infeasible after a prior stop attempt while reject_if_stop_detected is true");
+}
+
+TEST_F(TrafficLightFilterTest, IsFeasibleWhenRejectIfStopDetectedIsDisabled)
+{
+  const lanelet::Id light_id = 502;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  auto params = params_;
+  params.traffic_light.amber_rejection.reject_if_stop_detected = false;
+  params.traffic_light.amber_rejection.hysteresis_duration = 5.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
+  params.traffic_light.crossing_time_limit = 100.0;
+  filter_->update_parameters(params);
+
+  auto stopping_points = create_trajectory_with_stop_at(0.0, stop_x, 5.0);
+  expect_feasibility(
+    stopping_points, true, "Should be feasible when trajectory stops within threshold");
+
+  set_ego_motion(10.0, 0.0);
+  auto crossing_points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    crossing_points, true, "Should be feasible when reject_if_stop_detected is false");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -51,38 +51,23 @@ protected:
     vehicle_info.max_longitudinal_offset_m = 0.0;
     filter_->set_vehicle_info(vehicle_info);
 
-    // Initialize default parameters
-    node_->declare_parameter("traffic_light.deceleration_limit", 2.8);
-    node_->declare_parameter("traffic_light.jerk_limit", 5.0);
-    node_->declare_parameter("traffic_light.delay_response_time", 0.5);
-    node_->declare_parameter("traffic_light.crossing_time_limit", 2.75);
-    node_->declare_parameter("traffic_light.treat_amber_light_as_red_light", false);
-    node_->declare_parameter("traffic_light.treat_unknown_light_as_red_light", false);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_red", 0.0);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_amber", 0.0);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_unknown", 0.0);
-    node_->declare_parameter("traffic_light.amber_rejection_hysteresis_duration", 0.0);
-    node_->declare_parameter("traffic_light.ego_stopped_velocity_threshold", 0.01);
-    node_->declare_parameter("traffic_light.min_lookahead_distance", 20.0);
-    node_->declare_parameter("traffic_light.checked_trajectory_length.deceleration_limit", 999.9);
-    node_->declare_parameter("traffic_light.checked_trajectory_length.jerk_limit", 999.9);
-
-    validator::Params params;
-    params.traffic_light.deceleration_limit = 2.8;
-    params.traffic_light.jerk_limit = 5.0;
-    params.traffic_light.delay_response_time = 0.5;
-    params.traffic_light.crossing_time_limit = 2.75;
-    params.traffic_light.treat_amber_light_as_red_light = false;
-    params.traffic_light.treat_unknown_light_as_red_light = false;
-    params.traffic_light.stable_duration_threshold_red = 0.0;
-    params.traffic_light.stable_duration_threshold_amber = 0.0;
-    params.traffic_light.stable_duration_threshold_unknown = 0.0;
-    params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-    params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-    params.traffic_light.min_lookahead_distance = 20.0;
-    params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-    params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
-    filter_->update_parameters(params);
+    params_.traffic_light.deceleration_limit = 2.8;
+    params_.traffic_light.jerk_limit = 5.0;
+    params_.traffic_light.delay_response_time = 0.5;
+    params_.traffic_light.crossing_time_limit = 2.75;
+    params_.traffic_light.treat_amber_light_as_red_light = false;
+    params_.traffic_light.treat_unknown_light_as_red_light = false;
+    params_.traffic_light.stable_duration_threshold_red = 0.0;
+    params_.traffic_light.stable_duration_threshold_amber = 0.0;
+    params_.traffic_light.stable_duration_threshold_unknown = 0.0;
+    params_.traffic_light.amber_rejection.hysteresis_duration = 0.0;
+    params_.traffic_light.amber_rejection.reject_if_stop_detected = false;
+    params_.traffic_light.ego_stopped_velocity_threshold = 0.01;
+    params_.traffic_light.min_lookahead_distance = 20.0;
+    params_.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+    params_.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+    params_.traffic_light.stop_overshoot_margin = 0.5;
+    filter_->update_parameters(params_);
 
     context_.traffic_light_signals = std::make_shared<TrafficLightGroupArray>();
     context_.route = std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
@@ -203,6 +188,7 @@ protected:
   std::shared_ptr<TrafficLightFilter> filter_;
   std::shared_ptr<rclcpp::Node> node_;
   FilterContext context_;
+  validator::Params params_;
 };
 
 TEST_F(TrafficLightFilterTest, HandlesEmptyTrajectorySafely)
@@ -332,14 +318,8 @@ TEST_F(TrafficLightFilterTest, AllowsCrossingIfEgoFrontIsTooCloseToStop)
   vehicle_info.max_longitudinal_offset_m = 2.0;
   filter_->set_vehicle_info(vehicle_info);
 
-  validator::Params params;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.stop_overshoot_margin = 0.5;
+  auto params = params_;
   params.traffic_light.allow_if_cannot_stop_distance = 4.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -367,14 +347,9 @@ TEST_F(TrafficLightFilterTest, AllowsCrossingWhenEgoFrontHasPassedStopLine)
   vehicle_info.max_longitudinal_offset_m = 5.0;
   filter_->set_vehicle_info(vehicle_info);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 1.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 3.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -393,14 +368,9 @@ TEST_F(TrafficLightFilterTest, RejectsCrossingWhenEgoCanStopSafely)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 2.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 5.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -420,22 +390,16 @@ TEST_F(TrafficLightFilterTest, RejectsAtStoppingDistanceBoundary)
   constexpr double deceleration_limit = 5.0;
   constexpr double jerk_limit = 2.0;
   constexpr double delay_response_time = 2.0;
-  constexpr double stop_overshoot_margin = 0.5;
   // Ego naturally stops after exactly 1.0 m during the response delay, so the stop line at
-  // 0.5 m is exactly stopping_distance - stop_overshoot_margin.
+  // 0.5 m is exactly stopping_distance - stop_overshoot_margin (0.5 from SetUp).
   constexpr double stop_x = 0.5;
 
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = delay_response_time;
-  params.traffic_light.stop_overshoot_margin = stop_overshoot_margin;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = deceleration_limit;
   params.traffic_light.checked_trajectory_length.jerk_limit = jerk_limit;
   filter_->update_parameters(params);
@@ -454,14 +418,9 @@ TEST_F(TrafficLightFilterTest, RejectsWhenStoppingDistanceIsUnavailable)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 0.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 0.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -480,14 +439,8 @@ TEST_F(TrafficLightFilterTest, RejectsWithZeroCannotStopAllowance)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 1.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
-  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -556,11 +509,10 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
   // This is a scenario where ego can stop and cannot pass.
 
   // Let's adjust params to create the desired scenario.
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.deceleration_limit = -0.5;  // Very weak braking
   params.traffic_light.delay_response_time = 1.0;
   params.traffic_light.crossing_time_limit = 1.0;  // Short amber
-  params.traffic_light.treat_amber_light_as_red_light = false;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 200.0, 10.0);
@@ -576,18 +528,8 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_amber_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Even if it's NOT stoppable (ego at 0m, velocity 10m/s, stop at 5m),
@@ -607,18 +549,8 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithUnknownLightAsRedLight)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Crossing unknown light when treat_unknown_light_as_red_light is true
@@ -643,18 +575,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithUnknownStabilityFiltering)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
@@ -677,18 +600,10 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleAfterUnknownStableDurationThreshold)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
   params.traffic_light.stable_duration_threshold_amber = 5.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
@@ -710,18 +625,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleAfterUnknownStableDurationThresholdFr
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
@@ -753,18 +659,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithUnknownStabilityFilteringWhenEgoS
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   nav_msgs::msg::Odometry odometry = *context_.odometry;
@@ -785,18 +682,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithUnknownSignalHistoryCleanup)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
   params.traffic_light.stable_duration_threshold_amber = 5.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0, 5.0);
@@ -823,18 +712,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
-  params.traffic_light.treat_amber_light_as_red_light = false;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;  // 1 second stability
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Set initial state to GREEN
@@ -871,15 +752,8 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
-  params.traffic_light.treat_amber_light_as_red_light = false;
-  params.traffic_light.amber_rejection_hysteresis_duration = 2.0;  // 2 seconds hysteresis
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  auto params = params_;
+  params.traffic_light.amber_rejection.hysteresis_duration = 2.0;  // 2 seconds hysteresis
   filter_->update_parameters(params);
 
   // Ego at 0m, velocity 5m/s. Stoppable.
@@ -913,13 +787,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
   const double stop_x = 5.0;
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0);
@@ -948,13 +819,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalStateChange)
   const double stop_x = 5.0;
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0);


### PR DESCRIPTION
## Description
This PR improves amber-light rejection stability in `autoware_traffic_light_compliance_checker`, and wire the updated behavior through `traffic_light_stop` (modifier) and `traffic_light_filter` (validator).

### Changes:
- Detect when the input trajectory already attempts to stop at an amber light, and optionally add that traffic light ID to the amber force-rejection hysteresis buffer (if param `reject_if_stop_detected` is set to **true**).
- Compute a dynamic amber crossing time limit from the tracked signal duration (crossing_time_limit - tracked_duration) instead of always using the fixed parameter alone.
- Refactor compliance checking so amber rejection history and allow_if_cannot_stop are applied during violation evaluation, not as a post-process step. This avoids force-rejection updates re-arming hysteresis, and avoids stamping history for violations that are later discarded.
- Update modifier/validator parameter structs, schemas, configs, and related unit/integration tests.

## Related Links
- [Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2810)

## How was this PR tested?
- `colcon test --packages-select autoware_trajectory_modifier`
- `colcon test --packages-select autoware_trajectory_validator`
- LSIM

## Interface Changes
### ROS Parameter Changes

- **trajectory_modifier**

| Change Type | Parameter Name | Type | Default | Description |
| --- | -------------------- | ---------- | ---------- | ---------------------------------------------------- |
| removed | `traffic_light_stop.th_amber_rejection_hysteresis` | double | 0.5 | hysteresis duration to persist an AMBER rejection |
| added | `traffic_light_stop.th_stable_duration_unknown` | double | 0.5 | stability duration for UNKNOWN signals |
| added | `traffic_light_stop.amber_rejection.th_hysteresis` | double | 0.5 | hysteresis duration to persist an AMBER rejection |
| added | `traffic_light_stop.amber_rejection.reject_if_stop_detected` | bool | true | If true, commit amber force-rejection when the input trajectory already stops near an amber light |

- **trajectory_validator**

| Change Type | Parameter Name | Type | Default | Description |
| --- | -------------------- | ---------- | ---------- | ---------------------------------------------------- |
| removed | `traffic_light.amber_rejection_hysteresis_duration` | double | 0.5 | hysteresis duration to persist an AMBER rejection |
| added | `traffic_light_stop.amber_rejection.hysteresis_duration` | double | 0.5 | hysteresis duration to persist an AMBER rejection |
| added | `traffic_light_stop.amber_rejection.reject_if_stop_detected` | bool | true | If true, commit amber force-rejection when the input trajectory already stops near an amber light |