### PR TITLE
fix(minimum_rule_based_planner): wait for map before processing route

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -69,7 +69,13 @@ void PathPlanner::set_planner_data(
   const LaneletRoute::ConstSharedPtr & route_ptr)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
-  if (lanelet_map_bin_ptr && !route_context_.lanelet_map_ptr) {
+  if (!lanelet_map_bin_ptr) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000, "Lanelet map has not been received. Skipping planner data update.");
+    return;
+  }
+
+  if (!route_context_.lanelet_map_ptr) {
     route_context_.lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
     lanelet::utils::conversion::fromBinMsg(
       *lanelet_map_bin_ptr, route_context_.lanelet_map_ptr, &route_context_.traffic_rules_ptr,

--- a/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
@@ -117,6 +117,25 @@ TEST(PathPlannerTest, ConstructWithoutNode)
   EXPECT_NO_THROW(PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info));
 }
 
+TEST(PathPlannerTest, SetPlannerDataWaitsForMap)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  auto route = std::make_shared<LaneletRoute>();
+  autoware_planning_msgs::msg::LaneletSegment segment;
+  segment.primitives.emplace_back().id = 1;
+  segment.preferred_primitive = segment.primitives.front();
+  route->segments.push_back(segment);
+
+  EXPECT_NO_THROW(planner.set_planner_data(nullptr, route));
+  EXPECT_EQ(planner.route_context().lanelet_map_ptr, nullptr);
+  EXPECT_TRUE(planner.route_context().route_lanelets.empty());
+}
+
 // ============================================================
 // shift_trajectory_to_ego tests
 // ============================================================


### PR DESCRIPTION
## Description

Prevent `autoware_minimum_rule_based_planner` from crashing when a route is received before the lanelet map.

Previously, the planner could process the route while the lanelet map pointer was null, causing a null-pointer dereference when looking up route lanelets.

## Key changes

1. **Wait for the lanelet map**
   - Check whether the lanelet map has been received before updating planner data.
   - Emit a throttled warning while the map is unavailable.
   - Skip planner data initialization and path planning until the map is available.
   - Add a test that provides a route without a lanelet map.

## Related links

None.

## How was this PR tested?

New unit test.

## Notes for reviewers

None.

## Interface changes

None.
