### PR TITLE
feat: update mrm switching design patch 0807

### DIFF
--- a/system/autoware_diagnostic_graph_aggregator/config/default.param.yaml
+++ b/system/autoware_diagnostic_graph_aggregator/config/default.param.yaml
@@ -16,7 +16,15 @@
       - "{mode: 2003, path: /autoware/modes/pull_over}"
 
     use_driving_mode_mappings: true
-    driving_mode_mappings:
+    driving_mode_available:
+      - "{mode: 1001, path: /autoware/modes/stop}"
+      - "{mode: 1002, path: /autoware/modes/autonomous/available}"
+      - "{mode: 1003, path: /autoware/modes/local}"
+      - "{mode: 1004, path: /autoware/modes/remote}"
+      - "{mode: 2001, path: /autoware/modes/emergency_stop}"
+      - "{mode: 2002, path: /autoware/modes/comfortable_stop}"
+      - "{mode: 2003, path: /autoware/modes/pull_over}"
+    driving_mode_continuable:
       - "{mode: 1001, path: /autoware/modes/stop}"
       - "{mode: 1002, path: /autoware/modes/autonomous}"
       - "{mode: 1003, path: /autoware/modes/local}"

--- a/system/autoware_diagnostic_graph_aggregator/example/graph/main.yaml
+++ b/system/autoware_diagnostic_graph_aggregator/example/graph/main.yaml
@@ -12,6 +12,11 @@ units:
       - { type: link, link: /functions/pose_estimation }
       - { type: link, link: /functions/obstacle_detection }
 
+  - path: /autoware/modes/autonomous/available
+    type: and
+    list:
+      - { type: link, link: /autoware/modes/autonomous }
+
   - path: /autoware/modes/local
     type: and
     list:

--- a/system/autoware_diagnostic_graph_aggregator/src/node/driving_mode_mapping.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/driving_mode_mapping.cpp
@@ -33,18 +33,24 @@ DrivingModeMapping::DrivingModeMapping(rclcpp::Node & node, const Graph & graph)
     path_to_unit[unit->path()] = unit;
   }
 
-  const auto mappings = node.declare_parameter<std::vector<std::string>>("driving_mode_mappings");
-  for (const auto & mapping : mappings) {
-    YAML::Node yaml = YAML::Load(mapping);
-    const auto mode = yaml["mode"].as<uint32_t>();
-    const auto path = yaml["path"].as<std::string>();
-    const auto iter = path_to_unit.find(path);
-    if (iter != path_to_unit.end()) {
-      mode_to_unit_[mode] = iter->second;
-    } else {
-      RCLCPP_ERROR_STREAM(node.get_logger(), "Mode path not found: " << mode << " " << path);
+  const auto create_mapping = [&node, &path_to_unit](const std::string & param) {
+    const auto mappings = node.declare_parameter<std::vector<std::string>>(param);
+    std::unordered_map<uint32_t, BaseUnit *> units;
+    for (const auto & mapping : mappings) {
+      YAML::Node yaml = YAML::Load(mapping);
+      const auto mode = yaml["mode"].as<uint32_t>();
+      const auto path = yaml["path"].as<std::string>();
+      const auto iter = path_to_unit.find(path);
+      if (iter != path_to_unit.end()) {
+        units[mode] = iter->second;
+      } else {
+        RCLCPP_ERROR_STREAM(node.get_logger(), "Mode path not found: " << mode << " " << path);
+      }
     }
-  }
+    return units;
+  };
+  available_units_ = create_mapping("driving_mode_available");
+  continuable_units_ = create_mapping("driving_mode_continuable");
 
   pub_available_ =
     node.create_publisher<DrivingModeFlag>("/system/driving_mode/available", rclcpp::QoS(1));
@@ -54,16 +60,22 @@ DrivingModeMapping::DrivingModeMapping(rclcpp::Node & node, const Graph & graph)
 
 void DrivingModeMapping::update(const rclcpp::Time & stamp) const
 {
-  DrivingModeFlag message;
-  for (const auto & [mode, unit] : mode_to_unit_) {
-    tier4_system_msgs::msg::DrivingModeFlagItem item;
-    item.mode = mode;
-    item.flag = unit->level() == DiagnosticStatus::OK;
-    message.items.push_back(item);
-  }
-  message.stamp = stamp;
-  pub_available_->publish(message);
-  pub_continuable_->publish(message);
+  const auto create_message = [this, stamp](const auto & units) {
+    DrivingModeFlag msg;
+    msg.stamp = stamp;
+    for (const auto & [mode, unit] : units) {
+      tier4_system_msgs::msg::DrivingModeFlagItem item;
+      item.mode = mode;
+      item.flag = unit->level() == DiagnosticStatus::OK;
+      msg.items.push_back(item);
+    }
+    return msg;
+  };
+
+  const auto available_msg = create_message(available_units_);
+  const auto continuable_msg = create_message(continuable_units_);
+  pub_available_->publish(available_msg);
+  pub_continuable_->publish(continuable_msg);
 }
 
 }  // namespace autoware::diagnostic_graph_aggregator

--- a/system/autoware_diagnostic_graph_aggregator/src/node/driving_mode_mapping.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/driving_mode_mapping.hpp
@@ -37,7 +37,8 @@ private:
   rclcpp::Publisher<DrivingModeFlag>::SharedPtr pub_available_;
   rclcpp::Publisher<DrivingModeFlag>::SharedPtr pub_continuable_;
 
-  std::unordered_map<uint32_t, BaseUnit *> mode_to_unit_;
+  std::unordered_map<uint32_t, BaseUnit *> available_units_;
+  std::unordered_map<uint32_t, BaseUnit *> continuable_units_;
 };
 
 }  // namespace autoware::diagnostic_graph_aggregator

--- a/system/autoware_driving_mode_manager/msg/DebugModeRequest.msg
+++ b/system/autoware_driving_mode_manager/msg/DebugModeRequest.msg
@@ -15,3 +15,12 @@ uint32 mrm_behavior
 
 # Target mode returned by the decision logic. (required)
 uint32 autoware_mode
+
+# Transitioning to initial mode. (required)
+bool initializing
+
+# Transitioning to target mode. (required)
+bool transitioning
+
+# Modes that failed to transition. (required)
+uint32[] unavailable_modes

--- a/system/autoware_driving_mode_manager/src/core/main.cpp
+++ b/system/autoware_driving_mode_manager/src/core/main.cpp
@@ -156,7 +156,12 @@ void ManagerMain::publish_debug_flags() const
 
 void ManagerMain::publish_debug_request() const
 {
-  interface_->publish_debug_request(request_);
+  DebugStatus status;
+  status.request = request_;
+  status.initializing = is_initial_request_;
+  status.transitioning = !tasks_.empty();
+  status.unavailable_modes = temporary_unavailable_modes_;
+  interface_->publish_debug_request(status);
 }
 
 void ManagerMain::on_trajectory_source(const TrajectorySource & source)

--- a/system/autoware_driving_mode_manager/src/ros_interface.cpp
+++ b/system/autoware_driving_mode_manager/src/ros_interface.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace autoware::driving_mode_manager
 {
@@ -228,8 +229,14 @@ void RosInterface::publish_debug_flags(const DebugFlags & flags)
   pub_debug_mode_flag_->publish(msg);
 }
 
-void RosInterface::publish_debug_request(const RequestModes & request)
+void RosInterface::publish_debug_request(const DebugStatus & status)
 {
+  const auto vectorize = [](const auto & modes) {
+    std::vector<uint32_t> result;
+    for (const auto & mode : modes) result.push_back(mode.id);
+    return result;
+  };
+  const auto & request = status.request;
   DebugModeRequestMsg msg;
   msg.stamp = now();
   msg.operation_mode = request.operation_mode.id;
@@ -237,6 +244,9 @@ void RosInterface::publish_debug_request(const RequestModes & request)
   msg.mrm_strategy = static_cast<std::underlying_type_t<MrmStrategy>>(request.mrm_strategy);
   msg.mrm_behavior = request.mrm_behavior.id;
   msg.autoware_mode = request.autoware_mode.id;
+  msg.initializing = status.initializing;
+  msg.transitioning = status.transitioning;
+  msg.unavailable_modes = vectorize(status.unavailable_modes);
   pub_debug_mode_request_->publish(msg);
 }
 

--- a/system/autoware_driving_mode_manager/src/ros_interface.hpp
+++ b/system/autoware_driving_mode_manager/src/ros_interface.hpp
@@ -64,7 +64,7 @@ public:
   void publish_diagnostics(bool ok, const std::string & message) override;
 
   void publish_debug_flags(const DebugFlags & flags) override;
-  void publish_debug_request(const RequestModes & request) override;
+  void publish_debug_request(const DebugStatus & status) override;
 
   void log_info(const std::string & message) override;
   void log_warn(const std::string & message) override;

--- a/system/autoware_driving_mode_manager/src/type/interface.hpp
+++ b/system/autoware_driving_mode_manager/src/type/interface.hpp
@@ -46,7 +46,7 @@ public:
   virtual void publish_diagnostics(bool ok, const std::string & message) = 0;
 
   virtual void publish_debug_flags(const DebugFlags & flags) = 0;
-  virtual void publish_debug_request(const RequestModes & request) = 0;
+  virtual void publish_debug_request(const DebugStatus & status) = 0;
 
   virtual void log_info(const std::string & message) = 0;
   virtual void log_warn(const std::string & message) = 0;

--- a/system/autoware_driving_mode_manager/src/type/types.hpp
+++ b/system/autoware_driving_mode_manager/src/type/types.hpp
@@ -19,6 +19,8 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace autoware::driving_mode_manager
 {
@@ -83,6 +85,15 @@ struct GateStatus
 {
   GateStatusItem status;
   GateStatusItem expect;
+};
+
+struct DebugStatus
+{
+  RequestModes request;
+  bool initializing;
+  bool transitioning;
+  std::string task;
+  std::unordered_set<AutowareMode> unavailable_modes;
 };
 
 struct DebugFlags

--- a/system/autoware_driving_mode_manager/test/util/mock.cpp
+++ b/system/autoware_driving_mode_manager/test/util/mock.cpp
@@ -87,9 +87,9 @@ void MockInterface::publish_debug_flags(const DebugFlags & flags)
   (void)flags;
 }
 
-void MockInterface::publish_debug_request(const RequestModes & request)
+void MockInterface::publish_debug_request(const DebugStatus & status)
 {
-  (void)request;
+  (void)status;
 }
 
 void MockInterface::log_info(const std::string & message)

--- a/system/autoware_driving_mode_manager/test/util/mock.hpp
+++ b/system/autoware_driving_mode_manager/test/util/mock.hpp
@@ -40,7 +40,7 @@ public:
   void publish_diagnostics(bool ok, const std::string & message) override;
 
   void publish_debug_flags(const DebugFlags & flags) override;
-  void publish_debug_request(const RequestModes & request) override;
+  void publish_debug_request(const DebugStatus & status) override;
 
   void log_info(const std::string & message) override;
   void log_warn(const std::string & message) override;


### PR DESCRIPTION
## 変更
- autoware_diagnostic_graph_aggregator: 走行中エンゲージのためフラグを独立して出すように変更
- autoware_driving_mode_manager: デバッグメッセージの追加

## 影響

diagnostic_graph_aggregatorのパラメーターファイルをPRを参考に修正してください。
配列の各モードの設定は基本的にはコピペで、autonomousの部分だけ以下のようにavailableをつけます。
```diff
-    driving_mode_mappings:
+    driving_mode_available:
+      - "{mode: 1001, path: /autoware/modes/stop}"
+      - "{mode: 1002, path: /autoware/modes/autonomous/available}"  # ここだけ "/available" が付く
+      - "{mode: 1003, path: /autoware/modes/local}"
+      - "{mode: 1004, path: /autoware/modes/remote}"
+      - "{mode: 2001, path: /autoware/modes/emergency_stop}"
+      - "{mode: 2002, path: /autoware/modes/comfortable_stop}"
+      - "{mode: 2003, path: /autoware/modes/pull_over}"
+    driving_mode_continuable:
       - "{mode: 1001, path: /autoware/modes/stop}"
       - "{mode: 1002, path: /autoware/modes/autonomous}"
       - "{mode: 1003, path: /autoware/modes/local}"
       - "{mode: 1004, path: /autoware/modes/remote}"
       - "{mode: 2001, path: /autoware/modes/emergency_stop}"
       - "{mode: 2002, path: /autoware/modes/comfortable_stop}"
       - "{mode: 2003, path: /autoware/modes/pull_over}"
 ```

diagnostic_graph_aggregatorのグラフ定義ファイル(autoware-main.yaml)に以下を追加してください。
これは `モード変更条件＝モード維持条件(従来の設定) AND 走行中エンゲージ可否判定` を作っています。
```yaml
  - path: /autoware/modes/autonomous/available
    type: and
    list:
      - { type: link, link: /autoware/modes/autonomous }
      - { type: link, link: /autoware/system/available }

  - path: /autoware/system/available
    type: diag
    node: autoware_operation_mode_transition_manager
    name: mode_change_available
```
