### PR TITLE
fix(minimum_rule_based_planner): shift_to_ego

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -32,10 +32,10 @@
       path_shift:
         enable: true
         minimum_shift_length: 0.5
-        minimum_shift_distance: 5.0
-        min_speed_for_curvature: 2.77  # [m/s] 10 km/h
+        minimum_shift_distance: 3.0
+        min_speed_for_curvature: 1.39  # [m/s] 5 km/h
         lateral_accel_limit: 1.0      # [m/s^2]
-        curvature_limit: 0.1          # [1/m] R = 10 m
+        curvature_limit: 0.156          # [1/m] R = 10 m
 
       waypoint_group:
         separation_threshold: 1.0

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -35,6 +35,7 @@
         minimum_shift_distance: 5.0
         min_speed_for_curvature: 2.77  # [m/s] 10 km/h
         lateral_accel_limit: 1.0      # [m/s^2]
+        curvature_limit: 0.1          # [1/m] R = 10 m
 
       waypoint_group:
         separation_threshold: 1.0

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -140,6 +140,13 @@ minimum_rule_based_planner:
         validation:
           gt<>: [0.0]
 
+      curvature_limit:
+        type: double
+        default_value: 0.1
+        description: curvature budget of the shift polynomial. Caps the lateral offset corrected within the available length to curvature_limit * L^2 / (10*sqrt(3)/3) [1/m]
+        validation:
+          gt<>: [0.0]
+
   map_based_stop:
     stop_margin_distance:
       type: double

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -143,7 +143,7 @@ minimum_rule_based_planner:
       curvature_limit:
         type: double
         default_value: 0.1
-        description: upper bound [1/m] on the peak curvature of the shift polynomial. Caps the corrected lateral offset at curvature_limit * L^2 / (10*sqrt(3)/3), where L is the available shift length
+        description: upper bound [1/m] on the peak curvature of the shift polynomial. The shift length is stretched to at least sqrt((10*sqrt(3)/3) * |lateral offset| / curvature_limit) so that the whole offset is corrected within this bound
         validation:
           gt<>: [0.0]
 

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -143,7 +143,7 @@ minimum_rule_based_planner:
       curvature_limit:
         type: double
         default_value: 0.1
-        description: curvature budget of the shift polynomial. Caps the lateral offset corrected within the available length to curvature_limit * L^2 / (10*sqrt(3)/3) [1/m]
+        description: upper bound [1/m] on the peak curvature of the shift polynomial. Caps the corrected lateral offset at curvature_limit * L^2 / (10*sqrt(3)/3), where L is the available shift length
         validation:
           gt<>: [0.0]
 

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -407,6 +407,7 @@ Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
   shift_params.minimum_shift_distance = params_.path_planning.path_shift.minimum_shift_distance;
   shift_params.min_speed_for_curvature = params_.path_planning.path_shift.min_speed_for_curvature;
   shift_params.lateral_accel_limit = params_.path_planning.path_shift.lateral_accel_limit;
+  shift_params.curvature_limit = params_.path_planning.path_shift.curvature_limit;
 
   const double ego_velocity = input_data.odometry_ptr->twist.twist.linear.x;
   const double ego_yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1008,6 +1008,9 @@ constexpr double quintic_kappa_coeff = 5.773502691896258;  // 10*sqrt(3)/3
 constexpr double yaw_diff_clamp_rad = M_PI / 4.0;
 constexpr double lane_end_match_tolerance_sq = 4.0;  // [m^2] 2m tolerance squared
 constexpr double yaw_step = 0.1;  // [m] finite-difference step for centerline yaw
+// [m] half-baseline of the reference curvature estimate at the shift start. Long enough that the
+// 3-point estimate is not dominated by the point-to-point noise of the resampled centerline.
+constexpr double curvature_baseline_length = 2.0;
 
 struct QuinticShiftCoeffs
 {
@@ -1075,6 +1078,22 @@ double signed_curvature_3pt(
     return 0.0;
   }
   return 2.0 * cross / denom;
+}
+
+// Curvature of the reference line at index idx, estimated from 3 points spaced baseline_step apart.
+double reference_curvature(
+  const std::vector<TrajectoryPoint> & points, const size_t idx, const size_t baseline_step)
+{
+  const size_t i0 = idx > baseline_step ? idx - baseline_step : 0;
+  const size_t i2 = std::min(idx + baseline_step, points.size() - 1);
+  const size_t i1 = (i0 + i2) / 2;
+  if (i1 == i0 || i1 == i2) {
+    return 0.0;
+  }
+  const auto to_2d = [&](const size_t i) {
+    return lanelet::BasicPoint2d(points.at(i).pose.position.x, points.at(i).pose.position.y);
+  };
+  return signed_curvature_3pt(to_2d(i0), to_2d(i1), to_2d(i2));
 }
 
 std::optional<double> cal_margin2goal(
@@ -1801,26 +1820,62 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
     }
   }
   if (merge_idx >= trajectory.points.size() - 1) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("minimum_rule_based_planner").get_child("path_shift_to_ego"),
-      "Trajectory is shorter than the target shift length (%.2f m < %.2f m). "
-      "Terminal boundary conditions (y=0, y'=0, y''=0) cannot be satisfied; "
-      "the shift polynomial will not converge smoothly at the merge point.",
-      accumulated_length, L);
+    // The trajectory ends before the desired merge point (goal approach, stop point, or ego at the
+    // very end): merge at the last point so the terminal conditions still land on it. The lateral
+    // correction is capped below to keep the curvature of the shortened section feasible.
     L = accumulated_length;
-    merge_idx = trajectory.points.size() - 2;
+    merge_idx = trajectory.points.size() - 1;
+  }
+  if (L < delta_arc_length) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000, "Only %.2f m of trajectory ahead of ego; skipping the shift to ego.",
+      L);
+    return trajectory;
   }
 
-  const double kappa0 = ego_yaw_rate / clamped_velocity;
-  const auto coeffs = compute_quintic_shift_coeffs(lateral_offset, signed_yaw_dev, kappa0, L);
+  // The peak curvature of the shift is quintic_kappa_coeff*|d|/L^2, so the offset that can be
+  // corrected within L is bounded by the curvature budget. Correcting the rest would emit a path
+  // the vehicle cannot steer; it is left as a lateral error for the controller instead.
+  const double max_shift_length = shift_params.curvature_limit * L * L / quintic_kappa_coeff;
+  const double shift_length = std::clamp(lateral_offset, -max_shift_length, max_shift_length);
+  if (std::abs(shift_length - lateral_offset) > 1e-3) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000,
+      "Lateral offset %.2f m cannot be corrected within %.2f m at a curvature of %.2f 1/m; "
+      "shifting by %.2f m only.",
+      lateral_offset, L, shift_params.curvature_limit, shift_length);
+  }
+
+  // y(s) is a Frenet lateral offset from the reference line, so y''(0) must be the ego curvature
+  // *relative* to the reference: the generated curvature is roughly kappa_ref + y''. Passing the
+  // absolute ego curvature would start the section at ~2*kappa_ref and fall back to kappa_ref at
+  // s=L, i.e. a curvature bump right in front of ego on every cycle (on curves only).
+  const size_t curvature_baseline_step = std::max<size_t>(
+    1, static_cast<size_t>(std::lround(curvature_baseline_length / delta_arc_length)));
+  const double kappa_ref =
+    reference_curvature(trajectory.points, nearest_idx, curvature_baseline_step);
+  // Below min_speed_for_curvature the measured curvature yaw_rate / v is unusable (the clamped
+  // speed underestimates it, and both terms vanish as the vehicle stops), so fade the whole
+  // relative term out: the connection then assumes ego is on the reference curvature, which keeps
+  // the curvature continuous at low speed. Fading the measured term alone would instead leave
+  // -kappa_ref, i.e. a section that starts straight in the middle of a curve.
+  const double curvature_confidence =
+    std::clamp(ego_velocity / shift_params.min_speed_for_curvature, 0.0, 1.0);
+  const double kappa0 = curvature_confidence * (ego_yaw_rate / clamped_velocity - kappa_ref);
+  const auto coeffs = compute_quintic_shift_coeffs(shift_length, signed_yaw_dev, kappa0, L);
 
   const double ref_velocity = trajectory.points.at(nearest_idx).longitudinal_velocity_mps;
   std::vector<TrajectoryPoint> shifted_points;
 
-  TrajectoryPoint ego_pt;
-  ego_pt.pose = ego_pose;
-  ego_pt.longitudinal_velocity_mps = ref_velocity;
-  shifted_points.push_back(ego_pt);
+  TrajectoryPoint start_pt;
+  start_pt.pose = ego_pose;
+  // Identical to the ego pose unless the correction was capped above; then the section starts at
+  // the capped offset and the rest stays a lateral error.
+  const double uncorrected_offset = shift_length - lateral_offset;
+  start_pt.pose.position.x += uncorrected_offset * (-std::sin(traj_yaw));
+  start_pt.pose.position.y += uncorrected_offset * std::cos(traj_yaw);
+  start_pt.longitudinal_velocity_mps = ref_velocity;
+  shifted_points.push_back(start_pt);
 
   for (double s = delta_arc_length; s < L; s += delta_arc_length) {
     const double y_s = evaluate_quintic(coeffs, s);

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1802,11 +1802,22 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
   const double traj_yaw = tf2::getYaw(trajectory.points.at(nearest_idx).pose.orientation);
   const double signed_yaw_dev = autoware_utils::normalize_radian(ego_yaw - traj_yaw);
 
+  if (nearest_idx + 1 == trajectory.points.size()) {
+    // Goal overshoot: no reference ahead of ego to shape a shift section against, and splicing the
+    // ego pose onto the point behind it would emit a backwards segment.
+    return trajectory;
+  }
+
   const double clamped_velocity =
     std::max(std::max(0.0, ego_velocity), shift_params.min_speed_for_curvature);
   const double abs_d = std::abs(lateral_offset);
-  double L = compute_shift_length_from_lateral_accel(
-    abs_d, clamped_velocity, shift_params.lateral_accel_limit, shift_params.minimum_shift_distance);
+  // The section must start exactly at ego, so the offset is never capped: instead the section is
+  // stretched until its peak curvature quintic_kappa_coeff*|d|/L^2 fits within curvature_limit.
+  double L = std::max(
+    compute_shift_length_from_lateral_accel(
+      abs_d, clamped_velocity, shift_params.lateral_accel_limit,
+      shift_params.minimum_shift_distance),
+    std::sqrt(quintic_kappa_coeff * abs_d / shift_params.curvature_limit));
 
   double accumulated_length = 0.0;
   size_t merge_idx = nearest_idx;
@@ -1819,18 +1830,11 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
     }
   }
   if (merge_idx >= trajectory.points.size() - 1) {
-    // Ends before the desired merge point (goal approach); the cap below keeps the short L usable.
+    // Ends before the desired merge point (goal approach). The section is squeezed into what is
+    // left and exceeds curvature_limit; starting at ego wins over the curvature budget here.
     L = accumulated_length;
     merge_idx = trajectory.points.size() - 1;
   }
-  if (L < delta_arc_length) {
-    return trajectory;
-  }
-
-  // Peak curvature of the shift is quintic_kappa_coeff*|d|/L^2, so a short L bounds the offset that
-  // can be corrected. The remainder is deliberately left as a lateral error for the controller.
-  const double max_shift_length = shift_params.curvature_limit * L * L / quintic_kappa_coeff;
-  const double shift_length = std::clamp(lateral_offset, -max_shift_length, max_shift_length);
 
   // y is a Frenet offset, so y''(0) must be the ego curvature *relative* to the reference. Passing
   // the absolute value starts the section at ~2*kappa_ref, i.e. a curvature bump on every cycle.
@@ -1843,17 +1847,13 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
   const double curvature_confidence =
     std::clamp(ego_velocity / shift_params.min_speed_for_curvature, 0.0, 1.0);
   const double kappa0 = curvature_confidence * (ego_yaw_rate / clamped_velocity - kappa_ref);
-  const auto coeffs = compute_quintic_shift_coeffs(shift_length, signed_yaw_dev, kappa0, L);
+  const auto coeffs = compute_quintic_shift_coeffs(lateral_offset, signed_yaw_dev, kappa0, L);
 
   const double ref_velocity = trajectory.points.at(nearest_idx).longitudinal_velocity_mps;
   std::vector<TrajectoryPoint> shifted_points;
 
   TrajectoryPoint start_pt;
   start_pt.pose = ego_pose;
-  // Zero unless the cap dropped part of the correction, which then stays a lateral error.
-  const double uncorrected_offset = shift_length - lateral_offset;
-  start_pt.pose.position.x += uncorrected_offset * (-std::sin(traj_yaw));
-  start_pt.pose.position.y += uncorrected_offset * std::cos(traj_yaw);
   start_pt.longitudinal_velocity_mps = ref_velocity;
   shifted_points.push_back(start_pt);
 

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1008,8 +1008,8 @@ constexpr double quintic_kappa_coeff = 5.773502691896258;  // 10*sqrt(3)/3
 constexpr double yaw_diff_clamp_rad = M_PI / 4.0;
 constexpr double lane_end_match_tolerance_sq = 4.0;  // [m^2] 2m tolerance squared
 constexpr double yaw_step = 0.1;  // [m] finite-difference step for centerline yaw
-// [m] half-baseline of the reference curvature estimate at the shift start. Long enough that the
-// 3-point estimate is not dominated by the point-to-point noise of the resampled centerline.
+// [m] half-baseline of the 3-point reference curvature estimate. Shorter baselines are dominated by
+// the point-to-point noise of the resampled centerline.
 constexpr double curvature_baseline_length = 2.0;
 
 struct QuinticShiftCoeffs
@@ -1080,7 +1080,6 @@ double signed_curvature_3pt(
   return 2.0 * cross / denom;
 }
 
-// Curvature of the reference line at index idx, estimated from 3 points spaced baseline_step apart.
 double reference_curvature(
   const std::vector<TrajectoryPoint> & points, const size_t idx, const size_t baseline_step)
 {
@@ -1820,45 +1819,27 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
     }
   }
   if (merge_idx >= trajectory.points.size() - 1) {
-    // The trajectory ends before the desired merge point (goal approach, stop point, or ego at the
-    // very end): merge at the last point so the terminal conditions still land on it. The lateral
-    // correction is capped below to keep the curvature of the shortened section feasible.
+    // Ends before the desired merge point (goal approach); the cap below keeps the short L usable.
     L = accumulated_length;
     merge_idx = trajectory.points.size() - 1;
   }
   if (L < delta_arc_length) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 5000, "Only %.2f m of trajectory ahead of ego; skipping the shift to ego.",
-      L);
     return trajectory;
   }
 
-  // The peak curvature of the shift is quintic_kappa_coeff*|d|/L^2, so the offset that can be
-  // corrected within L is bounded by the curvature budget. Correcting the rest would emit a path
-  // the vehicle cannot steer; it is left as a lateral error for the controller instead.
+  // Peak curvature of the shift is quintic_kappa_coeff*|d|/L^2, so a short L bounds the offset that
+  // can be corrected. The remainder is deliberately left as a lateral error for the controller.
   const double max_shift_length = shift_params.curvature_limit * L * L / quintic_kappa_coeff;
   const double shift_length = std::clamp(lateral_offset, -max_shift_length, max_shift_length);
-  if (std::abs(shift_length - lateral_offset) > 1e-3) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 5000,
-      "Lateral offset %.2f m cannot be corrected within %.2f m at a curvature of %.2f 1/m; "
-      "shifting by %.2f m only.",
-      lateral_offset, L, shift_params.curvature_limit, shift_length);
-  }
 
-  // y(s) is a Frenet lateral offset from the reference line, so y''(0) must be the ego curvature
-  // *relative* to the reference: the generated curvature is roughly kappa_ref + y''. Passing the
-  // absolute ego curvature would start the section at ~2*kappa_ref and fall back to kappa_ref at
-  // s=L, i.e. a curvature bump right in front of ego on every cycle (on curves only).
+  // y is a Frenet offset, so y''(0) must be the ego curvature *relative* to the reference. Passing
+  // the absolute value starts the section at ~2*kappa_ref, i.e. a curvature bump on every cycle.
   const size_t curvature_baseline_step = std::max<size_t>(
     1, static_cast<size_t>(std::lround(curvature_baseline_length / delta_arc_length)));
   const double kappa_ref =
     reference_curvature(trajectory.points, nearest_idx, curvature_baseline_step);
-  // Below min_speed_for_curvature the measured curvature yaw_rate / v is unusable (the clamped
-  // speed underestimates it, and both terms vanish as the vehicle stops), so fade the whole
-  // relative term out: the connection then assumes ego is on the reference curvature, which keeps
-  // the curvature continuous at low speed. Fading the measured term alone would instead leave
-  // -kappa_ref, i.e. a section that starts straight in the middle of a curve.
+  // yaw_rate/v is unusable below min_speed_for_curvature, so fade the whole relative term out.
+  // Fading only the measured term would leave -kappa_ref: a straight start in the middle of a bend.
   const double curvature_confidence =
     std::clamp(ego_velocity / shift_params.min_speed_for_curvature, 0.0, 1.0);
   const double kappa0 = curvature_confidence * (ego_yaw_rate / clamped_velocity - kappa_ref);
@@ -1869,8 +1850,7 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
 
   TrajectoryPoint start_pt;
   start_pt.pose = ego_pose;
-  // Identical to the ego pose unless the correction was capped above; then the section starts at
-  // the capped offset and the rest stays a lateral error.
+  // Zero unless the cap dropped part of the correction, which then stays a lateral error.
   const double uncorrected_offset = shift_length - lateral_offset;
   start_pt.pose.position.x += uncorrected_offset * (-std::sin(traj_yaw));
   start_pt.pose.position.y += uncorrected_offset * std::cos(traj_yaw);

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -118,7 +118,7 @@ public:
     double ego_velocity, const builtin_interfaces::msg::Time & stamp);
 
   // Trajectory shifting
-  Trajectory shift_trajectory_to_ego(
+  static Trajectory shift_trajectory_to_ego(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose, double ego_velocity,
     double ego_yaw_rate, const TrajectoryShiftParams & shift_params, double delta_arc_length);
 

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -82,6 +82,7 @@ struct TrajectoryShiftParams
   double minimum_shift_distance{5.0};    // [m] floor for shift distance
   double min_speed_for_curvature{2.77};  // [m/s] lower bound on speed for kappa0 computation
   double lateral_accel_limit{0.5};       // [m/s^2] allowed lateral acceleration budget
+  double curvature_limit{0.1};           // [1/m] curvature budget of the shift polynomial
 };
 
 // ---------------------------------------------------------------------------
@@ -117,7 +118,7 @@ public:
     double ego_velocity, const builtin_interfaces::msg::Time & stamp);
 
   // Trajectory shifting
-  static Trajectory shift_trajectory_to_ego(
+  Trajectory shift_trajectory_to_ego(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose, double ego_velocity,
     double ego_yaw_rate, const TrajectoryShiftParams & shift_params, double delta_arc_length);
 

--- a/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
@@ -292,7 +292,7 @@ TEST(PathPlannerTest, ShiftOnCurveAtLowSpeedKeepsReferenceCurvature)
   }
 }
 
-TEST(PathPlannerTest, ShiftCapsCorrectionWhenTrajectoryIsShort)
+TEST(PathPlannerTest, ShiftStartsAtEgoWhenTrajectoryIsShort)
 {
   auto logger = rclcpp::get_logger("test_path_planner");
   auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
@@ -317,9 +317,11 @@ TEST(PathPlannerTest, ShiftCapsCorrectionWhenTrajectoryIsShort)
   const auto result =
     planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, spacing);
 
-  // Only curvature_limit * L^2 / quintic_kappa_coeff = 0.1 * 3^2 / 5.7735 of the offset fits.
+  // The section is squeezed into the remaining 3 m and exceeds curvature_limit, but still starts
+  // at ego with the whole offset.
   ASSERT_GE(result.points.size(), 2u);
-  EXPECT_NEAR(result.points.front().pose.position.y, 0.156, 1e-3);
+  EXPECT_NEAR(result.points.front().pose.position.x, ego_pose.position.x, 1e-3);
+  EXPECT_NEAR(result.points.front().pose.position.y, ego_pose.position.y, 1e-3);
 
   // The merge point is the last trajectory point, so the arc length must stay monotonic.
   for (size_t i = 0; i + 1 < result.points.size(); ++i) {
@@ -359,6 +361,84 @@ TEST(PathPlannerTest, ShiftSkippedWhenEgoIsAtTrajectoryEnd)
     EXPECT_NEAR(result.points.at(i).pose.position.x, traj.points.at(i).pose.position.x, 1e-6);
     EXPECT_NEAR(result.points.at(i).pose.position.y, traj.points.at(i).pose.position.y, 1e-6);
   }
+}
+
+TEST(PathPlannerTest, ShiftStretchesSectionToRespectCurvatureLimit)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  constexpr double spacing = 0.5;
+  auto traj = make_straight_trajectory(80, spacing, 2.0f);
+  auto ego_pose = make_pose(0.0, 1.0, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+  // Tight enough that the curvature bound, not the lateral acceleration bound, sets the length.
+  shift_params.curvature_limit = 0.02;
+
+  const auto result =
+    planner.shift_trajectory_to_ego(traj, ego_pose, 0.0, 0.0, shift_params, spacing);
+
+  ASSERT_GE(result.points.size(), 3u);
+  EXPECT_NEAR(result.points.front().pose.position.y, ego_pose.position.y, 1e-3);
+
+  for (size_t i = 0; i + 2 < result.points.size(); ++i) {
+    const auto & p0 = result.points.at(i).pose.position;
+    const auto & p1 = result.points.at(i + 1).pose.position;
+    const auto & p2 = result.points.at(i + 2).pose.position;
+    const double cross = (p1.x - p0.x) * (p2.y - p1.y) - (p1.y - p0.y) * (p2.x - p1.x);
+    const double denom = std::hypot(p1.x - p0.x, p1.y - p0.y) *
+                         std::hypot(p2.x - p1.x, p2.y - p1.y) *
+                         std::hypot(p2.x - p0.x, p2.y - p0.y);
+    ASSERT_GT(denom, 1e-9);
+    EXPECT_LE(std::abs(2.0 * cross / denom), shift_params.curvature_limit * 1.05);
+  }
+}
+
+TEST(PathPlannerTest, ShiftStartsAtEgoWhenRemainingLengthIsBelowOneSample)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  // The last interval is a 0.2 m remainder, i.e. shorter than one output sample.
+  constexpr double spacing = 0.5;
+  Trajectory traj;
+  traj.header.frame_id = "map";
+  for (const double x : {0.0, 0.5, 1.0, 1.2}) {
+    traj.points.push_back(make_traj_point(x, 0.0, 10.0f));
+  }
+  auto ego_pose = make_pose(1.0, 0.3, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+  shift_params.curvature_limit = 0.1;
+
+  const auto result =
+    planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, spacing);
+
+  // The shift section degenerates to the ego pose spliced onto the last point, offset and all.
+  ASSERT_EQ(result.points.size(), 2u);
+  EXPECT_NEAR(result.points.front().pose.position.x, ego_pose.position.x, 1e-3);
+  EXPECT_NEAR(result.points.front().pose.position.y, ego_pose.position.y, 1e-3);
+  EXPECT_NEAR(result.points.back().pose.position.x, traj.points.back().pose.position.x, 1e-3);
+  EXPECT_NEAR(result.points.back().pose.position.y, traj.points.back().pose.position.y, 1e-3);
 }
 
 // ============================================================

--- a/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
@@ -75,6 +75,21 @@ Trajectory make_straight_trajectory(size_t num_points, double spacing, float vel
   return traj;
 }
 
+// Constant-curvature left-turn trajectory starting at the origin with heading +x.
+Trajectory make_arc_trajectory(size_t num_points, double spacing, double radius, float velocity)
+{
+  Trajectory traj;
+  traj.header.frame_id = "map";
+  for (size_t i = 0; i < num_points; ++i) {
+    const double theta = spacing * static_cast<double>(i) / radius;
+    auto pt = make_traj_point(radius * std::sin(theta), radius * (1.0 - std::cos(theta)), velocity);
+    pt.pose.orientation.z = std::sin(theta / 2.0);
+    pt.pose.orientation.w = std::cos(theta / 2.0);
+    traj.points.push_back(pt);
+  }
+  return traj;
+}
+
 geometry_msgs::msg::Pose make_pose(double x, double y, double yaw = 0.0)
 {
   geometry_msgs::msg::Pose pose;
@@ -205,6 +220,145 @@ TEST(PathPlannerTest, ShiftNormal)
   const auto & last_result = result.points.back();
   EXPECT_NEAR(last_result.pose.position.x, last_orig.pose.position.x, 1e-3);
   EXPECT_NEAR(last_result.pose.position.y, last_orig.pose.position.y, 1e-3);
+}
+
+TEST(PathPlannerTest, ShiftOnCurveKeepsReferenceCurvature)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  constexpr double radius = 10.0;
+  constexpr double spacing = 0.5;
+  constexpr double ego_velocity = 10.0;
+  auto traj = make_arc_trajectory(60, spacing, radius, static_cast<float>(ego_velocity));
+
+  // Ego is exactly on the reference and turning with it, so the relative curvature is zero and the
+  // shift section must stay on the reference arc.
+  const auto ego_pose = traj.points.front().pose;
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+
+  const auto result = planner.shift_trajectory_to_ego(
+    traj, ego_pose, ego_velocity, ego_velocity / radius, shift_params, spacing);
+
+  ASSERT_FALSE(result.points.empty());
+  for (const auto & pt : result.points) {
+    const double distance_to_center = std::hypot(pt.pose.position.x, pt.pose.position.y - radius);
+    EXPECT_NEAR(distance_to_center, radius, 1.5e-2);
+  }
+}
+
+TEST(PathPlannerTest, ShiftOnCurveAtLowSpeedKeepsReferenceCurvature)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  constexpr double radius = 10.0;
+  constexpr double spacing = 0.5;
+  // Creeping speed: yaw_rate / max(v, min_speed_for_curvature) underestimates the ego curvature by
+  // more than an order of magnitude, so the relative curvature must be faded out instead of used.
+  constexpr double ego_velocity = 0.2;
+  auto traj = make_arc_trajectory(60, spacing, radius, static_cast<float>(ego_velocity));
+
+  const auto ego_pose = traj.points.front().pose;
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+
+  const auto result = planner.shift_trajectory_to_ego(
+    traj, ego_pose, ego_velocity, ego_velocity / radius, shift_params, spacing);
+
+  ASSERT_FALSE(result.points.empty());
+  for (const auto & pt : result.points) {
+    const double distance_to_center = std::hypot(pt.pose.position.x, pt.pose.position.y - radius);
+    EXPECT_NEAR(distance_to_center, radius, 1.5e-2);
+  }
+}
+
+TEST(PathPlannerTest, ShiftCapsCorrectionWhenTrajectoryIsShort)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  // 3 m of trajectory left (goal approach) against a 24 m shift length request.
+  constexpr double spacing = 0.5;
+  auto traj = make_straight_trajectory(7, spacing, 10.0f);
+  auto ego_pose = make_pose(0.0, 0.5, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+  shift_params.curvature_limit = 0.1;
+
+  const auto result =
+    planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, spacing);
+
+  // Only curvature_limit * L^2 / quintic_kappa_coeff = 0.1 * 3^2 / 5.7735 of the offset fits.
+  ASSERT_GE(result.points.size(), 2u);
+  EXPECT_NEAR(result.points.front().pose.position.y, 0.156, 1e-3);
+
+  // The merge point is the last trajectory point, so the arc length must stay monotonic.
+  for (size_t i = 0; i + 1 < result.points.size(); ++i) {
+    EXPECT_GT(result.points.at(i + 1).pose.position.x, result.points.at(i).pose.position.x);
+  }
+  EXPECT_NEAR(result.points.back().pose.position.x, traj.points.back().pose.position.x, 1e-3);
+  EXPECT_NEAR(result.points.back().pose.position.y, traj.points.back().pose.position.y, 1e-3);
+}
+
+TEST(PathPlannerTest, ShiftSkippedWhenEgoIsAtTrajectoryEnd)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  constexpr double spacing = 0.5;
+  auto traj = make_straight_trajectory(5, spacing, 10.0f);
+  // Ego is at the last point: there is no room left to shape a shift section.
+  auto ego_pose = make_pose(2.0, 0.1, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+  shift_params.curvature_limit = 0.1;
+
+  const auto result =
+    planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, spacing);
+
+  ASSERT_EQ(result.points.size(), traj.points.size());
+  for (size_t i = 0; i < result.points.size(); ++i) {
+    EXPECT_NEAR(result.points.at(i).pose.position.x, traj.points.at(i).pose.position.x, 1e-6);
+    EXPECT_NEAR(result.points.at(i).pose.position.y, traj.points.at(i).pose.position.y, 1e-6);
+  }
 }
 
 // ============================================================


### PR DESCRIPTION
## Description

`shift_trajectory_to_ego()` connects the planned trajectory to the current ego pose with a quintic
lateral-offset polynomial `y(s)`, solved from `y(0) = d, y'(0) = q, y''(0) = kappa0` and
`y(L) = y'(L) = y''(L) = 0`. This PR fixes three defects in how that connection is set up.

### 1. `y''(0)` was given the absolute ego curvature instead of the curvature relative to the reference

`y(s)` is a Frenet lateral offset from the reference line, so the emitted absolute curvature is
approximately `kappa_ref + y''`. The old code passed `kappa0 = ego_yaw_rate / v`, which is the
*absolute* ego curvature.

When ego tracks the reference exactly on a curve (`d = q = 0`, `ego_yaw_rate / v = kappa_ref`), this
collapses to

```
y(s) = (kappa_ref / 2) * s^2 * (1 - s/L)^3
```

i.e. the connection section starts at `2 * kappa_ref` at ego, dips to about `0.64 * kappa_ref`
around `s = 0.4 L`, and only returns to `kappa_ref` at the merge point. The trajectory bulges toward
the inside of the turn and the curvature right in front of the vehicle is off by 100%, on every
planning cycle, for as long as ego is on a curve. Since this is the feedforward term the lateral
controller acts on first, the error is more significant than the lateral bulge itself.

Fixed by subtracting the reference curvature at the shift start:
`kappa0 = ego_yaw_rate / v - kappa_ref`. `kappa_ref` is estimated with the existing
`signed_curvature_3pt()` over a +/- 2 m baseline, which is long enough not to be dominated by the
point-to-point noise of the resampled centerline.

### 2. The relative curvature is now faded out at low speed

`ego_yaw_rate / v` is unusable below `min_speed_for_curvature`: the denominator is clamped to that
floor, so the measured curvature is underestimated by more than an order of magnitude (at 0.2 m/s on
a 10 m radius the estimate is off by ~14x), and both terms vanish as the vehicle stops.

The whole relative term is therefore scaled by
`clamp(v / min_speed_for_curvature, 0, 1)`, so at creeping speed the connection assumes ego sits on
the reference curvature and the curvature stays continuous. Fading only the measured term would
leave `-kappa_ref`, which is worse: the section would start straight in the middle of a bend.

### 3. Near the goal the terminal boundary conditions landed on the wrong point

When the trajectory ended before the requested shift length, the old code set
`L = accumulated_length` (the arc length up to the **last** point) but `merge_idx = size() - 2`.
The polynomial therefore reached `y = 0` at the last point while the untouched tail was appended
from the second-to-last point, so the output stepped backwards at the end and the arc length was no
longer monotonic.

Two changes:

- `merge_idx = size() - 1`, so the terminal conditions land on the point the tail actually starts
  from.
- The lateral correction is capped so that the shortened `L` stays geometrically usable. The peak
  curvature of the offset term is `10*sqrt(3)/3 * |d| / L^2`, so the correctable offset is bounded
  by `curvature_limit * L^2 / (10*sqrt(3)/3)`. Whatever does not fit is deliberately left as a
  lateral error for the controller rather than emitted as a path the vehicle cannot steer.
- If less than one output point remains ahead of ego (`L < delta_arc_length`), the trajectory is
  returned unchanged instead of shifted.

### 4. Warning spam removed

The `RCLCPP_WARN` on the short-trajectory path fired every cycle on goal approach, and its message
("terminal boundary conditions cannot be satisfied") no longer describes what the code does. The
short-trajectory and capped-correction paths are both normal operating conditions now, so they are
handled silently.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- psim
- colcon test

| Test | Covers |
|:--|:--|
| `ShiftOnCurveKeepsReferenceCurvature` | Ego on a 10 m radius arc at 10 m/s: every output point stays on the reference arc within 1.5 cm. Fails before fix 1. |
| `ShiftOnCurveAtLowSpeedKeepsReferenceCurvature` | Same arc at 0.2 m/s, where `yaw_rate / v` is unusable. Fails before fix 2. |
| `ShiftCapsCorrectionWhenTrajectoryIsShort` | 3 m of trajectory against a 24 m shift request: the correction is capped at `0.1 * 3^2 / 5.7735 = 0.156 m`, the arc length stays monotonic, and the last point matches the input. Fails before fix 3. |
| `ShiftSkippedWhenEgoIsAtTrajectoryEnd` | Ego at the last trajectory point: the input is returned unchanged. |


## Notes for reviewers

`min_speed_for_curvature` is now used for two things: the floor on the denominator of
`ego_yaw_rate / v`, and the denominator of the low-speed fade. Reusing one threshold seemed
reasonable, but splitting it into a separate parameter is easy if reviewers prefer that.

`curvature_limit` only binds when `L` could not be made long enough. During normal driving
`L = v * sqrt(10*sqrt(3)/3 * |d| / lateral_accel_limit)` already implies a peak curvature of
`lateral_accel_limit / v^2` (0.01 1/m at 10 m/s with the default 1.0 m/s^2), far below the 0.1
default. It takes effect when `L` is floored by `minimum_shift_distance` (low speed, cap 0.43 m) or
truncated by the end of the trajectory. So `lateral_accel_limit` governs comfort at speed and
`curvature_limit` governs geometric feasibility when the available length is short; the two do not
compete.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Added | `path_planning.path_shift.curvature_limit` | `double` | `0.1` | Upper bound [1/m] on the peak curvature of the shift polynomial. Caps the corrected lateral offset at `curvature_limit * L^2 / (10*sqrt(3)/3)`, where `L` is the available shift length. `0.1` corresponds to a 10 m radius. |

## Effects on system behavior

- On curves, the connection section no longer emits roughly twice the reference curvature at ego, so
  the lateral controller's feedforward sees the intended curvature. This changes the published
  trajectory on every cycle where ego is on a curve.
- Below `min_speed_for_curvature` the connection ignores the measured yaw rate and assumes ego is on
  the reference curvature.
- On goal approach the output no longer steps backwards at the last point, and a lateral offset that
  does not fit in the remaining length is only partially corrected (the remainder stays a lateral
  error for the controller).
- The per-cycle `RCLCPP_WARN` on goal approach is gone.
