### PR TITLE
feat(control_validator): improve roll back detection logic

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -164,10 +164,20 @@ void VelocityValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
 
-  const bool is_stopped = std::abs(v_vel) < 0.05;
+  const auto stopped_vel_th = 5e-2;
+  const auto is_stopped = std::abs(v_vel) < stopped_vel_th;
 
-  const bool is_rolling_back =
-    std::signbit(v_vel * t_vel) && std::abs(v_vel) > params_.rolling_back_velocity;
+  const auto is_rolling_back = [&]() -> bool {
+    if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
+      return false;
+    }
+
+    if (std::abs(t_vel) < stopped_vel_th) {
+      return std::signbit(v_vel);
+    }
+    return std::signbit(v_vel * t_vel);
+  }();
+
   if (!params_.hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
     res.is_rolling_back = is_rolling_back;
   }

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -167,19 +167,17 @@ void VelocityValidator::validate(
   const auto stopped_vel_th = 5e-2;
   const auto is_stopped = std::abs(v_vel) < stopped_vel_th;
 
-  const auto is_rolling_back = [&]() -> bool {
-    if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
-      return false;
-    }
-
-    if (std::abs(t_vel) < stopped_vel_th) {
-      return std::signbit(v_vel);
-    }
-    return std::signbit(v_vel * t_vel);
-  }();
-
   if (!params_.hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
-    res.is_rolling_back = is_rolling_back;
+    res.is_rolling_back = [&]() -> bool {
+      if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
+        return false;
+      }
+  
+      if (std::abs(t_vel) < stopped_vel_th) {
+        return std::signbit(v_vel);
+      }
+      return std::signbit(v_vel * t_vel);
+    }();
   }
 
   const double over_velocity_v_vel =

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -166,10 +166,20 @@ void VelocityValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
 
-  const bool is_stopped = std::abs(v_vel) < 0.05;
+  const auto stopped_vel_th = 5e-2;
+  const auto is_stopped = std::abs(v_vel) < stopped_vel_th;
 
-  const bool is_rolling_back =
-    std::signbit(v_vel * t_vel) && std::abs(v_vel) > params_.rolling_back_velocity;
+  const auto is_rolling_back = [&]() -> bool {
+    if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
+      return false;
+    }
+
+    if (std::abs(t_vel) < stopped_vel_th) {
+      return std::signbit(v_vel);
+    }
+    return std::signbit(v_vel * t_vel);
+  }();
+
   if (!params_.hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
     res.is_rolling_back = is_rolling_back;
   }

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -169,19 +169,17 @@ void VelocityValidator::validate(
   const auto stopped_vel_th = 5e-2;
   const auto is_stopped = std::abs(v_vel) < stopped_vel_th;
 
-  const auto is_rolling_back = [&]() -> bool {
-    if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
-      return false;
-    }
-
-    if (std::abs(t_vel) < stopped_vel_th) {
-      return std::signbit(v_vel);
-    }
-    return std::signbit(v_vel * t_vel);
-  }();
-
   if (!params_.hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
-    res.is_rolling_back = is_rolling_back;
+    res.is_rolling_back = [&]() -> bool {
+      if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
+        return false;
+      }
+  
+      if (std::abs(t_vel) < stopped_vel_th) {
+        return std::signbit(v_vel);
+      }
+      return std::signbit(v_vel * t_vel);
+    }();
   }
 
   const double over_velocity_v_vel =

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -19,6 +19,7 @@
 #include <tf2/LinearMath/Quaternion.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <gtest/gtest-param-test.h>
@@ -30,6 +31,7 @@
 
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using nav_msgs::msg::Odometry;
 
 Trajectory make_linear_trajectory(
   const TrajectoryPoint & start, const TrajectoryPoint & end, size_t num_points, double velocity)
@@ -71,6 +73,14 @@ TrajectoryPoint make_trajectory_point(double x, double y)
   point.pose.position.x = x;
   point.pose.position.y = y;
   return point;
+}
+
+Odometry make_odometry(double longitudinal_velocity)
+{
+  Odometry odometry;
+  odometry.pose.pose.orientation.w = 1.0;
+  odometry.twist.twist.linear.x = longitudinal_velocity;
+  return odometry;
 }
 
 namespace autoware::control_validator
@@ -230,5 +240,73 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(false, 1.0, 5.0), std::make_tuple(false, 1.0, -5.0),
     std::make_tuple(true, -1.0, -1.0), std::make_tuple(false, -1.0, -5.0),
     std::make_tuple(false, -1.0, 5.0)));
+
+class VelocityValidatorTest
+: public ::testing::TestWithParam<std::tuple<double, double, bool, bool>>
+{
+public:
+  void validate(
+    ControlValidatorStatus & res, const Trajectory & reference_trajectory,
+    const Odometry & kinematics)
+  {
+    velocity_validator_->validate(res, reference_trajectory, kinematics);
+  }
+
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    rclcpp::NodeOptions options;
+    options.arguments(
+      {"--ros-args", "--params-file",
+       ament_index_cpp::get_package_share_directory("autoware_control_validator") +
+         "/config/control_validator.param.yaml",
+       "--params-file",
+       ament_index_cpp::get_package_share_directory("autoware_test_utils") +
+         "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<ControlValidator>(options);
+    ::control_validator::ParamListener param_listener(node_->get_node_parameters_interface());
+    velocity_validator_ = std::make_shared<VelocityValidator>(param_listener.get_params());
+  }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<VelocityValidator> velocity_validator_;
+};
+
+TEST_P(VelocityValidatorTest, test_velocity_validation)
+{
+  const auto [target_vel, vehicle_vel, expected_is_rolling_back, expected_is_over_velocity] =
+    GetParam();
+
+  const auto reference_trajectory = make_linear_trajectory(
+    make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, target_vel);
+  const auto kinematics = make_odometry(vehicle_vel);
+
+  ControlValidatorStatus res;
+  res.is_rolling_back = false;
+  res.is_over_velocity = false;
+  validate(res, reference_trajectory, kinematics);
+
+  EXPECT_EQ(res.is_rolling_back, expected_is_rolling_back);
+  EXPECT_EQ(res.is_over_velocity, expected_is_over_velocity);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  VelocityValidatorTests, VelocityValidatorTest,
+  ::testing::Values(
+    // 1. non-zero target velocity with no rollback (same sign)
+    std::make_tuple(1.0, 1.0, false, false),
+    // 2. zero target velocity with no rollback (forward motion while stopped target)
+    std::make_tuple(0.0, 1.0, false, false),
+    // 3. non-zero target velocity with rollback (opposite signs)
+    std::make_tuple(1.0, -1.0, true, false),
+    // 4. zero target velocity with rollback (backward motion while stopped target)
+    std::make_tuple(0.0, -1.0, true, false),
+    // over velocity: vehicle much faster than target
+    std::make_tuple(1.0, 5.0, false, true),
+    // reverse driving with matching signs is not rollback
+    std::make_tuple(-1.0, -1.0, false, false)));
 
 }  // namespace autoware::control_validator

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -35,6 +35,7 @@
 
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using nav_msgs::msg::Odometry;
 
 Trajectory make_linear_trajectory(
   const TrajectoryPoint & start, const TrajectoryPoint & end, size_t num_points, double velocity)
@@ -76,6 +77,14 @@ TrajectoryPoint make_trajectory_point(double x, double y)
   point.pose.position.x = x;
   point.pose.position.y = y;
   return point;
+}
+
+Odometry make_odometry(double longitudinal_velocity)
+{
+  Odometry odometry;
+  odometry.pose.pose.orientation.w = 1.0;
+  odometry.twist.twist.linear.x = longitudinal_velocity;
+  return odometry;
 }
 
 namespace autoware::control_validator
@@ -382,5 +391,73 @@ TEST_F(UncrossableBoundDepartureValidatorTest, InvalidWhenTrajectoryDepartsBound
   EXPECT_FALSE(res.will_cross_uncrossable_bound);
   EXPECT_FALSE(markers.markers.empty());
 }
+
+class VelocityValidatorTest
+: public ::testing::TestWithParam<std::tuple<double, double, bool, bool>>
+{
+public:
+  void validate(
+    ControlValidatorStatus & res, const Trajectory & reference_trajectory,
+    const Odometry & kinematics)
+  {
+    velocity_validator_->validate(res, reference_trajectory, kinematics);
+  }
+
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    rclcpp::NodeOptions options;
+    options.arguments(
+      {"--ros-args", "--params-file",
+       ament_index_cpp::get_package_share_directory("autoware_control_validator") +
+         "/config/control_validator.param.yaml",
+       "--params-file",
+       ament_index_cpp::get_package_share_directory("autoware_test_utils") +
+         "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<ControlValidator>(options);
+    ::control_validator::ParamListener param_listener(node_->get_node_parameters_interface());
+    velocity_validator_ = std::make_shared<VelocityValidator>(param_listener.get_params());
+  }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<VelocityValidator> velocity_validator_;
+};
+
+TEST_P(VelocityValidatorTest, test_velocity_validation)
+{
+  const auto [target_vel, vehicle_vel, expected_is_rolling_back, expected_is_over_velocity] =
+    GetParam();
+
+  const auto reference_trajectory = make_linear_trajectory(
+    make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, target_vel);
+  const auto kinematics = make_odometry(vehicle_vel);
+
+  ControlValidatorStatus res;
+  res.is_rolling_back = false;
+  res.is_over_velocity = false;
+  validate(res, reference_trajectory, kinematics);
+
+  EXPECT_EQ(res.is_rolling_back, expected_is_rolling_back);
+  EXPECT_EQ(res.is_over_velocity, expected_is_over_velocity);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  VelocityValidatorTests, VelocityValidatorTest,
+  ::testing::Values(
+    // 1. non-zero target velocity with no rollback (same sign)
+    std::make_tuple(1.0, 1.0, false, false),
+    // 2. zero target velocity with no rollback (forward motion while stopped target)
+    std::make_tuple(0.0, 1.0, false, false),
+    // 3. non-zero target velocity with rollback (opposite signs)
+    std::make_tuple(1.0, -1.0, true, false),
+    // 4. zero target velocity with rollback (backward motion while stopped target)
+    std::make_tuple(0.0, -1.0, true, false),
+    // over velocity: vehicle much faster than target
+    std::make_tuple(1.0, 5.0, false, true),
+    // reverse driving with matching signs is not rollback
+    std::make_tuple(-1.0, -1.0, false, false)));
 
 }  // namespace autoware::control_validator


### PR DESCRIPTION
## Description
- Fix rollback detection in `VelocityValidator` so near-zero target velocity is handled correctly. Previously `signbit(v_vel * t_vel)` failed when **t_vel** ≈ 0, so rollback while holding a stop was often missed.
- When `|t_vel|` is below the stop threshold, treat stop intent explicitly and flag rollback only for backward vehicle motion above `rolling_back_velocity`; otherwise keep the opposite-sign check.
- Add unit tests for `VelocityValidator` covering the main rollback cases (zero/non-zero target, with/without rollback), plus over-velocity and reverse-drive sanity cases.

## How was this PR tested?
- `colcon build --packages-select autoware_control_validator --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon test --packages-select autoware_control_validator`