### PR TITLE
feat(traffic_light_compliance_checker): improve compliance checker handling of turn signal

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
+++ b/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
@@ -7,11 +7,17 @@ autoware_package()
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_compliance_checker.cpp
   src/traffic_light_status_tracker.cpp
+  src/utils.cpp
 )
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_ros REQUIRED)
+  file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME} ${TEST_SOURCES})
+  target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
 ament_auto_package()

--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -87,6 +87,13 @@ To prevent sudden, harsh emergency braking maneuvers caused by raw perception no
 - **Segment-by-Segment Geometric Scan:** The checker evaluates trajectory segments sequentially against mapped stop lines using a localized `boost::geometry::intersection` check. The loop breaks immediately upon finding the first chronological intersection point, calculating the dynamic distance-to-stop-line and interpolating the exact crossing timestamp (for amber light) using `autoware::interpolation::lerp`.
 - **Red Light Evaluation:** Generates a violation if an intersection occurs, unless the trajectory makes the ego come to a complete stop within the specified `stop_overshoot_margin`.
 - **Amber Light Evaluation:** Computes the dynamic stopping distance based on current velocity, acceleration, applied deceleration, and system response latency. If the vehicle can stop safely before the line, or if it cannot clear the intersection within the `crossing_time_limit`, an amber violation is recorded to enforce a stop.
+- **Arrow-aware amber passing:** On protected turn lanes with a separate direction-arrow bulb in the map, the circle signal often goes `GREEN → AMBER → RED` before `GREEN *_ARROW` appears. While the circle is amber after a green circle, requiring a stop would be overly strict. When `enable_arrow_aware_yellow_passing` is true, the checker skips stop-line collection (no amber/red violation) if all of the following hold:
+  - ego route lane is a left or right turn lane (`turn_direction`)
+  - the traffic light has a static arrow in the map (`subtype` containing `arrow`, or light-bulb `arrow` attribute)
+  - the amber phase was reached from a green circle (`YellowState::kFromGreen`)
+  - the current signal still reports an amber circle
+
+  Transitions from red (or unknown) to amber still require a stop. A brief red circle before the green arrow is reported is also still treated as a stop (same scope as the behavior velocity traffic light module).
 
 ## Structs and Interface Definitions
 
@@ -132,5 +139,6 @@ The interfaces pass inputs and output results through the following standard dat
 | `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$).                 |
 | `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.                   |
 | `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.                              |
+| `enable_arrow_aware_yellow_passing`            | `bool`   | If true, allow Green Circle → Amber pass on turn lanes with a mapped static arrow.                         |
 | `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.                    |
 | `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.                            |

--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -87,10 +87,10 @@ To prevent sudden, harsh emergency braking maneuvers caused by raw perception no
 - **Segment-by-Segment Geometric Scan:** The checker evaluates trajectory segments sequentially against mapped stop lines using a localized `boost::geometry::intersection` check. The loop breaks immediately upon finding the first chronological intersection point, calculating the dynamic distance-to-stop-line and interpolating the exact crossing timestamp (for amber light) using `autoware::interpolation::lerp`.
 - **Red Light Evaluation:** Generates a violation if an intersection occurs, unless the trajectory makes the ego come to a complete stop within the specified `stop_overshoot_margin`.
 - **Amber Light Evaluation:** Computes the dynamic stopping distance based on current velocity, acceleration, applied deceleration, and system response latency. If the vehicle can stop safely before the line, or if it cannot clear the intersection within the `crossing_time_limit`, an amber violation is recorded to enforce a stop.
-- **Arrow-aware amber passing:** On protected turn lanes with a separate direction-arrow bulb in the map, the circle signal often goes `GREEN → AMBER → RED` before `GREEN *_ARROW` appears. While the circle is amber after a green circle, requiring a stop would be overly strict. When `enable_arrow_aware_yellow_passing` is true, the checker skips stop-line collection (no amber/red violation) if all of the following hold:
+- **Arrow-aware amber passing:** On protected turn lanes with a separate direction-arrow bulb in the map, the circle signal often goes `GREEN → AMBER → RED` before `GREEN *_ARROW` appears. While the circle is amber after a green circle, requiring a stop would be overly strict. When `enable_arrow_aware_amber_passing` is true, the checker skips stop-line collection (no amber/red violation) if all of the following hold:
   - ego route lane is a left or right turn lane (`turn_direction`)
   - the traffic light has a static arrow in the map (`subtype` containing `arrow`, or light-bulb `arrow` attribute)
-  - the amber phase was reached from a green circle (`YellowState::kFromGreen`)
+  - the amber phase was reached from a green circle (`AmberState::kFromGreen`)
   - the current signal still reports an amber circle
 
   Transitions from red (or unknown) to amber still require a stop. A brief red circle before the green arrow is reported is also still treated as a stop (same scope as the behavior velocity traffic light module).
@@ -139,6 +139,6 @@ The interfaces pass inputs and output results through the following standard dat
 | `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$).                 |
 | `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.                   |
 | `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.                              |
-| `enable_arrow_aware_yellow_passing`            | `bool`   | If true, allow Green Circle → Amber pass on turn lanes with a mapped static arrow.                         |
+| `enable_arrow_aware_amber_passing`             | `bool`   | If true, allow Green Circle → Amber pass on turn lanes with a mapped static arrow.                         |
 | `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.                    |
 | `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.                            |

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -82,6 +82,7 @@ struct Violation
 struct ComplianceResult
 {
   std::vector<Violation> violations;
+  std::vector<int64_t> detected_stop_amber_ids;
 };
 
 /// @brief parameters for traffic light signal status tracking
@@ -104,16 +105,18 @@ struct Parameters
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
   double min_lookahead_distance;
-  double stable_duration_threshold_red;
-  double stable_duration_threshold_amber;
-  double stable_duration_threshold_unknown;
-  double amber_rejection_hysteresis_duration;
   double ego_stopped_velocity_threshold;
+  StatusTrackerParameters status_tracker_parameters;
   struct CheckedTrajectoryLength
   {
     double deceleration_limit;
     double jerk_limit;
   } checked_trajectory_length;
+  struct AmberRejection
+  {
+    double hysteresis_duration;
+    bool reject_if_stop_detected;
+  } amber_rejection;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -85,11 +85,11 @@ struct ComplianceResult
   Violations violations;
 };
 
-/// @brief how the current yellow/amber phase was reached
-enum class YellowState {
-  kNotYellow,     ///< not currently in a yellow/amber state
-  kFromGreen,     ///< yellow reached from green circle;
-  kFromNonGreen,  ///< yellow reached from non-green;
+/// @brief how the current amber phase was reached
+enum class AmberState {
+  kNotAmber,      ///< not currently in an amber state
+  kFromGreen,     ///< amber reached from green circle
+  kFromNonGreen,  ///< amber reached from non-green
 };
 
 /// @brief parameters for traffic light signal status tracking
@@ -109,7 +109,7 @@ struct Parameters
   double crossing_time_limit;
   bool treat_amber_light_as_red_light;
   bool treat_unknown_light_as_red_light;
-  bool enable_arrow_aware_yellow_passing{true};
+  bool enable_arrow_aware_amber_passing{true};
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
   double min_lookahead_distance;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -85,6 +85,13 @@ struct ComplianceResult
   Violations violations;
 };
 
+/// @brief how the current yellow/amber phase was reached
+enum class YellowState {
+  kNotYellow,     ///< not currently in a yellow/amber state
+  kFromGreen,     ///< yellow reached from green circle;
+  kFromNonGreen,  ///< yellow reached from non-green;
+};
+
 /// @brief parameters for traffic light signal status tracking
 struct StatusTrackerParameters
 {
@@ -102,6 +109,7 @@ struct Parameters
   double crossing_time_limit;
   bool treat_amber_light_as_red_light;
   bool treat_unknown_light_as_red_light;
+  bool enable_arrow_aware_yellow_passing{true};
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
   double min_lookahead_distance;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -109,7 +109,7 @@ struct Parameters
   double crossing_time_limit;
   bool treat_amber_light_as_red_light;
   bool treat_unknown_light_as_red_light;
-  bool enable_arrow_aware_amber_passing{true};
+  bool enable_arrow_aware_amber_passing;
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
   double min_lookahead_distance;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -77,12 +77,12 @@ struct Violation
     return arc_length_to_cross_point < other.arc_length_to_cross_point;
   }
 };
+using Violations = std::vector<Violation>;
 
 /// @brief result of compliance check
 struct ComplianceResult
 {
-  std::vector<Violation> violations;
-  std::vector<int64_t> detected_stop_amber_ids;
+  Violations violations;
 };
 
 /// @brief parameters for traffic light signal status tracking

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -70,29 +70,26 @@ private:
   [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
     const rclcpp::Time & current_time, bool is_ego_stopped) const;
 
-  void update_amber_rejection_history(
-    const ComplianceResult & result, const rclcpp::Time & current_time,
-    const std::vector<int64_t> & force_reject_amber_ids);
-
   void cleanup_amber_rejection_history(const rclcpp::Time & current_time);
 
-  [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
+  [[nodiscard]] ComplianceResult check_with_filtered_signals(
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-    const bool check_amber_lights) const;
+    const bool check_amber_lights);
 
-  ComplianceResult get_red_light_violations(
+  Violations get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
     const double distance_offset = 0.0) const;
-  ComplianceResult get_amber_light_violations(
+  Violations get_amber_light_violations(
     const std::vector<StopLineInfo> & amber_stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
-    const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset = 0.0) const;
+    const std::vector<int64_t> & force_reject_amber_ids, const rclcpp::Time & current_time,
+    const double distance_offset = 0.0) const;
 
   /// @brief return the red and amber stop lines related to the given traffic light groups
   [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
@@ -110,10 +107,13 @@ private:
     const double distance_to_stop_line, const double current_velocity,
     const double current_acceleration, const double time_to_cross_stop_line) const;
 
+  bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
+
   Parameters params_;
   vehicle_info_utils::VehicleInfo vehicle_info_;
   std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
-  std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  mutable std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  std::optional<double> ego_stopping_distance_;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -76,7 +76,7 @@ private:
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-    const bool check_amber_lights);
+    const bool check_amber_lights) const;
 
   Violations get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -82,12 +82,12 @@ private:
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
     const bool check_amber_lights) const;
 
-  std::vector<Violation> get_red_light_violations(
+  ComplianceResult get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
     const double distance_offset = 0.0) const;
-  std::vector<Violation> get_amber_light_violations(
+  ComplianceResult get_amber_light_violations(
     const std::vector<StopLineInfo> & amber_stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const lanelet::BasicLineString2d & trajectory_ls,

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -104,8 +104,9 @@ private:
 
   /// @brief return true if ego can safely pass an amber traffic light
   [[nodiscard]] bool can_pass_amber_light(
-    const double distance_to_stop_line, const double current_velocity,
-    const double current_acceleration, const double time_to_cross_stop_line) const;
+    const int64_t traffic_light_id, const double distance_to_stop_line,
+    const double current_velocity, const double current_acceleration,
+    const double time_to_cross_stop_line) const;
 
   bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
 

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -19,10 +19,12 @@
 
 #include <rclcpp/time.hpp>
 
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <cstdint>
 #include <unordered_map>
+#include <vector>
 
 namespace autoware::traffic_light_compliance_checker
 {
@@ -46,6 +48,13 @@ public:
     const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
     const rclcpp::Time & current_time, bool is_ego_stopped);
 
+  /**
+   * @brief return how the current amber phase was reached for a traffic light group
+   * @param traffic_light_group_id traffic light regulatory element / group id
+   * @return yellow transition state; kNotYellow if the id is unknown or not amber
+   */
+  [[nodiscard]] YellowState get_yellow_transition_state(int64_t traffic_light_group_id) const;
+
   [[nodiscard]] double get_duration(const int64_t traffic_light_id) const
   {
     const auto it = signal_history_.find(traffic_light_id);
@@ -54,14 +63,20 @@ public:
   }
 
 private:
-  void cleanup_signal_history(const rclcpp::Time & current_time);
-
   struct SignalStateHistory
   {
     autoware_perception_msgs::msg::TrafficLightGroup msg;
     rclcpp::Time first_seen_time;
     rclcpp::Time last_seen_time;
+    YellowState yellow_transition_state{YellowState::kNotYellow};
   };
+
+  void cleanup_signal_history(const rclcpp::Time & current_time);
+
+  static void update_yellow_transition_state(
+    SignalStateHistory & history,
+    const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & previous_elements,
+    const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & current_elements);
 
   StatusTrackerParameters params_;
   std::unordered_map<int64_t, SignalStateHistory> signal_history_;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -23,6 +23,7 @@
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -42,7 +43,7 @@ public:
    * @param signals raw traffic light signals
    * @param current_time current time stamp
    * @param is_ego_stopped true if ego velocity is below the stopped threshold
-   * @return signals with unstable states cleared
+   * @return signals with stable states (or raw signals if ego is stopped)
    */
   [[nodiscard]] autoware_perception_msgs::msg::TrafficLightGroupArray filter_signals(
     const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
@@ -65,7 +66,8 @@ public:
 private:
   struct SignalStateHistory
   {
-    autoware_perception_msgs::msg::TrafficLightGroup msg;
+    autoware_perception_msgs::msg::TrafficLightGroup current_state;
+    std::optional<autoware_perception_msgs::msg::TrafficLightGroup> stable_state;
     rclcpp::Time first_seen_time;
     rclcpp::Time last_seen_time;
     YellowState yellow_transition_state{YellowState::kNotYellow};
@@ -77,6 +79,9 @@ private:
     SignalStateHistory & history,
     const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & previous_elements,
     const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & current_elements);
+
+  double required_stability_duration(
+    const autoware_perception_msgs::msg::TrafficLightGroup & signal) const;
 
   StatusTrackerParameters params_;
   std::unordered_map<int64_t, SignalStateHistory> signal_history_;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -52,9 +52,9 @@ public:
   /**
    * @brief return how the current amber phase was reached for a traffic light group
    * @param traffic_light_group_id traffic light regulatory element / group id
-   * @return yellow transition state; kNotYellow if the id is unknown or not amber
+   * @return amber transition state; kNotAmber if the id is unknown or not amber
    */
-  [[nodiscard]] YellowState get_yellow_transition_state(int64_t traffic_light_group_id) const;
+  [[nodiscard]] AmberState get_amber_transition_state(int64_t traffic_light_group_id) const;
 
   [[nodiscard]] double get_duration(const int64_t traffic_light_id) const
   {
@@ -70,12 +70,12 @@ private:
     std::optional<autoware_perception_msgs::msg::TrafficLightGroup> stable_state;
     rclcpp::Time first_seen_time;
     rclcpp::Time last_seen_time;
-    YellowState yellow_transition_state{YellowState::kNotYellow};
+    AmberState amber_transition_state{AmberState::kNotAmber};
   };
 
   void cleanup_signal_history(const rclcpp::Time & current_time);
 
-  static void update_yellow_transition_state(
+  static void update_amber_transition_state(
     SignalStateHistory & history,
     const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & previous_elements,
     const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & current_elements);

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -46,6 +46,13 @@ public:
     const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
     const rclcpp::Time & current_time, bool is_ego_stopped);
 
+  [[nodiscard]] double get_duration(const int64_t traffic_light_id) const
+  {
+    const auto it = signal_history_.find(traffic_light_id);
+    if (it == signal_history_.end()) return 0.0;
+    return (it->second.last_seen_time - it->second.first_seen_time).seconds();
+  }
+
 private:
   void cleanup_signal_history(const rclcpp::Time & current_time);
 

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
@@ -1,0 +1,64 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__UTILS_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__UTILS_HPP_
+
+#include "autoware/traffic_light_compliance_checker/structs.hpp"
+
+#include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <memory>
+#include <vector>
+
+namespace autoware::traffic_light_compliance_checker
+{
+
+[[nodiscard]] bool is_equal(
+  const autoware_perception_msgs::msg::TrafficLightElement & a,
+  const autoware_perception_msgs::msg::TrafficLightElement & b);
+
+[[nodiscard]] bool is_equal(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b);
+
+[[nodiscard]] bool has_amber_circle(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements);
+
+[[nodiscard]] bool has_green_circle(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements);
+
+[[nodiscard]] bool has_red_circle(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements);
+
+[[nodiscard]] bool has_unknown(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements);
+
+[[nodiscard]] bool has_static_arrow(
+  const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem);
+
+[[nodiscard]] bool is_arrow_aware_amber_pass(
+  const lanelet::ConstLanelet & lanelet,
+  const autoware_perception_msgs::msg::TrafficLightGroup & signal,
+  const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem,
+  YellowState yellow_transition_state);
+
+}  // namespace autoware::traffic_light_compliance_checker
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__UTILS_HPP_

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__UTILS_HPP_
 
 #include "autoware/traffic_light_compliance_checker/structs.hpp"
-
 #include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 
 #include <autoware_perception_msgs/msg/traffic_light_element.hpp>

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
@@ -56,7 +56,7 @@ namespace autoware::traffic_light_compliance_checker
   const lanelet::ConstLanelet & lanelet,
   const autoware_perception_msgs::msg::TrafficLightGroup & signal,
   const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem,
-  YellowState yellow_transition_state);
+  AmberState amber_transition_state);
 
 }  // namespace autoware::traffic_light_compliance_checker
 

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/utils.hpp
@@ -56,7 +56,7 @@ namespace autoware::traffic_light_compliance_checker
   const lanelet::ConstLanelet & lanelet,
   const autoware_perception_msgs::msg::TrafficLightGroup & signal,
   const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem,
-  AmberState amber_transition_state);
+  const AmberState amber_transition_state);
 
 }  // namespace autoware::traffic_light_compliance_checker
 

--- a/common/autoware_traffic_light_compliance_checker/package.xml
+++ b/common/autoware_traffic_light_compliance_checker/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_interpolation</depend>
+  <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
@@ -24,6 +25,7 @@
   <depend>rclcpp</depend>
   <depend>tl_expected</depend>
 
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -40,9 +40,9 @@
 
 namespace
 {
+using autoware::traffic_light_compliance_checker::AmberState;
 using autoware::traffic_light_compliance_checker::is_arrow_aware_amber_pass;
 using autoware::traffic_light_compliance_checker::StopLineInfo;
-using autoware::traffic_light_compliance_checker::YellowState;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
 /// traffic light groups
@@ -50,8 +50,8 @@ std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightG
 collect_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
   const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups,
-  const bool enable_arrow_aware_yellow_passing,
-  const std::function<YellowState(int64_t)> & get_yellow_transition_state)
+  const bool enable_arrow_aware_amber_passing,
+  const std::function<AmberState(int64_t)> & get_amber_transition_state)
 {
   std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>> stop_lines;
   std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
@@ -78,10 +78,10 @@ collect_stop_lines(
       std::dynamic_pointer_cast<const lanelet::autoware::AutowareTrafficLight>(*traffic_light_it);
 
     if (
-      enable_arrow_aware_yellow_passing &&
+      enable_arrow_aware_amber_passing &&
       is_arrow_aware_amber_pass(
         lanelet, signal, aw_traffic_light,
-        get_yellow_transition_state(signal.traffic_light_group_id))) {
+        get_amber_transition_state(signal.traffic_light_group_id))) {
       continue;
     }
 
@@ -366,8 +366,8 @@ TrafficLightComplianceChecker::get_stop_lines(
   std::vector<StopLineInfo> amber_stop_lines;
   for (const auto & [stop_line_info, signal] : collect_stop_lines(
          lanelet_map, route, traffic_lights.traffic_light_groups,
-         params_.enable_arrow_aware_yellow_passing,
-         [this](const int64_t id) { return status_tracker_->get_yellow_transition_state(id); })) {
+         params_.enable_arrow_aware_amber_passing,
+         [this](const int64_t id) { return status_tracker_->get_amber_transition_state(id); })) {
     const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
       signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
       autoware_perception_msgs::msg::TrafficLightElement::RED);

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
+#include "autoware/traffic_light_compliance_checker/utils.hpp"
+
+#include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
@@ -28,8 +31,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <memory>
-#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -37,13 +40,17 @@
 namespace
 {
 using autoware::traffic_light_compliance_checker::StopLineInfo;
+using autoware::traffic_light_compliance_checker::YellowState;
+using autoware::traffic_light_compliance_checker::is_arrow_aware_amber_pass;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
 /// traffic light groups
 std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>>
 collect_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
-  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
+  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups,
+  const bool enable_arrow_aware_yellow_passing,
+  const std::function<YellowState(int64_t)> & get_yellow_transition_state)
 {
   std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>> stop_lines;
   std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
@@ -65,8 +72,17 @@ collect_stop_lines(
       continue;
     }
 
-    if (!autoware::traffic_light_utils::isTrafficSignalStop(
-          lanelet_map.laneletLayer.get(hit->second), signal)) {
+    const auto & lanelet = lanelet_map.laneletLayer.get(hit->second);
+    const auto aw_traffic_light =
+      std::dynamic_pointer_cast<const lanelet::autoware::AutowareTrafficLight>(*traffic_light_it);
+
+    if (enable_arrow_aware_yellow_passing && is_arrow_aware_amber_pass(
+          lanelet, signal, aw_traffic_light,
+          get_yellow_transition_state(signal.traffic_light_group_id))) {
+      continue;
+    }
+
+    if (!autoware::traffic_light_utils::isTrafficSignalStop(lanelet, signal)) {
       continue;
     }
 
@@ -345,8 +361,10 @@ TrafficLightComplianceChecker::get_stop_lines(
 {
   std::vector<StopLineInfo> red_stop_lines;
   std::vector<StopLineInfo> amber_stop_lines;
-  for (const auto & [stop_line_info, signal] :
-       collect_stop_lines(lanelet_map, route, traffic_lights.traffic_light_groups)) {
+  for (const auto & [stop_line_info, signal] : collect_stop_lines(
+         lanelet_map, route, traffic_lights.traffic_light_groups,
+         params_.enable_arrow_aware_yellow_passing,
+         [this](const int64_t id) { return status_tracker_->get_yellow_transition_state(id); })) {
     const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
       signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
       autoware_perception_msgs::msg::TrafficLightElement::RED);

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -36,16 +36,6 @@
 
 namespace
 {
-autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tracker_parameters(
-  const autoware::traffic_light_compliance_checker::Parameters & parameters)
-{
-  autoware::traffic_light_compliance_checker::StatusTrackerParameters p{};
-  p.stable_duration_threshold_red = parameters.stable_duration_threshold_red;
-  p.stable_duration_threshold_amber = parameters.stable_duration_threshold_amber;
-  p.stable_duration_threshold_unknown = parameters.stable_duration_threshold_unknown;
-  return p;
-}
-
 using autoware::traffic_light_compliance_checker::StopLineInfo;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
@@ -102,8 +92,7 @@ TrafficLightComplianceChecker::TrafficLightComplianceChecker(
   const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
 : params_(parameters),
   vehicle_info_(vehicle_info),
-  status_tracker_(
-    std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
+  status_tracker_(std::make_unique<TrafficLightStatusTracker>(parameters.status_tracker_parameters))
 {
 }
 
@@ -112,7 +101,7 @@ TrafficLightComplianceChecker::~TrafficLightComplianceChecker() = default;
 void TrafficLightComplianceChecker::update_parameters(const Parameters & parameters)
 {
   params_ = parameters;
-  status_tracker_->update_parameters(to_status_tracker_parameters(parameters));
+  status_tracker_->update_parameters(parameters.status_tracker_parameters);
 }
 
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
@@ -146,7 +135,7 @@ std::vector<int64_t> TrafficLightComplianceChecker::get_force_reject_amber_ids(
     return force_reject_amber_ids;
   }
   for (const auto & [id, rejected_time] : amber_rejection_history_) {
-    if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+    if ((current_time - rejected_time).seconds() <= params_.amber_rejection.hysteresis_duration) {
       force_reject_amber_ids.push_back(id);
     }
   }
@@ -168,13 +157,22 @@ void TrafficLightComplianceChecker::update_amber_rejection_history(
       amber_rejection_history_[violation.traffic_light_id] = current_time;
     }
   }
+
+  for (const auto & detected_stop_amber_id : result.detected_stop_amber_ids) {
+    if (
+      std::find(
+        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), detected_stop_amber_id) ==
+      force_reject_amber_ids.end()) {
+      amber_rejection_history_[detected_stop_amber_id] = current_time;
+    }
+  }
 }
 
 void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   const rclcpp::Time & current_time)
 {
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
-    if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
+    if ((current_time - it->second).seconds() > params_.amber_rejection.hysteresis_duration) {
       it = amber_rejection_history_.erase(it);
     } else {
       ++it;
@@ -182,12 +180,12 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   }
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
+ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
   const std::vector<StopLineInfo> & red_stop_lines,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
 {
-  std::vector<Violation> violations;
+  ComplianceResult result;
   for (const auto & red_stop_line : red_stop_lines) {
     auto distance_to_stop_line = 0.0;
     lanelet::BasicPoints2d intersection_points;
@@ -205,21 +203,21 @@ std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
       intersection_points.empty() ||
       is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
       continue;
-    violations.emplace_back(
+    result.violations.emplace_back(
       ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
       intersection_points.front(), distance_to_stop_line + distance_offset);
   }
-  return violations;
+  return result;
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations(
+ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
   const std::vector<StopLineInfo> & amber_stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point,
   const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
 {
-  std::vector<Violation> violations;
+  ComplianceResult result;
   for (const auto & amber_stop_line : amber_stop_lines) {
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
@@ -246,8 +244,11 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
 
     if (
       !amber_stop_line_crossing_time ||
-      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line))
+      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
+      if (stop_point.has_value())
+        result.detected_stop_amber_ids.push_back(amber_stop_line.traffic_light_id);
       continue;
+    }
 
     const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
     const auto current_acceleration = trajectory.front().acceleration_mps2;
@@ -260,12 +261,12 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
       is_force_reject || !can_pass_amber_light(
                            distance_to_stop_line, current_velocity, current_acceleration,
                            *amber_stop_line_crossing_time)) {
-      violations.emplace_back(
+      result.violations.emplace_back(
         ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
         intersection_point, distance_to_stop_line + distance_offset);
     }
   }
-  return violations;
+  return result;
 }
 
 tl::expected<ComplianceResult, std::string>
@@ -338,15 +339,16 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   ComplianceResult result;
   if (check_red_lights) {
-    result.violations =
-      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+    result = get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
   }
   if (check_amber_lights) {
-    const auto amber_light_violations = get_amber_light_violations(
+    const auto amber_light_result = get_amber_light_violations(
       amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
       backward_length);
     result.violations.insert(
-      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+      result.violations.end(), amber_light_result.violations.begin(),
+      amber_light_result.violations.end());
+    result.detected_stop_amber_ids = amber_light_result.detected_stop_amber_ids;
   }
 
   if (ego_stopping_distance.has_value() && params_.allow_if_cannot_stop_distance > 0.0) {

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -239,8 +239,8 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
                              amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
 
     bool can_pass = can_pass_amber_light(
-      distance_to_stop_line, current_velocity, current_acceleration,
-      *amber_stop_line_crossing_time);
+      amber_stop_line.traffic_light_id, distance_to_stop_line, current_velocity,
+      current_acceleration, *amber_stop_line_crossing_time);
 
     if (!is_force_reject && can_pass) continue;
 
@@ -379,7 +379,7 @@ bool TrafficLightComplianceChecker::is_stop_point_within_margin_from_stop_line(
 }
 
 bool TrafficLightComplianceChecker::can_pass_amber_light(
-  const double distance_to_stop_line, const double current_velocity,
+  const int64_t traffic_light_id, const double distance_to_stop_line, const double current_velocity,
   const double current_acceleration, const double time_to_cross_stop_line) const
 {
   const double decel_limit = params_.deceleration_limit;
@@ -388,9 +388,12 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
   const auto distance_for_ego_to_stop = autoware::motion_utils::calculate_stop_distance(
     current_velocity, current_acceleration, decel_limit, jerk_limit, delay_response_time);
 
+  const auto crossing_time_limit =
+    std::max(0.0, params_.crossing_time_limit - status_tracker_->get_duration(traffic_light_id));
+
   const bool can_stop =
     distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_to_stop_line;
-  const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
+  const bool can_pass_in_time = time_to_cross_stop_line <= crossing_time_limit;
   const bool can_pass = !can_stop && can_pass_in_time;
   return can_pass;
 }

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -119,6 +119,11 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
   const auto force_reject_amber_ids =
     get_force_reject_amber_ids(input.current_time, is_ego_stopped);
 
+  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
+    input.current_velocity, input.current_acceleration,
+    params_.checked_trajectory_length.deceleration_limit,
+    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+
   auto result = check_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
 
@@ -257,7 +262,7 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-  const bool check_amber_lights)
+  const bool check_amber_lights) const
 {
   if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
@@ -265,10 +270,7 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
-    input.current_velocity, input.current_acceleration,
-    params_.checked_trajectory_length.deceleration_limit,
-    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+
   // Floor by min_lookahead_distance so low ego speed still covers nearby stop lines,
   // while keeping the comfortable-stop cap so far lights are not over-checked
   // (important for traffic_light_filter which rejects trajectories).

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
-#include "autoware/traffic_light_compliance_checker/utils.hpp"
 
+#include "autoware/traffic_light_compliance_checker/utils.hpp"
 #include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
@@ -33,15 +33,16 @@
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace
 {
+using autoware::traffic_light_compliance_checker::is_arrow_aware_amber_pass;
 using autoware::traffic_light_compliance_checker::StopLineInfo;
 using autoware::traffic_light_compliance_checker::YellowState;
-using autoware::traffic_light_compliance_checker::is_arrow_aware_amber_pass;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
 /// traffic light groups
@@ -76,9 +77,11 @@ collect_stop_lines(
     const auto aw_traffic_light =
       std::dynamic_pointer_cast<const lanelet::autoware::AutowareTrafficLight>(*traffic_light_it);
 
-    if (enable_arrow_aware_yellow_passing && is_arrow_aware_amber_pass(
-          lanelet, signal, aw_traffic_light,
-          get_yellow_transition_state(signal.traffic_light_group_id))) {
+    if (
+      enable_arrow_aware_yellow_passing &&
+      is_arrow_aware_amber_pass(
+        lanelet, signal, aw_traffic_light,
+        get_yellow_transition_state(signal.traffic_light_group_id))) {
       continue;
     }
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -107,6 +107,10 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
   const Inputs & input, const bool check_red_lights, const bool check_amber_lights)
 {
+  if (input.map == nullptr) {
+    return tl::make_unexpected("Lanelet map is not set");
+  }
+
   const bool is_ego_stopped =
     std::abs(input.current_velocity) < params_.ego_stopped_velocity_threshold;
   const auto filtered_signals =
@@ -117,11 +121,7 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
 
   auto result = check_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
-  if (!result) {
-    return result;
-  }
 
-  update_amber_rejection_history(*result, input.current_time, force_reject_amber_ids);
   cleanup_amber_rejection_history(input.current_time);
 
   return result;
@@ -142,32 +142,6 @@ std::vector<int64_t> TrafficLightComplianceChecker::get_force_reject_amber_ids(
   return force_reject_amber_ids;
 }
 
-void TrafficLightComplianceChecker::update_amber_rejection_history(
-  const ComplianceResult & result, const rclcpp::Time & current_time,
-  const std::vector<int64_t> & force_reject_amber_ids)
-{
-  for (const auto & violation : result.violations) {
-    if (violation.type != ViolationType::AMBER_LIGHT) {
-      continue;
-    }
-    if (
-      std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), violation.traffic_light_id) ==
-      force_reject_amber_ids.end()) {
-      amber_rejection_history_[violation.traffic_light_id] = current_time;
-    }
-  }
-
-  for (const auto & detected_stop_amber_id : result.detected_stop_amber_ids) {
-    if (
-      std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), detected_stop_amber_id) ==
-      force_reject_amber_ids.end()) {
-      amber_rejection_history_[detected_stop_amber_id] = current_time;
-    }
-  }
-}
-
 void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   const rclcpp::Time & current_time)
 {
@@ -180,12 +154,12 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   }
 }
 
-ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
+Violations TrafficLightComplianceChecker::get_red_light_violations(
   const std::vector<StopLineInfo> & red_stop_lines,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
 {
-  ComplianceResult result;
+  Violations violations;
   for (const auto & red_stop_line : red_stop_lines) {
     auto distance_to_stop_line = 0.0;
     lanelet::BasicPoints2d intersection_points;
@@ -201,23 +175,26 @@ ComplianceResult TrafficLightComplianceChecker::get_red_light_violations(
     }
     if (
       intersection_points.empty() ||
-      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
+      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line) ||
+      is_allow_if_cannot_stop(distance_to_stop_line))
       continue;
-    result.violations.emplace_back(
+
+    violations.emplace_back(
       ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
       intersection_points.front(), distance_to_stop_line + distance_offset);
   }
-  return result;
+  return violations;
 }
 
-ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
+Violations TrafficLightComplianceChecker::get_amber_light_violations(
   const std::vector<StopLineInfo> & amber_stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point,
-  const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
+  const std::vector<int64_t> & force_reject_amber_ids, const rclcpp::Time & current_time,
+  const double distance_offset) const
 {
-  ComplianceResult result;
+  Violations violations;
   for (const auto & amber_stop_line : amber_stop_lines) {
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
@@ -246,7 +223,11 @@ ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
       !amber_stop_line_crossing_time ||
       is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
       if (stop_point.has_value())
-        result.detected_stop_amber_ids.push_back(amber_stop_line.traffic_light_id);
+        amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
+      continue;
+    }
+
+    if (is_allow_if_cannot_stop(distance_to_stop_line)) {
       continue;
     }
 
@@ -257,24 +238,26 @@ ComplianceResult TrafficLightComplianceChecker::get_amber_light_violations(
                              force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
                              amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
 
-    if (
-      is_force_reject || !can_pass_amber_light(
-                           distance_to_stop_line, current_velocity, current_acceleration,
-                           *amber_stop_line_crossing_time)) {
-      result.violations.emplace_back(
-        ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
-        intersection_point, distance_to_stop_line + distance_offset);
-    }
+    bool can_pass = can_pass_amber_light(
+      distance_to_stop_line, current_velocity, current_acceleration,
+      *amber_stop_line_crossing_time);
+
+    if (!is_force_reject && can_pass) continue;
+
+    if (!can_pass) amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
+
+    violations.emplace_back(
+      ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
+      intersection_point, distance_to_stop_line + distance_offset);
   }
-  return result;
+  return violations;
 }
 
-tl::expected<ComplianceResult, std::string>
-TrafficLightComplianceChecker::check_with_filtered_signals(
+ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-  const bool check_amber_lights) const
+  const bool check_amber_lights)
 {
   if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
@@ -282,7 +265,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
+  ego_stopping_distance_ = autoware::motion_utils::calculate_stop_distance(
     input.current_velocity, input.current_acceleration,
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
@@ -292,7 +275,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   // stop_overshoot_margin extends the scan so a stop just past the line is not truncated.
   const auto max_trajectory_length = std::max(
     params_.min_lookahead_distance,
-    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin);
+    ego_stopping_distance_.value_or(0.0) + params_.stop_overshoot_margin);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -339,30 +322,15 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   ComplianceResult result;
   if (check_red_lights) {
-    result = get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+    result.violations =
+      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
   }
   if (check_amber_lights) {
-    const auto amber_light_result = get_amber_light_violations(
+    const auto amber_light_violations = get_amber_light_violations(
       amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
-      backward_length);
+      input.current_time, backward_length);
     result.violations.insert(
-      result.violations.end(), amber_light_result.violations.begin(),
-      amber_light_result.violations.end());
-    result.detected_stop_amber_ids = amber_light_result.detected_stop_amber_ids;
-  }
-
-  if (ego_stopping_distance.has_value() && params_.allow_if_cannot_stop_distance > 0.0) {
-    result.violations.erase(
-      std::remove_if(
-        result.violations.begin(), result.violations.end(),
-        [&](const auto & violation) {
-          const auto distance_from_ego_front = violation.arc_length_to_cross_point -
-                                               backward_length -
-                                               vehicle_info_.max_longitudinal_offset_m;
-          return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
-                 distance_from_ego_front < *ego_stopping_distance - params_.stop_overshoot_margin;
-        }),
-      result.violations.end());
+      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
   }
 
   return result;
@@ -425,6 +393,17 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
   const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
   const bool can_pass = !can_stop && can_pass_in_time;
   return can_pass;
+}
+
+bool TrafficLightComplianceChecker::is_allow_if_cannot_stop(
+  const double distance_to_cross_point) const
+{
+  if (!ego_stopping_distance_.has_value() || params_.allow_if_cannot_stop_distance < 1e-3)
+    return false;
+  const auto distance_from_ego_front =
+    distance_to_cross_point - vehicle_info_.max_longitudinal_offset_m;
+  return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
+         distance_from_ego_front < *ego_stopping_distance_ - params_.stop_overshoot_margin;
 }
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -222,7 +222,7 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
     if (
       !amber_stop_line_crossing_time ||
       is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
-      if (stop_point.has_value())
+      if (stop_point.has_value() && params_.amber_rejection.reject_if_stop_detected)
         amber_rejection_history_[amber_stop_line.traffic_light_id] = current_time;
       continue;
     }

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
-#include "autoware/traffic_light_compliance_checker/utils.hpp"
 
-#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+#include "autoware/traffic_light_compliance_checker/utils.hpp"
 
 #include <vector>
 
@@ -79,38 +78,37 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
 
   for (const auto & signal : signals.traffic_light_groups) {
     const auto id = signal.traffic_light_group_id;
-    std::vector<autoware_perception_msgs::msg::TrafficLightElement> previous_elements;
-    if (signal_history_.find(id) == signal_history_.end()) {
-      signal_history_[id] = {signal, current_time, current_time, YellowState::kNotYellow};
+    auto history_it = signal_history_.find(id);
+    if (history_it == signal_history_.end()) {
+      SignalStateHistory signal_state{
+        signal, std::nullopt, current_time, current_time, YellowState::kNotYellow};
+      history_it = signal_history_.insert({id, signal_state}).first;
     } else {
-      previous_elements = signal_history_[id].msg.elements;
-      if (!is_equal(previous_elements, signal.elements)) {
-        signal_history_[id].first_seen_time = current_time;
-        signal_history_[id].msg = signal;
+      auto & history = history_it->second;
+      if (!is_equal(history.current_state.elements, signal.elements)) {
+        history.first_seen_time = current_time;
+        history.current_state = signal;
       }
-      signal_history_[id].last_seen_time = current_time;
+      history.last_seen_time = current_time;
     }
-    // Classify from raw elements before stability filtering clears amber.
-    update_yellow_transition_state(signal_history_[id], previous_elements, signal.elements);
 
-    auto filtered_signal = signal;
+    const auto state_duration = (current_time - history_it->second.first_seen_time).seconds();
+
+    if (state_duration >= required_stability_duration(signal)) {
+      auto stable_changed = !history_it->second.stable_state ||
+                            !is_equal(history_it->second.stable_state->elements, signal.elements);
+      if (stable_changed && history_it->second.stable_state) {
+        update_yellow_transition_state(
+          history_it->second, history_it->second.stable_state->elements, signal.elements);
+      }
+      history_it->second.stable_state = signal;
+    }
+
     if (is_ego_stopped) {
-      filtered_signals.traffic_light_groups.push_back(filtered_signal);
-      continue;
+      filtered_signals.traffic_light_groups.push_back(signal);
+    } else if (history_it->second.stable_state) {
+      filtered_signals.traffic_light_groups.push_back(*history_it->second.stable_state);
     }
-    const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
-    const bool is_red = has_red_circle(signal.elements);
-    const bool is_amber = has_amber_circle(signal.elements);
-    const bool is_unknown = has_unknown(signal.elements);
-
-    if (is_red && state_duration < params_.stable_duration_threshold_red) {
-      filtered_signal.elements.clear();
-    } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
-      filtered_signal.elements.clear();
-    } else if (is_unknown && state_duration < params_.stable_duration_threshold_unknown) {
-      filtered_signal.elements.clear();
-    }
-    filtered_signals.traffic_light_groups.push_back(filtered_signal);
   }
 
   cleanup_signal_history(current_time);
@@ -121,11 +119,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
 void TrafficLightStatusTracker::cleanup_signal_history(const rclcpp::Time & current_time)
 {
   for (auto it = signal_history_.begin(); it != signal_history_.end();) {
-    const bool is_red = has_red_circle(it->second.msg.elements);
-    const bool is_amber = has_amber_circle(it->second.msg.elements);
-    const double stable_duration = is_red     ? params_.stable_duration_threshold_red
-                                   : is_amber ? params_.stable_duration_threshold_amber
-                                              : params_.stable_duration_threshold_unknown;
+    const double stable_duration = required_stability_duration(it->second.current_state);
     if ((current_time - it->second.last_seen_time).seconds() > stable_duration) {
       it = signal_history_.erase(it);
     } else {
@@ -134,4 +128,18 @@ void TrafficLightStatusTracker::cleanup_signal_history(const rclcpp::Time & curr
   }
 }
 
+double TrafficLightStatusTracker::required_stability_duration(
+  const autoware_perception_msgs::msg::TrafficLightGroup & signal) const
+{
+  if (has_red_circle(signal.elements)) {
+    return params_.stable_duration_threshold_red;
+  }
+  if (has_amber_circle(signal.elements)) {
+    return params_.stable_duration_threshold_amber;
+  }
+  if (has_unknown(signal.elements)) {
+    return params_.stable_duration_threshold_unknown;
+  }
+  return 0.0;
+}
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -31,41 +31,41 @@ void TrafficLightStatusTracker::update_parameters(const StatusTrackerParameters 
   params_ = parameters;
 }
 
-YellowState TrafficLightStatusTracker::get_yellow_transition_state(
+AmberState TrafficLightStatusTracker::get_amber_transition_state(
   const int64_t traffic_light_group_id) const
 {
   const auto it = signal_history_.find(traffic_light_group_id);
   if (it == signal_history_.end()) {
-    return YellowState::kNotYellow;
+    return AmberState::kNotAmber;
   }
-  return it->second.yellow_transition_state;
+  return it->second.amber_transition_state;
 }
 
-void TrafficLightStatusTracker::update_yellow_transition_state(
+void TrafficLightStatusTracker::update_amber_transition_state(
   SignalStateHistory & history,
   const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & previous_elements,
   const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & current_elements)
 {
   const bool is_amber_now = has_amber_circle(current_elements);
   if (!is_amber_now) {
-    history.yellow_transition_state = YellowState::kNotYellow;
+    history.amber_transition_state = AmberState::kNotAmber;
     return;
   }
 
   // Only classify the transition on the first frame of amber.
-  if (history.yellow_transition_state != YellowState::kNotYellow) {
+  if (history.amber_transition_state != AmberState::kNotAmber) {
     return;
   }
 
   if (previous_elements.empty()) {
-    // Origin unknown; keep kNotYellow so arrow-aware pass does not apply.
+    // Origin unknown; keep kNotAmber so arrow-aware pass does not apply.
     return;
   }
 
   if (has_green_circle(previous_elements)) {
-    history.yellow_transition_state = YellowState::kFromGreen;
+    history.amber_transition_state = AmberState::kFromGreen;
   } else {
-    history.yellow_transition_state = YellowState::kFromNonGreen;
+    history.amber_transition_state = AmberState::kFromNonGreen;
   }
 }
 
@@ -81,7 +81,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
     auto history_it = signal_history_.find(id);
     if (history_it == signal_history_.end()) {
       SignalStateHistory signal_state{
-        signal, std::nullopt, current_time, current_time, YellowState::kNotYellow};
+        signal, std::nullopt, current_time, current_time, AmberState::kNotAmber};
       history_it = signal_history_.insert({id, signal_state}).first;
     } else {
       auto & history = history_it->second;
@@ -98,7 +98,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
       auto stable_changed = !history_it->second.stable_state ||
                             !is_equal(history_it->second.stable_state->elements, signal.elements);
       if (stable_changed && history_it->second.stable_state) {
-        update_yellow_transition_state(
+        update_amber_transition_state(
           history_it->second, history_it->second.stable_state->elements, signal.elements);
       }
       history_it->second.stable_state = signal;

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -13,37 +13,11 @@
 // limitations under the License.
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
+#include "autoware/traffic_light_compliance_checker/utils.hpp"
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
 #include <vector>
-
-namespace
-{
-bool is_equal(
-  const autoware_perception_msgs::msg::TrafficLightElement & a,
-  const autoware_perception_msgs::msg::TrafficLightElement & b)
-{
-  return a.color == b.color && a.shape == b.shape && a.status == b.status;
-}
-
-bool is_equal(
-  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
-  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b)
-{
-  if (a.size() != b.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < a.size(); ++i) {
-    if (!is_equal(a[i], b[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
-}  // namespace
 
 namespace autoware::traffic_light_compliance_checker
 {
@@ -58,6 +32,44 @@ void TrafficLightStatusTracker::update_parameters(const StatusTrackerParameters 
   params_ = parameters;
 }
 
+YellowState TrafficLightStatusTracker::get_yellow_transition_state(
+  const int64_t traffic_light_group_id) const
+{
+  const auto it = signal_history_.find(traffic_light_group_id);
+  if (it == signal_history_.end()) {
+    return YellowState::kNotYellow;
+  }
+  return it->second.yellow_transition_state;
+}
+
+void TrafficLightStatusTracker::update_yellow_transition_state(
+  SignalStateHistory & history,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & previous_elements,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & current_elements)
+{
+  const bool is_amber_now = has_amber_circle(current_elements);
+  if (!is_amber_now) {
+    history.yellow_transition_state = YellowState::kNotYellow;
+    return;
+  }
+
+  // Only classify the transition on the first frame of amber.
+  if (history.yellow_transition_state != YellowState::kNotYellow) {
+    return;
+  }
+
+  if (previous_elements.empty()) {
+    // Origin unknown; keep kNotYellow so arrow-aware pass does not apply.
+    return;
+  }
+
+  if (has_green_circle(previous_elements)) {
+    history.yellow_transition_state = YellowState::kFromGreen;
+  } else {
+    history.yellow_transition_state = YellowState::kFromNonGreen;
+  }
+}
+
 autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker::filter_signals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
   const rclcpp::Time & current_time, const bool is_ego_stopped)
@@ -67,15 +79,19 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
 
   for (const auto & signal : signals.traffic_light_groups) {
     const auto id = signal.traffic_light_group_id;
+    std::vector<autoware_perception_msgs::msg::TrafficLightElement> previous_elements;
     if (signal_history_.find(id) == signal_history_.end()) {
-      signal_history_[id] = {signal, current_time, current_time};
+      signal_history_[id] = {signal, current_time, current_time, YellowState::kNotYellow};
     } else {
-      if (!is_equal(signal_history_[id].msg.elements, signal.elements)) {
+      previous_elements = signal_history_[id].msg.elements;
+      if (!is_equal(previous_elements, signal.elements)) {
         signal_history_[id].first_seen_time = current_time;
         signal_history_[id].msg = signal;
       }
       signal_history_[id].last_seen_time = current_time;
     }
+    // Classify from raw elements before stability filtering clears amber.
+    update_yellow_transition_state(signal_history_[id], previous_elements, signal.elements);
 
     auto filtered_signal = signal;
     if (is_ego_stopped) {
@@ -83,14 +99,9 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
       continue;
     }
     const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
-    const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-      autoware_perception_msgs::msg::TrafficLightElement::RED);
-    const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-      autoware_perception_msgs::msg::TrafficLightElement::AMBER);
-    const bool is_unknown = autoware::traffic_light_utils::hasTrafficLightColor(
-      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+    const bool is_red = has_red_circle(signal.elements);
+    const bool is_amber = has_amber_circle(signal.elements);
+    const bool is_unknown = has_unknown(signal.elements);
 
     if (is_red && state_duration < params_.stable_duration_threshold_red) {
       filtered_signal.elements.clear();
@@ -110,10 +121,8 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
 void TrafficLightStatusTracker::cleanup_signal_history(const rclcpp::Time & current_time)
 {
   for (auto it = signal_history_.begin(); it != signal_history_.end();) {
-    const bool is_red = autoware::traffic_light_utils::hasTrafficLightColor(
-      it->second.msg.elements, autoware_perception_msgs::msg::TrafficLightElement::RED);
-    const bool is_amber = autoware::traffic_light_utils::hasTrafficLightColor(
-      it->second.msg.elements, autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+    const bool is_red = has_red_circle(it->second.msg.elements);
+    const bool is_amber = has_amber_circle(it->second.msg.elements);
     const double stable_duration = is_red     ? params_.stable_duration_threshold_red
                                    : is_amber ? params_.stable_duration_threshold_amber
                                               : params_.stable_duration_threshold_unknown;

--- a/common/autoware_traffic_light_compliance_checker/src/utils.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/utils.cpp
@@ -50,36 +50,31 @@ bool is_equal(
 }
 
 bool is_shape_and_color(
-  const std::vector<TrafficLightElement> & elements,
-  const TrafficLightElement::_shape_type & shape,
+  const std::vector<TrafficLightElement> & elements, const TrafficLightElement::_shape_type & shape,
   const TrafficLightElement::_color_type & color)
 {
   return autoware::traffic_light_utils::hasTrafficLightShapeAndColor(elements, shape, color);
 }
 
-bool has_amber_circle(
-  const std::vector<TrafficLightElement> & elements)
+bool has_amber_circle(const std::vector<TrafficLightElement> & elements)
 {
-  return is_shape_and_color(
-    elements, TrafficLightElement::CIRCLE, TrafficLightElement::AMBER);
+  return is_shape_and_color(elements, TrafficLightElement::CIRCLE, TrafficLightElement::AMBER);
 }
 
-bool has_green_circle(
-  const std::vector<TrafficLightElement> & elements)
+bool has_green_circle(const std::vector<TrafficLightElement> & elements)
 {
   return is_shape_and_color(elements, TrafficLightElement::CIRCLE, TrafficLightElement::GREEN);
 }
 
-bool has_red_circle(
-  const std::vector<TrafficLightElement> & elements)
+bool has_red_circle(const std::vector<TrafficLightElement> & elements)
 {
   return is_shape_and_color(elements, TrafficLightElement::CIRCLE, TrafficLightElement::RED);
 }
 
-bool has_unknown(
-  const std::vector<TrafficLightElement> & elements)
+bool has_unknown(const std::vector<TrafficLightElement> & elements)
 {
-  return autoware::traffic_light_utils::hasTrafficLightColor(elements, TrafficLightElement::UNKNOWN);
+  return autoware::traffic_light_utils::hasTrafficLightColor(
+    elements, TrafficLightElement::UNKNOWN);
 }
 
 bool has_static_arrow(

--- a/common/autoware_traffic_light_compliance_checker/src/utils.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/utils.cpp
@@ -1,0 +1,136 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_compliance_checker/utils.hpp"
+
+#include <autoware/lanelet2_utils/intersection.hpp>
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::traffic_light_compliance_checker
+{
+using autoware_perception_msgs::msg::TrafficLightElement;
+
+bool is_equal(
+  const autoware_perception_msgs::msg::TrafficLightElement & a,
+  const autoware_perception_msgs::msg::TrafficLightElement & b)
+{
+  return a.color == b.color && a.shape == b.shape && a.status == b.status;
+}
+
+bool is_equal(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b)
+{
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (!is_equal(a[i], b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool is_shape_and_color(
+  const std::vector<TrafficLightElement> & elements,
+  const TrafficLightElement::_shape_type & shape,
+  const TrafficLightElement::_color_type & color)
+{
+  return autoware::traffic_light_utils::hasTrafficLightShapeAndColor(elements, shape, color);
+}
+
+bool has_amber_circle(
+  const std::vector<TrafficLightElement> & elements)
+{
+  return is_shape_and_color(
+    elements, TrafficLightElement::CIRCLE, TrafficLightElement::AMBER);
+}
+
+bool has_green_circle(
+  const std::vector<TrafficLightElement> & elements)
+{
+  return is_shape_and_color(elements, TrafficLightElement::CIRCLE, TrafficLightElement::GREEN);
+}
+
+bool has_red_circle(
+  const std::vector<TrafficLightElement> & elements)
+{
+  return is_shape_and_color(elements, TrafficLightElement::CIRCLE, TrafficLightElement::RED);
+}
+
+bool has_unknown(
+  const std::vector<TrafficLightElement> & elements)
+{
+  return autoware::traffic_light_utils::hasTrafficLightColor(elements, TrafficLightElement::UNKNOWN);
+}
+
+bool has_static_arrow(
+  const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem)
+{
+  if (!reg_elem) {
+    return false;
+  }
+
+  for (const auto & light : reg_elem->trafficLights()) {
+    const auto & attributes = light.attributes();
+    if (attributes.find("subtype") != attributes.end()) {
+      const std::string subtype = attributes.at("subtype").value();
+      if (subtype.find("arrow") != std::string::npos) {
+        return true;
+      }
+    }
+  }
+
+  for (const auto & light_bulb_ls : reg_elem->lightBulbs()) {
+    for (const auto & node : light_bulb_ls) {
+      const auto & attributes = node.attributes();
+      if (attributes.find("arrow") != attributes.end()) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+bool is_arrow_aware_amber_pass(
+  const lanelet::ConstLanelet & lanelet,
+  const autoware_perception_msgs::msg::TrafficLightGroup & signal,
+  const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem,
+  const YellowState yellow_transition_state)
+{
+  if (!has_amber_circle(signal.elements)) {
+    return false;
+  }
+  if (yellow_transition_state != YellowState::kFromGreen) {
+    return false;
+  }
+
+  const bool is_turn_lane = autoware::experimental::lanelet2_utils::is_left_direction(lanelet) ||
+                            autoware::experimental::lanelet2_utils::is_right_direction(lanelet);
+  if (!is_turn_lane) {
+    return false;
+  }
+
+  return has_static_arrow(reg_elem);
+}
+
+}  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/utils.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/utils.cpp
@@ -110,12 +110,12 @@ bool is_arrow_aware_amber_pass(
   const lanelet::ConstLanelet & lanelet,
   const autoware_perception_msgs::msg::TrafficLightGroup & signal,
   const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem,
-  const YellowState yellow_transition_state)
+  const AmberState amber_transition_state)
 {
   if (!has_amber_circle(signal.elements)) {
     return false;
   }
-  if (yellow_transition_state != YellowState::kFromGreen) {
+  if (amber_transition_state != AmberState::kFromGreen) {
     return false;
   }
 

--- a/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
@@ -1,0 +1,304 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
+
+#include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
+#include "autoware_lanelet2_extension/utility/utilities.hpp"
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+using autoware::traffic_light_compliance_checker::Inputs;
+using autoware::traffic_light_compliance_checker::Parameters;
+using autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker;
+using autoware::traffic_light_compliance_checker::ViolationType;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::LaneletSegment;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+constexpr lanelet::Id k_light_id = 1000;
+constexpr double k_stop_line_x = 30.0;
+
+Parameters make_default_params()
+{
+  Parameters p{};
+  p.deceleration_limit = 1.0;
+  p.jerk_limit = 1.0;
+  p.delay_response_time = 0.0;
+  p.crossing_time_limit = 0.1;  // force amber pass kinematics to fail when stop is required
+  p.treat_amber_light_as_red_light = false;
+  p.treat_unknown_light_as_red_light = false;
+  p.enable_arrow_aware_yellow_passing = true;
+  p.stop_overshoot_margin = 0.0;
+  p.allow_if_cannot_stop_distance = 0.0;
+  p.min_lookahead_distance = 100.0;
+  p.stable_duration_threshold_red = 0.0;
+  p.stable_duration_threshold_amber = 0.0;
+  p.stable_duration_threshold_unknown = 0.0;
+  p.amber_rejection_hysteresis_duration = 0.0;
+  p.ego_stopped_velocity_threshold = 0.01;
+  p.checked_trajectory_length.deceleration_limit = 999.0;
+  p.checked_trajectory_length.jerk_limit = 999.0;
+  return p;
+}
+
+autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
+{
+  autoware::vehicle_info_utils::VehicleInfo info;
+  info.max_longitudinal_offset_m = 0.0;
+  return info;
+}
+
+std::shared_ptr<lanelet::LaneletMap> create_map(
+  const std::string & turn_direction, const bool with_static_arrow)
+{
+  lanelet::Point3d sl1(lanelet::utils::getId(), k_stop_line_x, -5.0, 0.0);
+  lanelet::Point3d sl2(lanelet::utils::getId(), k_stop_line_x, 5.0, 0.0);
+  lanelet::LineString3d stop_line(lanelet::utils::getId(), {sl1, sl2});
+
+  lanelet::Point3d light_pt1(lanelet::utils::getId(), k_stop_line_x + 5.0, 5.0, 5.0);
+  lanelet::Point3d light_pt2(lanelet::utils::getId(), k_stop_line_x + 5.0, 4.0, 5.0);
+  lanelet::LineString3d light_shape(lanelet::utils::getId(), {light_pt1, light_pt2});
+  if (with_static_arrow) {
+    light_shape.attributes()["subtype"] = "right_arrow";
+  } else {
+    light_shape.attributes()["subtype"] = "red_yellow_green";
+  }
+
+  auto traffic_light_re = lanelet::autoware::AutowareTrafficLight::make(
+    k_light_id, lanelet::AttributeMap(), {light_shape}, stop_line);
+
+  lanelet::Point3d l1(lanelet::utils::getId(), 0.0, -5.0, 0.0);
+  lanelet::Point3d l2(lanelet::utils::getId(), 200.0, -5.0, 0.0);
+  lanelet::Point3d r1(lanelet::utils::getId(), 0.0, 5.0, 0.0);
+  lanelet::Point3d r2(lanelet::utils::getId(), 200.0, 5.0, 0.0);
+  lanelet::LineString3d left(lanelet::utils::getId(), {l1, l2});
+  lanelet::LineString3d right(lanelet::utils::getId(), {r1, r2});
+
+  lanelet::Lanelet lanelet(lanelet::utils::getId(), left, right);
+  if (!turn_direction.empty()) {
+    lanelet.attributes()["turn_direction"] = turn_direction;
+  }
+  lanelet.addRegulatoryElement(traffic_light_re);
+
+  return lanelet::utils::createMap({lanelet});
+}
+
+LaneletRoute create_route(const lanelet::Id lanelet_id)
+{
+  LaneletRoute route;
+  LaneletSegment segment;
+  segment.preferred_primitive.id = lanelet_id;
+  route.segments.push_back(segment);
+  return route;
+}
+
+std::vector<TrajectoryPoint> create_crossing_trajectory(const double velocity)
+{
+  std::vector<TrajectoryPoint> trajectory;
+  constexpr double spacing = 1.0;
+  constexpr double end_x = 60.0;
+  const auto duration_sec = end_x / velocity;
+  for (double x = 0.0; x <= end_x + 1e-6; x += spacing) {
+    TrajectoryPoint point;
+    point.pose.position.x = x;
+    point.pose.position.y = 0.0;
+    point.pose.orientation.w = 1.0;
+    point.longitudinal_velocity_mps = static_cast<float>(velocity);
+    point.acceleration_mps2 = 0.0f;
+    point.time_from_start = rclcpp::Duration::from_seconds((x / end_x) * duration_sec);
+    trajectory.push_back(point);
+  }
+  return trajectory;
+}
+
+TrafficLightElement make_element(uint8_t color, uint8_t shape = TrafficLightElement::CIRCLE)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = 1.0f;
+  return element;
+}
+
+TrafficLightGroupArray make_signals(const TrafficLightElement & element)
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = k_light_id;
+  group.elements.push_back(element);
+
+  TrafficLightGroupArray signals;
+  signals.traffic_light_groups.push_back(group);
+  return signals;
+}
+
+Inputs make_inputs(
+  const std::shared_ptr<lanelet::LaneletMap> & map, const TrafficLightGroupArray & signals,
+  const rclcpp::Time & time)
+{
+  const auto lanelet_id = map->laneletLayer.begin()->id();
+  Inputs input;
+  input.trajectory = create_crossing_trajectory(10.0);
+  input.map = map;
+  input.route = create_route(lanelet_id);
+  input.signals = signals;
+  input.current_time = time;
+  input.current_velocity = 10.0;
+  input.current_acceleration = 0.0;
+  return input;
+}
+}  // namespace
+
+class ArrowAwareAmberTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    params_ = make_default_params();
+    checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+  }
+
+  void feed_signal(const TrafficLightGroupArray & signals, const rclcpp::Time & time)
+  {
+    // Drive tracker state using a non-crossing check path via check() itself.
+    auto map = create_map("right", true);
+    auto input = make_inputs(map, signals, time);
+    // Short trajectory that does not cross the stop line, only to update tracker state.
+    input.trajectory = create_crossing_trajectory(10.0);
+    // Truncate before stop line so no violation is recorded while priming history.
+    input.trajectory.erase(
+      std::remove_if(
+        input.trajectory.begin(), input.trajectory.end(),
+        [](const TrajectoryPoint & p) { return p.pose.position.x > k_stop_line_x - 5.0; }),
+      input.trajectory.end());
+    ASSERT_FALSE(input.trajectory.empty());
+    const auto result = checker_->check(input, true, true);
+    ASSERT_TRUE(result.has_value());
+  }
+
+  Parameters params_;
+  std::unique_ptr<TrafficLightComplianceChecker> checker_;
+};
+
+TEST_F(ArrowAwareAmberTest, GreenToAmberOnTurnLaneWithArrowAllowsPass)
+{
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
+
+  feed_signal(make_signals(make_element(TrafficLightElement::GREEN)), t0);
+
+  auto map = create_map("right", true);
+  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ArrowAwareAmberTest, RedToAmberStillViolates)
+{
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
+
+  feed_signal(make_signals(make_element(TrafficLightElement::RED)), t0);
+
+  auto map = create_map("right", true);
+  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
+}
+
+TEST_F(ArrowAwareAmberTest, NonTurnLaneStillViolates)
+{
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
+
+  // Prime tracker with green using a turn+arrow map (tracker is per TL id, not lane).
+  feed_signal(make_signals(make_element(TrafficLightElement::GREEN)), t0);
+
+  auto map = create_map("", true);  // no turn_direction
+  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
+}
+
+TEST_F(ArrowAwareAmberTest, NoStaticArrowStillViolates)
+{
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
+
+  feed_signal(make_signals(make_element(TrafficLightElement::GREEN)), t0);
+
+  auto map = create_map("right", false);
+  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
+}
+
+TEST_F(ArrowAwareAmberTest, FeatureDisabledStillViolates)
+{
+  params_.enable_arrow_aware_yellow_passing = false;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
+
+  feed_signal(make_signals(make_element(TrafficLightElement::GREEN)), t0);
+
+  auto map = create_map("right", true);
+  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
+}
+
+TEST_F(ArrowAwareAmberTest, GreenRightArrowAllowsPass)
+{
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+
+  auto map = create_map("right", true);
+  auto input = make_inputs(
+    map,
+    make_signals(make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)), t0);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}

--- a/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
@@ -62,10 +62,11 @@ Parameters make_default_params()
   p.stop_overshoot_margin = 0.0;
   p.allow_if_cannot_stop_distance = 0.0;
   p.min_lookahead_distance = 100.0;
-  p.stable_duration_threshold_red = 0.0;
-  p.stable_duration_threshold_amber = 0.0;
-  p.stable_duration_threshold_unknown = 0.0;
-  p.amber_rejection_hysteresis_duration = 0.0;
+  p.status_tracker_parameters.stable_duration_threshold_red = 0.0;
+  p.status_tracker_parameters.stable_duration_threshold_amber = 0.0;
+  p.status_tracker_parameters.stable_duration_threshold_unknown = 0.0;
+  p.amber_rejection.hysteresis_duration = 0.0;
+  p.amber_rejection.reject_if_stop_detected = false;
   p.ego_stopped_velocity_threshold = 0.01;
   p.checked_trajectory_length.deceleration_limit = 999.0;
   p.checked_trajectory_length.jerk_limit = 999.0;

--- a/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
-
 #include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
@@ -296,8 +295,8 @@ TEST_F(ArrowAwareAmberTest, GreenRightArrowAllowsPass)
 
   auto map = create_map("right", true);
   auto input = make_inputs(
-    map,
-    make_signals(make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)), t0);
+    map, make_signals(make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)),
+    t0);
   const auto result = checker_->check(input, true, true);
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result->violations.empty());

--- a/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_arrow_aware_amber.cpp
@@ -58,7 +58,7 @@ Parameters make_default_params()
   p.crossing_time_limit = 0.1;  // force amber pass kinematics to fail when stop is required
   p.treat_amber_light_as_red_light = false;
   p.treat_unknown_light_as_red_light = false;
-  p.enable_arrow_aware_yellow_passing = true;
+  p.enable_arrow_aware_amber_passing = true;
   p.stop_overshoot_margin = 0.0;
   p.allow_if_cannot_stop_distance = 0.0;
   p.min_lookahead_distance = 100.0;
@@ -273,7 +273,7 @@ TEST_F(ArrowAwareAmberTest, NoStaticArrowStillViolates)
 
 TEST_F(ArrowAwareAmberTest, FeatureDisabledStillViolates)
 {
-  params_.enable_arrow_aware_yellow_passing = false;
+  params_.enable_arrow_aware_amber_passing = false;
   checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
 
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);

--- a/common/autoware_traffic_light_compliance_checker/test/test_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_compliance_checker.cpp
@@ -29,6 +29,7 @@
 #include <lanelet2_core/LaneletMap.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -81,7 +82,7 @@ autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
 }
 
 std::shared_ptr<lanelet::LaneletMap> create_map(
-  const std::string & turn_direction, const bool with_static_arrow)
+  const std::string & turn_direction = "", const bool with_static_arrow = false)
 {
   lanelet::Point3d sl1(lanelet::utils::getId(), k_stop_line_x, -5.0, 0.0);
   lanelet::Point3d sl2(lanelet::utils::getId(), k_stop_line_x, 5.0, 0.0);
@@ -143,6 +144,28 @@ std::vector<TrajectoryPoint> create_crossing_trajectory(const double velocity)
   return trajectory;
 }
 
+std::vector<TrajectoryPoint> create_stopping_trajectory(const double stop_x, const double velocity)
+{
+  std::vector<TrajectoryPoint> trajectory;
+  constexpr double spacing = 1.0;
+  const auto duration_sec = stop_x / std::max(velocity, 1e-3);
+  auto append_point = [&](const double x, const bool is_stop) {
+    TrajectoryPoint point;
+    point.pose.position.x = x;
+    point.pose.position.y = 0.0;
+    point.pose.orientation.w = 1.0;
+    point.longitudinal_velocity_mps = is_stop ? 0.0f : static_cast<float>(velocity);
+    point.acceleration_mps2 = 0.0f;
+    point.time_from_start = rclcpp::Duration::from_seconds((x / stop_x) * duration_sec);
+    trajectory.push_back(point);
+  };
+  for (double x = 0.0; x < stop_x - 1e-6; x += spacing) {
+    append_point(x, false);
+  }
+  append_point(stop_x, true);
+  return trajectory;
+}
+
 TrafficLightElement make_element(uint8_t color, uint8_t shape = TrafficLightElement::CIRCLE)
 {
   TrafficLightElement element;
@@ -166,22 +189,22 @@ TrafficLightGroupArray make_signals(const TrafficLightElement & element)
 
 Inputs make_inputs(
   const std::shared_ptr<lanelet::LaneletMap> & map, const TrafficLightGroupArray & signals,
-  const rclcpp::Time & time)
+  const rclcpp::Time & time, const double velocity = 10.0)
 {
   const auto lanelet_id = map->laneletLayer.begin()->id();
   Inputs input;
-  input.trajectory = create_crossing_trajectory(10.0);
+  input.trajectory = create_crossing_trajectory(velocity);
   input.map = map;
   input.route = create_route(lanelet_id);
   input.signals = signals;
   input.current_time = time;
-  input.current_velocity = 10.0;
+  input.current_velocity = velocity;
   input.current_acceleration = 0.0;
   return input;
 }
 }  // namespace
 
-class ArrowAwareAmberTest : public ::testing::Test
+class ComplianceCheckerTest : public ::testing::Test
 {
 protected:
   void SetUp() override
@@ -192,11 +215,8 @@ protected:
 
   void feed_signal(const TrafficLightGroupArray & signals, const rclcpp::Time & time)
   {
-    // Drive tracker state using a non-crossing check path via check() itself.
     auto map = create_map("right", true);
     auto input = make_inputs(map, signals, time);
-    // Short trajectory that does not cross the stop line, only to update tracker state.
-    input.trajectory = create_crossing_trajectory(10.0);
     // Truncate before stop line so no violation is recorded while priming history.
     input.trajectory.erase(
       std::remove_if(
@@ -212,7 +232,180 @@ protected:
   std::unique_ptr<TrafficLightComplianceChecker> checker_;
 };
 
-TEST_F(ArrowAwareAmberTest, GreenToAmberOnTurnLaneWithArrowAllowsPass)
+// ---------------------------------------------------------------------------
+// General compliance cases
+// ---------------------------------------------------------------------------
+
+TEST_F(ComplianceCheckerTest, NullMapReturnsError)
+{
+  Inputs input;
+  input.map = nullptr;
+  input.current_time = rclcpp::Time(100, 0, RCL_ROS_TIME);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error(), "Lanelet map is not set");
+}
+
+TEST_F(ComplianceCheckerTest, EmptyTrajectoryHasNoViolations)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::RED)), rclcpp::Time(100, 0, RCL_ROS_TIME));
+  input.trajectory.clear();
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithGreenCircle)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::GREEN)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, ViolationWithRedCircle)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::RED)), rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::RED_LIGHT);
+  EXPECT_EQ(result->violations.front().traffic_light_id, k_light_id);
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithRedCircleAndStopBeforeLine)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::RED)), rclcpp::Time(100, 0, RCL_ROS_TIME));
+  input.trajectory = create_stopping_trajectory(k_stop_line_x - 2.0, 10.0);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithRedCircleAndStopAtLineWithinMargin)
+{
+  params_.stop_overshoot_margin = 1.0;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::RED)), rclcpp::Time(100, 0, RCL_ROS_TIME));
+  input.trajectory = create_stopping_trajectory(k_stop_line_x + 0.5, 10.0);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, ViolationWithAmberCircle)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::AMBER)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithAmberCircle)
+{
+  params_.crossing_time_limit = 10.0;
+  params_.deceleration_limit = 0.1;  // cannot stop before the line
+  params_.jerk_limit = 0.1;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::AMBER)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithAmberCircleAndStopBeforeLine)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::AMBER)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  input.trajectory = create_stopping_trajectory(k_stop_line_x - 2.0, 10.0);
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, ViolationWithAmberTreatedAsRed)
+{
+  params_.treat_amber_light_as_red_light = true;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::AMBER)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::RED_LIGHT);
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithUnknown)
+{
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::UNKNOWN)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+TEST_F(ComplianceCheckerTest, ViolationWithUnknownTreatedAsRed)
+{
+  params_.treat_unknown_light_as_red_light = true;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::UNKNOWN)),
+    rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->violations.empty());
+  EXPECT_EQ(result->violations.front().type, ViolationType::RED_LIGHT);
+}
+
+TEST_F(ComplianceCheckerTest, NoViolationWithAllowIfCannotStopNearLine)
+{
+  params_.allow_if_cannot_stop_distance = 40.0;
+  params_.checked_trajectory_length.deceleration_limit = 0.1;
+  params_.checked_trajectory_length.jerk_limit = 0.1;
+  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
+
+  auto map = create_map();
+  auto input = make_inputs(
+    map, make_signals(make_element(TrafficLightElement::RED)), rclcpp::Time(100, 0, RCL_ROS_TIME));
+  const auto result = checker_->check(input, true, true);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->violations.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Arrow-aware amber passing cases
+// ---------------------------------------------------------------------------
+
+TEST_F(ComplianceCheckerTest, NoViolationWithArrowAwareGreenToAmber)
 {
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
   const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
@@ -226,7 +419,7 @@ TEST_F(ArrowAwareAmberTest, GreenToAmberOnTurnLaneWithArrowAllowsPass)
   EXPECT_TRUE(result->violations.empty());
 }
 
-TEST_F(ArrowAwareAmberTest, RedToAmberStillViolates)
+TEST_F(ComplianceCheckerTest, ViolationWithArrowAwareRedToAmber)
 {
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
   const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
@@ -241,7 +434,7 @@ TEST_F(ArrowAwareAmberTest, RedToAmberStillViolates)
   EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
 }
 
-TEST_F(ArrowAwareAmberTest, NonTurnLaneStillViolates)
+TEST_F(ComplianceCheckerTest, ViolationWithArrowAwareNonTurnLane)
 {
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
   const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
@@ -257,7 +450,7 @@ TEST_F(ArrowAwareAmberTest, NonTurnLaneStillViolates)
   EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
 }
 
-TEST_F(ArrowAwareAmberTest, NoStaticArrowStillViolates)
+TEST_F(ComplianceCheckerTest, ViolationWithArrowAwareNoStaticArrow)
 {
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
   const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
@@ -272,25 +465,7 @@ TEST_F(ArrowAwareAmberTest, NoStaticArrowStillViolates)
   EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
 }
 
-TEST_F(ArrowAwareAmberTest, FeatureDisabledStillViolates)
-{
-  params_.enable_arrow_aware_amber_passing = false;
-  checker_ = std::make_unique<TrafficLightComplianceChecker>(params_, make_vehicle_info());
-
-  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
-  const rclcpp::Time t1(100, 200000000, RCL_ROS_TIME);
-
-  feed_signal(make_signals(make_element(TrafficLightElement::GREEN)), t0);
-
-  auto map = create_map("right", true);
-  auto input = make_inputs(map, make_signals(make_element(TrafficLightElement::AMBER)), t1);
-  const auto result = checker_->check(input, true, true);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_FALSE(result->violations.empty());
-  EXPECT_EQ(result->violations.front().type, ViolationType::AMBER_LIGHT);
-}
-
-TEST_F(ArrowAwareAmberTest, GreenRightArrowAllowsPass)
+TEST_F(ComplianceCheckerTest, NoViolationWithGreenRightArrow)
 {
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
 

--- a/common/autoware_traffic_light_compliance_checker/test/test_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_status_tracker.cpp
@@ -24,9 +24,9 @@
 
 namespace
 {
+using autoware::traffic_light_compliance_checker::AmberState;
 using autoware::traffic_light_compliance_checker::StatusTrackerParameters;
 using autoware::traffic_light_compliance_checker::TrafficLightStatusTracker;
-using autoware::traffic_light_compliance_checker::YellowState;
 using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
@@ -77,10 +77,10 @@ TEST(TrafficLightStatusTrackerTest, GreenToAmberSetsFromGreen)
   constexpr int64_t id = 42;
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kNotAmber);
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kFromGreen);
 }
 
 TEST(TrafficLightStatusTrackerTest, RedToAmberSetsFromNonGreen)
@@ -92,17 +92,17 @@ TEST(TrafficLightStatusTrackerTest, RedToAmberSetsFromNonGreen)
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::RED)), t0);
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromNonGreen);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kFromNonGreen);
 }
 
-TEST(TrafficLightStatusTrackerTest, AmberWithoutHistoryStaysNotYellow)
+TEST(TrafficLightStatusTrackerTest, AmberWithoutHistoryStaysNotAmber)
 {
   TrafficLightStatusTracker tracker(make_params());
   const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
   constexpr int64_t id = 42;
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t0);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kNotAmber);
 }
 
 TEST(TrafficLightStatusTrackerTest, StateResetsWhenAmberEnds)
@@ -115,10 +115,10 @@ TEST(TrafficLightStatusTrackerTest, StateResetsWhenAmberEnds)
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kFromGreen);
 
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::RED)), t2);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kNotAmber);
 }
 
 TEST(TrafficLightStatusTrackerTest, AmberStatePersistsAcrossFrames)
@@ -132,5 +132,5 @@ TEST(TrafficLightStatusTrackerTest, AmberStatePersistsAcrossFrames)
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
   update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t2);
-  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+  EXPECT_EQ(tracker.get_amber_transition_state(id), AmberState::kFromGreen);
 }

--- a/common/autoware_traffic_light_compliance_checker/test/test_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/test/test_status_tracker.cpp
@@ -1,0 +1,136 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+using autoware::traffic_light_compliance_checker::StatusTrackerParameters;
+using autoware::traffic_light_compliance_checker::TrafficLightStatusTracker;
+using autoware::traffic_light_compliance_checker::YellowState;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+TrafficLightElement make_element(uint8_t color, uint8_t shape = TrafficLightElement::CIRCLE)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = 1.0f;
+  return element;
+}
+
+TrafficLightGroupArray make_signals(int64_t id, const TrafficLightElement & element)
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  group.elements.push_back(element);
+
+  TrafficLightGroupArray signals;
+  signals.traffic_light_groups.push_back(group);
+  return signals;
+}
+
+StatusTrackerParameters make_params()
+{
+  StatusTrackerParameters params{};
+  params.stable_duration_threshold_red = 0.0;
+  params.stable_duration_threshold_amber = 0.0;
+  params.stable_duration_threshold_unknown = 0.0;
+  return params;
+}
+
+void update_tracker(
+  TrafficLightStatusTracker & tracker, const TrafficLightGroupArray & signals,
+  const rclcpp::Time & time)
+{
+  [[maybe_unused]] const auto filtered = tracker.filter_signals(signals, time, false);
+}
+}  // namespace
+
+TEST(TrafficLightStatusTrackerTest, GreenToAmberSetsFromGreen)
+{
+  TrafficLightStatusTracker tracker(make_params());
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 100000000, RCL_ROS_TIME);
+  constexpr int64_t id = 42;
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+}
+
+TEST(TrafficLightStatusTrackerTest, RedToAmberSetsFromNonGreen)
+{
+  TrafficLightStatusTracker tracker(make_params());
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 100000000, RCL_ROS_TIME);
+  constexpr int64_t id = 42;
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::RED)), t0);
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromNonGreen);
+}
+
+TEST(TrafficLightStatusTrackerTest, AmberWithoutHistoryStaysNotYellow)
+{
+  TrafficLightStatusTracker tracker(make_params());
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  constexpr int64_t id = 42;
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t0);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+}
+
+TEST(TrafficLightStatusTrackerTest, StateResetsWhenAmberEnds)
+{
+  TrafficLightStatusTracker tracker(make_params());
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 100000000, RCL_ROS_TIME);
+  const rclcpp::Time t2(100, 200000000, RCL_ROS_TIME);
+  constexpr int64_t id = 42;
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::RED)), t2);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kNotYellow);
+}
+
+TEST(TrafficLightStatusTrackerTest, AmberStatePersistsAcrossFrames)
+{
+  TrafficLightStatusTracker tracker(make_params());
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  const rclcpp::Time t1(100, 100000000, RCL_ROS_TIME);
+  const rclcpp::Time t2(100, 200000000, RCL_ROS_TIME);
+  constexpr int64_t id = 42;
+
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::GREEN)), t0);
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t1);
+  update_tracker(tracker, make_signals(id, make_element(TrafficLightElement::AMBER)), t2);
+  EXPECT_EQ(tracker.get_yellow_transition_state(id), YellowState::kFromGreen);
+}

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -95,7 +95,6 @@
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
       th_stable_duration_unknown: 0.5 # [s]
-      th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
       amber_rejection:
         th_hysteresis: 0.5 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -89,7 +89,7 @@
       stop_for_amber_light: false
       treat_amber_light_as_red: false
       treat_unknown_light_as_red: true
-      enable_arrow_aware_yellow_passing: true # allow Green->Amber on turn lanes with mapped static arrow
+      enable_arrow_aware_amber_passing: true # allow Green->Amber on turn lanes with mapped static arrow
       overshoot_tolerance: 0.5 # [m]
       allow_if_cannot_stop_distance: 1.0 # [m]
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -89,6 +89,7 @@
       stop_for_amber_light: false
       treat_amber_light_as_red: false
       treat_unknown_light_as_red: true
+      enable_arrow_aware_yellow_passing: true # allow Green->Amber on turn lanes with mapped static arrow
       overshoot_tolerance: 0.5 # [m]
       allow_if_cannot_stop_distance: 1.0 # [m]
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -88,14 +88,18 @@
       stop_for_red_light: true
       stop_for_amber_light: false
       treat_amber_light_as_red: false
-      treat_unknown_light_as_red: false
-      overshoot_tolerance: 0.0 # [m]
-      allow_if_cannot_stop_distance: 0.0 # [m]
+      treat_unknown_light_as_red: true
+      overshoot_tolerance: 0.5 # [m]
+      allow_if_cannot_stop_distance: 1.0 # [m]
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
+      th_stable_duration_unknown: 0.5 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
+      amber_rejection:
+        th_hysteresis: 0.5 # [s]
+        reject_if_stop_detected: true # reject if we detect a previous stop attempt from input trajectory
 
     # Surround Obstacle Stop Plugin Parameters
     surround_obstacle_stop:

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -411,7 +411,7 @@ trajectory_modifier_params:
       default_value: true
       description: Treat unknown light as red light
       read_only: false
-    enable_arrow_aware_yellow_passing:
+    enable_arrow_aware_amber_passing:
       type: bool
       default_value: true
       description: Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -411,6 +411,11 @@ trajectory_modifier_params:
       default_value: true
       description: Treat unknown light as red light
       read_only: false
+    enable_arrow_aware_yellow_passing:
+      type: bool
+      default_value: true
+      description: Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow
+      read_only: false
     overshoot_tolerance:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -408,7 +408,7 @@ trajectory_modifier_params:
       read_only: false
     treat_unknown_light_as_red:
       type: bool
-      default_value: false
+      default_value: true
       description: Treat unknown light as red light
       read_only: false
     overshoot_tolerance:
@@ -420,7 +420,7 @@ trajectory_modifier_params:
       read_only: false
     allow_if_cannot_stop_distance:
       type: double
-      default_value: 0.0
+      default_value: 1.0
       description: allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]
       validation:
         bounds<>: [0.0, 100.0]
@@ -446,10 +446,10 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
-    th_amber_rejection_hysteresis:
+    th_stable_duration_unknown:
       type: double
       default_value: 0.5
-      description: Threshold for amber rejection hysteresis [s]
+      description: Threshold for stable duration of unknown light [s]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
@@ -460,6 +460,19 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    amber_rejection:
+      th_hysteresis:
+        type: double
+        default_value: 0.5
+        description: Threshold for amber rejection hysteresis [s]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      reject_if_stop_detected:
+        type: bool
+        default_value: true
+        description: Reject if we detect a previous stop attempt from input trajectory
+        read_only: false
 
   surround_obstacle_stop:
     use_objects:

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -453,7 +453,7 @@
               "description": "Treat unknown light as red light",
               "default": true
             },
-            "enable_arrow_aware_yellow_passing": {
+            "enable_arrow_aware_amber_passing": {
               "type": "boolean",
               "description": "Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow (protected turn phase)",
               "default": true

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -451,18 +451,18 @@
             "treat_unknown_light_as_red": {
               "type": "boolean",
               "description": "Treat unknown light as red light",
-              "default": false
+              "default": true
             },
             "overshoot_tolerance": {
               "type": "number",
               "description": "Overshoot tolerance [m]",
-              "default": 0.0,
+              "default": 0.5,
               "minimum": 0.0
             },
             "allow_if_cannot_stop_distance": {
               "type": "number",
               "description": "allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]",
-              "default": 0.0,
+              "default": 1.0,
               "minimum": 0.0
             },
             "min_lookahead_distance": {
@@ -483,9 +483,9 @@
               "default": 0.2,
               "minimum": 0.0
             },
-            "th_amber_rejection_hysteresis": {
+            "th_stable_duration_unknown": {
               "type": "number",
-              "description": "Threshold for amber rejection hysteresis [s]",
+              "description": "Threshold for stable duration of unknown light [s]",
               "default": 0.5,
               "minimum": 0.0
             },
@@ -494,6 +494,24 @@
               "description": "Crossing time limit [s]",
               "default": 2.75,
               "minimum": 0.0
+            },
+            "amber_rejection": {
+              "type": "object",
+              "properties": {
+                "th_hysteresis": {
+                  "type": "number",
+                  "description": "Threshold for amber rejection hysteresis [s]",
+                  "default": 0.5,
+                  "minimum": 0.0
+                },
+                "reject_if_stop_detected": {
+                  "type": "boolean",
+                  "description": "Reject if we detect a previous stop attempt from input trajectory",
+                  "default": true
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -453,6 +453,11 @@
               "description": "Treat unknown light as red light",
               "default": true
             },
+            "enable_arrow_aware_yellow_passing": {
+              "type": "boolean",
+              "description": "Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow (protected turn phase)",
+              "default": true
+            },
             "overshoot_tolerance": {
               "type": "number",
               "description": "Overshoot tolerance [m]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -35,6 +35,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
+  p.enable_arrow_aware_yellow_passing = tl_stop_p.enable_arrow_aware_yellow_passing;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -35,7 +35,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
-  p.enable_arrow_aware_yellow_passing = tl_stop_p.enable_arrow_aware_yellow_passing;
+  p.enable_arrow_aware_amber_passing = tl_stop_p.enable_arrow_aware_amber_passing;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -118,7 +118,11 @@ bool TrafficLightStop::check_traffic_lights(
 
   const auto result =
     checker_->check(inputs, params_.stop_for_red_light, params_.stop_for_amber_light);
-  if (!result) return false;
+  if (!result) {
+    RCLCPP_ERROR(
+      get_node_ptr()->get_logger(), "Failed to check traffic lights: %s", result.error().c_str());
+    return false;
+  }
 
   if (result->violations.empty()) return false;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -28,15 +28,17 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
 {
   const auto tl_stop_p = params.traffic_light_stop;
   const auto stopping_params = params.stopping_constraints;
-  autoware::traffic_light_compliance_checker::Parameters p;
+  autoware::traffic_light_compliance_checker::Parameters p{};
   p.deceleration_limit = stopping_params.maximum_deceleration;
   p.jerk_limit = stopping_params.jerk_limit;
+  p.delay_response_time = 0.0;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
+  p.ego_stopped_velocity_threshold = 0.01;
   p.status_tracker_parameters.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.status_tracker_parameters.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.status_tracker_parameters.stable_duration_threshold_unknown =

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -37,9 +37,12 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
-  p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
-  p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
-  p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;
+  p.status_tracker_parameters.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
+  p.status_tracker_parameters.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
+  p.status_tracker_parameters.stable_duration_threshold_unknown =
+    tl_stop_p.th_stable_duration_unknown;
+  p.amber_rejection.hysteresis_duration = tl_stop_p.amber_rejection.th_hysteresis;
+  p.amber_rejection.reject_if_stop_detected = tl_stop_p.amber_rejection.reject_if_stop_detected;
   p.checked_trajectory_length.deceleration_limit = stopping_params.nominal_deceleration;
   p.checked_trajectory_length.jerk_limit = stopping_params.jerk_limit;
   return p;

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -89,6 +89,17 @@ TrajectoryPoints create_straight_trajectory(
   return trajectory;
 }
 
+/// Trajectory that cruises then ends with zero velocity at stop_x (stop attempt).
+TrajectoryPoints create_trajectory_with_stop_at(
+  double start_x, double stop_x, double cruise_velocity, double spacing = 1.0)
+{
+  auto trajectory = create_straight_trajectory(start_x, stop_x, cruise_velocity, spacing);
+  if (!trajectory.empty()) {
+    trajectory.back().longitudinal_velocity_mps = 0.0F;
+  }
+  return trajectory;
+}
+
 Odometry::ConstSharedPtr make_odometry(
   double x, double y, double velocity, const rclcpp::Time & stamp)
 {
@@ -231,6 +242,7 @@ protected:
     tl.min_lookahead_distance = 20.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
+    tl.th_stable_duration_unknown = 0.0;
     tl.amber_rejection.th_hysteresis = 0.0;
     tl.amber_rejection.reject_if_stop_detected = false;
     tl.crossing_time_limit = 2.75;
@@ -474,4 +486,59 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithUnknownLightAsRedL
   const bool modified = plugin_->modify_trajectory(trajectory, make_default_input(10.0));
   EXPECT_TRUE(modified)
     << "Unknown treated as red should insert stop point even when not stoppable";
+}
+
+TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithAmberLightWhenPreviousStopIsDetected)
+{
+  const lanelet::Id light_id = 400;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  params_.traffic_light_stop.amber_rejection.reject_if_stop_detected = true;
+  params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
+  params_.traffic_light_stop.overshoot_tolerance = 0.5;
+  params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
+  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  plugin_->update_params(params_);
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  auto stopping_trajectory = create_trajectory_with_stop_at(0.0, stop_x - ego_front_offset, 5.0);
+  expect_not_modified(
+    stopping_trajectory, make_default_input(5.0),
+    "Input trajectory should not be modified when it already contains a valid stop point");
+
+  auto crossing_trajectory = create_straight_trajectory(0.0, 10.0, 10.0);
+  const bool modified = plugin_->modify_trajectory(crossing_trajectory, make_default_input(10.0));
+  EXPECT_TRUE(modified) << "Should modify trajectory when a prior stop attempt is detected and "
+                           "reject_if_stop_detected is true";
+  EXPECT_FLOAT_EQ(crossing_trajectory.back().longitudinal_velocity_mps, 0.0F);
+}
+
+TEST_F(TrafficLightStopIntegrationTest, TrajectoryNotModifiedWhenRejectIfStopDetectedIsDisabled)
+{
+  const lanelet::Id light_id = 401;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  params_.traffic_light_stop.amber_rejection.reject_if_stop_detected = false;
+  params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
+  params_.traffic_light_stop.overshoot_tolerance = 0.5;
+  params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
+  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  plugin_->update_params(params_);
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  auto stopping_trajectory = create_trajectory_with_stop_at(0.0, stop_x - ego_front_offset, 5.0);
+  expect_not_modified(
+    stopping_trajectory, make_default_input(5.0),
+    "Input trajectory should not be modified when it already contains a valid stop point");
+
+  auto crossing_trajectory = create_straight_trajectory(0.0, 10.0, 10.0);
+  expect_not_modified(
+    crossing_trajectory, make_default_input(10.0),
+    "Input trajectory should not be modified when reject_if_stop_detected is false");
 }

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -231,7 +231,8 @@ protected:
     tl.min_lookahead_distance = 20.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
-    tl.th_amber_rejection_hysteresis = 0.0;
+    tl.amber_rejection.th_hysteresis = 0.0;
+    tl.amber_rejection.reject_if_stop_detected = false;
     tl.crossing_time_limit = 2.75;
   }
 

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -131,7 +131,7 @@
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights
-      enable_arrow_aware_yellow_passing: true # [-] allow Green->Amber on turn lanes with mapped static arrow
+      enable_arrow_aware_amber_passing: true # [-] allow Green->Amber on turn lanes with mapped static arrow
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
       allow_if_cannot_stop_distance: 0.0 # [m] allow crossing a stop line within this distance if ego cannot stop before the line plus its margin
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -131,6 +131,7 @@
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights
+      enable_arrow_aware_yellow_passing: true # [-] allow Green->Amber on turn lanes with mapped static arrow
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
       allow_if_cannot_stop_distance: 0.0 # [m] allow crossing a stop line within this distance if ego cannot stop before the line plus its margin
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -137,11 +137,13 @@
       stable_duration_threshold_red: 0.0 # [s] minimum duration a red light must be seen before it is considered active
       stable_duration_threshold_amber: 0.0 # [s] minimum duration an amber light must be seen before it is considered active
       stable_duration_threshold_unknown: 0.0 # [s] minimum duration an unknown light must be seen before it is considered active
-      amber_rejection_hysteresis_duration: 0.0 # [s] duration to persist an amber rejection
       ego_stopped_velocity_threshold: 0.01 # [m/s] velocity below which ego is considered fully stopped
       checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
         deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
         jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+      amber_rejection:
+        hysteresis_duration: 0.0 # [s] hysteresis duration to persist an AMBER rejection
+        reject_if_stop_detected: false # reject if we detect a previous stop attempt from input trajectory
 
     boundary_departure:
       boundary_types: ["road_border"]

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -434,6 +434,11 @@ validator:
       default_value: false
       description: when true, unknown lights are handled like red lights
       read_only: false
+    enable_arrow_aware_yellow_passing:
+      type: bool
+      default_value: true
+      description: Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow
+      read_only: false
     stop_overshoot_margin:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -434,7 +434,7 @@ validator:
       default_value: false
       description: when true, unknown lights are handled like red lights
       read_only: false
-    enable_arrow_aware_yellow_passing:
+    enable_arrow_aware_amber_passing:
       type: bool
       default_value: true
       description: Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -468,11 +468,6 @@ validator:
       default_value: 0.0
       description: Minimum duration an UNKNOWN signal must be seen before it is considered active (seconds)
       read_only: false
-    amber_rejection_hysteresis_duration:
-      type: double
-      default_value: 0.0
-      description: Hysteresis duration to persist an AMBER rejection (seconds)
-      read_only: false
     ego_stopped_velocity_threshold:
       type: double
       default_value: 0.01
@@ -488,6 +483,17 @@ validator:
         type: double
         default_value: 2.0
         description: jerk limit to calculate the stop distance used as trajectory length limit
+        read_only: false
+    amber_rejection:
+      hysteresis_duration:
+        type: double
+        default_value: 0.0
+        description: Hysteresis duration to persist an AMBER rejection (seconds)
+        read_only: false
+      reject_if_stop_detected:
+        type: bool
+        default_value: false
+        description: Reject if we detect a previous stop attempt from input trajectory
         read_only: false
 
   boundary_departure:

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -634,12 +634,6 @@
               "default": 0.0,
               "minimum": 0.0
             },
-            "amber_rejection_hysteresis_duration": {
-              "type": "number",
-              "description": "Duration to persist an AMBER rejection state to prevent flipping [s].",
-              "default": 0.0,
-              "minimum": 0.0
-            },
             "ego_stopped_velocity_threshold": {
               "type": "number",
               "description": "Velocity threshold below which stability and hysteresis filters are bypassed [m/s].",
@@ -658,6 +652,24 @@
                   "type": "number",
                   "description": "Jerk limit used together with `deceleration_limit` to compute the trajectory scan length [m/s³].",
                   "default": 2.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "amber_rejection": {
+              "type": "object",
+              "properties": {
+                "hysteresis_duration": {
+                  "type": "number",
+                  "description": "Hysteresis duration to persist an AMBER rejection [s].",
+                  "default": 0.0,
+                  "minimum": 0.0
+                },
+                "reject_if_stop_detected": {
+                  "type": "boolean",
+                  "description": "Reject if we detect a previous stop attempt from input trajectory.",
+                  "default": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -598,7 +598,7 @@
               "description": "When true, UNKNOWN lights are treated identically to red lights.",
               "default": false
             },
-            "enable_arrow_aware_yellow_passing": {
+            "enable_arrow_aware_amber_passing": {
               "type": "boolean",
               "description": "Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow (protected turn phase).",
               "default": true

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -598,6 +598,11 @@
               "description": "When true, UNKNOWN lights are treated identically to red lights.",
               "default": false
             },
+            "enable_arrow_aware_yellow_passing": {
+              "type": "boolean",
+              "description": "Allow passing on amber after Green Circle when on a turn lane with a mapped static arrow (protected turn phase).",
+              "default": true
+            },
             "stop_overshoot_margin": {
               "type": "number",
               "description": "Maximum allowed distance between the trajectory's stop point and the stop line for the trajectory to be considered as stopping correctly [m].",

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -85,14 +85,17 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.stop_overshoot_margin = params.stop_overshoot_margin;
   p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = params.min_lookahead_distance;
-  p.stable_duration_threshold_red = params.stable_duration_threshold_red;
-  p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
-  p.stable_duration_threshold_unknown = params.stable_duration_threshold_unknown;
-  p.amber_rejection_hysteresis_duration = params.amber_rejection_hysteresis_duration;
+  p.status_tracker_parameters.stable_duration_threshold_red = params.stable_duration_threshold_red;
+  p.status_tracker_parameters.stable_duration_threshold_amber =
+    params.stable_duration_threshold_amber;
+  p.status_tracker_parameters.stable_duration_threshold_unknown =
+    params.stable_duration_threshold_unknown;
   p.ego_stopped_velocity_threshold = params.ego_stopped_velocity_threshold;
   p.checked_trajectory_length.deceleration_limit =
     params.checked_trajectory_length.deceleration_limit;
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
+  p.amber_rejection.hysteresis_duration = params.amber_rejection.hysteresis_duration;
+  p.amber_rejection.reject_if_stop_detected = params.amber_rejection.reject_if_stop_detected;
   return p;
 }
 }  // namespace

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -82,6 +82,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.crossing_time_limit = params.crossing_time_limit;
   p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
   p.treat_unknown_light_as_red_light = params.treat_unknown_light_as_red_light;
+  p.enable_arrow_aware_yellow_passing = params.enable_arrow_aware_yellow_passing;
   p.stop_overshoot_margin = params.stop_overshoot_margin;
   p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = params.min_lookahead_distance;

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -82,7 +82,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.crossing_time_limit = params.crossing_time_limit;
   p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
   p.treat_unknown_light_as_red_light = params.treat_unknown_light_as_red_light;
-  p.enable_arrow_aware_yellow_passing = params.enable_arrow_aware_yellow_passing;
+  p.enable_arrow_aware_amber_passing = params.enable_arrow_aware_amber_passing;
   p.stop_overshoot_margin = params.stop_overshoot_margin;
   p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = params.min_lookahead_distance;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -57,6 +57,7 @@ protected:
     params_.traffic_light.crossing_time_limit = 2.75;
     params_.traffic_light.treat_amber_light_as_red_light = false;
     params_.traffic_light.treat_unknown_light_as_red_light = false;
+    params.traffic_light.enable_arrow_aware_yellow_passing = true;
     params_.traffic_light.stable_duration_threshold_red = 0.0;
     params_.traffic_light.stable_duration_threshold_amber = 0.0;
     params_.traffic_light.stable_duration_threshold_unknown = 0.0;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -57,7 +57,7 @@ protected:
     params_.traffic_light.crossing_time_limit = 2.75;
     params_.traffic_light.treat_amber_light_as_red_light = false;
     params_.traffic_light.treat_unknown_light_as_red_light = false;
-    params.traffic_light.enable_arrow_aware_yellow_passing = true;
+    params_.traffic_light.enable_arrow_aware_amber_passing = true;
     params_.traffic_light.stable_duration_threshold_red = 0.0;
     params_.traffic_light.stable_duration_threshold_amber = 0.0;
     params_.traffic_light.stable_duration_threshold_unknown = 0.0;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -162,6 +162,17 @@ protected:
     return points;
   }
 
+  /// Trajectory that cruises then ends with zero velocity at stop_x (stop attempt).
+  static std::vector<TrajectoryPoint> create_trajectory_with_stop_at(
+    double start_x, double stop_x, float cruise_velocity = 5.0)
+  {
+    auto points = create_trajectory(start_x, stop_x, cruise_velocity);
+    if (!points.empty()) {
+      points.back().longitudinal_velocity_mps = 0.0F;
+    }
+    return points;
+  }
+
   void set_ego_motion(const double velocity, const double acceleration)
   {
     auto odometry = std::make_shared<nav_msgs::msg::Odometry>(*context_.odometry);
@@ -779,6 +790,59 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
 
   // Now it should be feasible if it cannot stop
   expect_feasibility(points2, true, "Should be feasible after hysteresis duration");
+}
+
+TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightWhenPreviousStopIsDetected)
+{
+  const lanelet::Id light_id = 501;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  auto params = params_;
+  params.traffic_light.amber_rejection.reject_if_stop_detected = true;
+  params.traffic_light.amber_rejection.hysteresis_duration = 5.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
+  params.traffic_light.crossing_time_limit = 100.0;
+  filter_->update_parameters(params);
+
+  auto stopping_points = create_trajectory_with_stop_at(0.0, stop_x, 5.0);
+  expect_feasibility(
+    stopping_points, true, "Should be feasible when trajectory stops within threshold");
+
+  set_ego_motion(10.0, 0.0);
+  auto crossing_points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    crossing_points, false,
+    "Should be infeasible after a prior stop attempt while reject_if_stop_detected is true");
+}
+
+TEST_F(TrafficLightFilterTest, IsFeasibleWhenRejectIfStopDetectedIsDisabled)
+{
+  const lanelet::Id light_id = 502;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+
+  auto params = params_;
+  params.traffic_light.amber_rejection.reject_if_stop_detected = false;
+  params.traffic_light.amber_rejection.hysteresis_duration = 5.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
+  params.traffic_light.crossing_time_limit = 100.0;
+  filter_->update_parameters(params);
+
+  auto stopping_points = create_trajectory_with_stop_at(0.0, stop_x, 5.0);
+  expect_feasibility(
+    stopping_points, true, "Should be feasible when trajectory stops within threshold");
+
+  set_ego_motion(10.0, 0.0);
+  auto crossing_points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    crossing_points, true, "Should be feasible when reject_if_stop_detected is false");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -51,38 +51,23 @@ protected:
     vehicle_info.max_longitudinal_offset_m = 0.0;
     filter_->set_vehicle_info(vehicle_info);
 
-    // Initialize default parameters
-    node_->declare_parameter("traffic_light.deceleration_limit", 2.8);
-    node_->declare_parameter("traffic_light.jerk_limit", 5.0);
-    node_->declare_parameter("traffic_light.delay_response_time", 0.5);
-    node_->declare_parameter("traffic_light.crossing_time_limit", 2.75);
-    node_->declare_parameter("traffic_light.treat_amber_light_as_red_light", false);
-    node_->declare_parameter("traffic_light.treat_unknown_light_as_red_light", false);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_red", 0.0);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_amber", 0.0);
-    node_->declare_parameter("traffic_light.stable_duration_threshold_unknown", 0.0);
-    node_->declare_parameter("traffic_light.amber_rejection_hysteresis_duration", 0.0);
-    node_->declare_parameter("traffic_light.ego_stopped_velocity_threshold", 0.01);
-    node_->declare_parameter("traffic_light.min_lookahead_distance", 20.0);
-    node_->declare_parameter("traffic_light.checked_trajectory_length.deceleration_limit", 999.9);
-    node_->declare_parameter("traffic_light.checked_trajectory_length.jerk_limit", 999.9);
-
-    validator::Params params;
-    params.traffic_light.deceleration_limit = 2.8;
-    params.traffic_light.jerk_limit = 5.0;
-    params.traffic_light.delay_response_time = 0.5;
-    params.traffic_light.crossing_time_limit = 2.75;
-    params.traffic_light.treat_amber_light_as_red_light = false;
-    params.traffic_light.treat_unknown_light_as_red_light = false;
-    params.traffic_light.stable_duration_threshold_red = 0.0;
-    params.traffic_light.stable_duration_threshold_amber = 0.0;
-    params.traffic_light.stable_duration_threshold_unknown = 0.0;
-    params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-    params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-    params.traffic_light.min_lookahead_distance = 20.0;
-    params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-    params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
-    filter_->update_parameters(params);
+    params_.traffic_light.deceleration_limit = 2.8;
+    params_.traffic_light.jerk_limit = 5.0;
+    params_.traffic_light.delay_response_time = 0.5;
+    params_.traffic_light.crossing_time_limit = 2.75;
+    params_.traffic_light.treat_amber_light_as_red_light = false;
+    params_.traffic_light.treat_unknown_light_as_red_light = false;
+    params_.traffic_light.stable_duration_threshold_red = 0.0;
+    params_.traffic_light.stable_duration_threshold_amber = 0.0;
+    params_.traffic_light.stable_duration_threshold_unknown = 0.0;
+    params_.traffic_light.amber_rejection.hysteresis_duration = 0.0;
+    params_.traffic_light.amber_rejection.reject_if_stop_detected = false;
+    params_.traffic_light.ego_stopped_velocity_threshold = 0.01;
+    params_.traffic_light.min_lookahead_distance = 20.0;
+    params_.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+    params_.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+    params_.traffic_light.stop_overshoot_margin = 0.5;
+    filter_->update_parameters(params_);
 
     context_.traffic_light_signals = std::make_shared<TrafficLightGroupArray>();
     context_.route = std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
@@ -203,6 +188,7 @@ protected:
   std::shared_ptr<TrafficLightFilter> filter_;
   std::shared_ptr<rclcpp::Node> node_;
   FilterContext context_;
+  validator::Params params_;
 };
 
 TEST_F(TrafficLightFilterTest, HandlesEmptyTrajectorySafely)
@@ -332,14 +318,8 @@ TEST_F(TrafficLightFilterTest, AllowsCrossingIfEgoFrontIsTooCloseToStop)
   vehicle_info.max_longitudinal_offset_m = 2.0;
   filter_->set_vehicle_info(vehicle_info);
 
-  validator::Params params;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.stop_overshoot_margin = 0.5;
+  auto params = params_;
   params.traffic_light.allow_if_cannot_stop_distance = 4.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -367,14 +347,9 @@ TEST_F(TrafficLightFilterTest, AllowsCrossingWhenEgoFrontHasPassedStopLine)
   vehicle_info.max_longitudinal_offset_m = 5.0;
   filter_->set_vehicle_info(vehicle_info);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 1.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 3.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -393,14 +368,9 @@ TEST_F(TrafficLightFilterTest, RejectsCrossingWhenEgoCanStopSafely)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 2.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 5.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -420,22 +390,16 @@ TEST_F(TrafficLightFilterTest, RejectsAtStoppingDistanceBoundary)
   constexpr double deceleration_limit = 5.0;
   constexpr double jerk_limit = 2.0;
   constexpr double delay_response_time = 2.0;
-  constexpr double stop_overshoot_margin = 0.5;
   // Ego naturally stops after exactly 1.0 m during the response delay, so the stop line at
-  // 0.5 m is exactly stopping_distance - stop_overshoot_margin.
+  // 0.5 m is exactly stopping_distance - stop_overshoot_margin (0.5 from SetUp).
   constexpr double stop_x = 0.5;
 
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = delay_response_time;
-  params.traffic_light.stop_overshoot_margin = stop_overshoot_margin;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = deceleration_limit;
   params.traffic_light.checked_trajectory_length.jerk_limit = jerk_limit;
   filter_->update_parameters(params);
@@ -454,14 +418,9 @@ TEST_F(TrafficLightFilterTest, RejectsWhenStoppingDistanceIsUnavailable)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 0.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
   params.traffic_light.allow_if_cannot_stop_distance = 10.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 0.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -480,14 +439,8 @@ TEST_F(TrafficLightFilterTest, RejectsWithZeroCannotStopAllowance)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.delay_response_time = 1.0;
-  params.traffic_light.stop_overshoot_margin = 0.5;
-  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
   params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
   params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
   filter_->update_parameters(params);
@@ -556,11 +509,10 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
   // This is a scenario where ego can stop and cannot pass.
 
   // Let's adjust params to create the desired scenario.
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.deceleration_limit = -0.5;  // Very weak braking
   params.traffic_light.delay_response_time = 1.0;
   params.traffic_light.crossing_time_limit = 1.0;  // Short amber
-  params.traffic_light.treat_amber_light_as_red_light = false;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 200.0, 10.0);
@@ -576,18 +528,8 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_amber_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Even if it's NOT stoppable (ego at 0m, velocity 10m/s, stop at 5m),
@@ -607,18 +549,8 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithUnknownLightAsRedLight)
   create_and_set_map(light_id, stop_x);
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
-  params.traffic_light.stable_duration_threshold_unknown = 0.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Crossing unknown light when treat_unknown_light_as_red_light is true
@@ -643,18 +575,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithUnknownStabilityFiltering)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
@@ -677,18 +600,10 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleAfterUnknownStableDurationThreshold)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
   params.traffic_light.stable_duration_threshold_amber = 5.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
@@ -710,18 +625,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleAfterUnknownStableDurationThresholdFr
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
@@ -753,18 +659,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithUnknownStabilityFilteringWhenEgoS
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
-  params.traffic_light.stable_duration_threshold_amber = 0.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   nav_msgs::msg::Odometry odometry = *context_.odometry;
@@ -785,18 +682,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithUnknownSignalHistoryCleanup)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
+  auto params = params_;
   params.traffic_light.treat_unknown_light_as_red_light = true;
-  params.traffic_light.stable_duration_threshold_red = 0.0;
   params.traffic_light.stable_duration_threshold_amber = 5.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0, 5.0);
@@ -823,18 +712,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
-  params.traffic_light.treat_amber_light_as_red_light = false;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;  // 1 second stability
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Set initial state to GREEN
@@ -871,15 +752,8 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
 
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
-  params.traffic_light.deceleration_limit = 2.8;
-  params.traffic_light.delay_response_time = 0.5;
-  params.traffic_light.crossing_time_limit = 2.75;
-  params.traffic_light.treat_amber_light_as_red_light = false;
-  params.traffic_light.amber_rejection_hysteresis_duration = 2.0;  // 2 seconds hysteresis
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  auto params = params_;
+  params.traffic_light.amber_rejection.hysteresis_duration = 2.0;  // 2 seconds hysteresis
   filter_->update_parameters(params);
 
   // Ego at 0m, velocity 5m/s. Stoppable.
@@ -913,13 +787,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
   const double stop_x = 5.0;
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0);
@@ -948,13 +819,10 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalStateChange)
   const double stop_x = 5.0;
   create_and_set_map(light_id, stop_x);
 
-  validator::Params params;
+  auto params = params_;
   params.traffic_light.stable_duration_threshold_red = 1.0;
   params.traffic_light.stable_duration_threshold_amber = 1.0;
   params.traffic_light.stable_duration_threshold_unknown = 1.0;
-  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   auto points = create_trajectory(0.0, 10.0);


### PR DESCRIPTION
## Description
- Add arrow-aware decisions in `traffic_light_compliance_checker` so Green Circle → Amber on protected turn lanes with a mapped static arrow does not produce false stop/violations while waiting for the green turn arrow.
- Harden `TrafficLightStatusTracker` to keep emitting the last stable signal while red/amber/unknown candidates settle, instead of clearing elements; update amber transition state only when a new stable status is accepted.
- Add unit tests for `TrafficLightComplianceChecker` and `TrafficLightStatusTracker`

### Changes
- added `AmberState` enum: `{kNotAmber, kFromGreen, kFromNonGreen}` to classify the transition into amber
- added parameter `enable_arrow_aware_amber_passing` and wired through modifier's `traffic_light_stop` and validator's `traffic_light_filter`
- `TrafficLightStatusTracker`:
  - modified history to track `current_state`, optional `stable_state`, and `amber_transition_state`
  - modified `filter_signals()` to emit last stable state (return raw state when ego is stopped)
  - added function `update_amber_transition_state()`  to set the amber transition state for stable traffic light status
  - added interface function `get_amber_transition_state()` to inquire amber transition status
- Added utility helper functions (`utils.hpp` / `utils.cpp`)
- modified `collect_stop_lines()` to skips stop-line collection when arrow-aware amber pass conditions hold

## How was this PR tested?
- LSIM

**before:**

[tl_08-06_15-27.webm](https://github.com/user-attachments/assets/8b693c70-1fbb-4022-9154-47dde09dc4a6)

**after:**

[tl_08-06_15-27_fixed.webm](https://github.com/user-attachments/assets/ee1b1f21-2b99-471e-97c1-1d3924a2be1f)
