### PR TITLE
feat(minimum_rule_based_planner): publish planning factor for go and stop trajectories

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
@@ -56,6 +56,25 @@ std_msgs::msg::ColorRGBA make_color(float r, float g, float b, float a)
 }
 }  // namespace
 
+const char * to_string(const StopLineType type)
+{
+  switch (type) {
+    case StopLineType::StopLine:
+      return "stop_line";
+    case StopLineType::Walkway:
+      return "walkway";
+    case StopLineType::Crosswalk:
+      return "crosswalk";
+    case StopLineType::TrafficLight:
+      return "traffic_light";
+    case StopLineType::Intersection:
+      return "intersection";
+    case StopLineType::PrivateArea:
+      return "private_area";
+  }
+  return "unknown";
+}
+
 bool is_possibility_type(StopLineType type)
 {
   switch (type) {
@@ -176,25 +195,6 @@ std::optional<lanelet::ConstLineString3d> entry_side_bound(
   if (!left_arc && !right_arc) return std::nullopt;
   if (left_arc && (!right_arc || *left_arc <= *right_arc)) return lanelet.leftBound();
   return lanelet.rightBound();
-}
-
-const char * to_string(const StopLineType type)
-{
-  switch (type) {
-    case StopLineType::StopLine:
-      return "stop_line";
-    case StopLineType::Walkway:
-      return "walkway";
-    case StopLineType::Crosswalk:
-      return "crosswalk";
-    case StopLineType::TrafficLight:
-      return "traffic_light";
-    case StopLineType::Intersection:
-      return "intersection";
-    case StopLineType::PrivateArea:
-      return "private_area";
-  }
-  return "unknown";
 }
 
 bool is_crosswalk_or_walkway(const lanelet::ConstLanelet & lanelet, bool & is_walkway)
@@ -329,9 +329,8 @@ void MapBasedStopPlanner::set_planner_data(
 }
 
 MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
-  const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose,
-  const double ego_velocity, const double ego_acceleration,
-  const StopSelectionParams & params) const
+  const Trajectory & trajectory, const double ego_arc_length, const double ego_velocity,
+  const double ego_acceleration, const StopSelectionParams & params) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -378,48 +377,53 @@ MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
   // The go trajectory stops only at mandatory targets (e.g. stop lines); the stop trajectory
   // additionally stops at possibility targets (e.g. traffic lights).
   const auto go_stop = plan_single_stop(
-    stop_lines, trajectory, ego_pose, ego_velocity, ego_acceleration, params,
+    stop_lines, trajectory, ego_arc_length, ego_velocity, ego_acceleration, params,
     /*include_possibility=*/false);
   const auto stop_stop = plan_single_stop(
-    stop_lines, trajectory, ego_pose, ego_velocity, ego_acceleration, params,
+    stop_lines, trajectory, ego_arc_length, ego_velocity, ego_acceleration, params,
     /*include_possibility=*/true);
 
-  if (go_stop) result.go_trajectory = go_stop->trajectory;
+  if (go_stop) {
+    result.go_trajectory = go_stop->trajectory;
+    result.go_stop_point = go_stop->stop_point;
+  }
 
   const bool stop_differs_from_go =
     stop_stop &&
-    (!go_stop || std::abs(stop_stop->stop_point_arc_length - go_stop->stop_point_arc_length) >
+    (!go_stop || std::abs(stop_stop->stop_point.arc_length - go_stop->stop_point.arc_length) >
                    params.stop_point_diff_threshold);
-  if (stop_differs_from_go) result.stop_trajectory = stop_stop->trajectory;
+  if (stop_differs_from_go) {
+    result.stop_trajectory = stop_stop->trajectory;
+    result.stop_stop_point = stop_stop->stop_point;
+  }
 
   return result;
 }
 
 std::optional<MapBasedStopPlanner::SingleStopResult> MapBasedStopPlanner::plan_single_stop(
   const std::vector<StopLine> & stop_lines, const Trajectory & trajectory,
-  const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
-  const double ego_acceleration, const StopSelectionParams & params,
-  const bool include_possibility) const
+  const double ego_arc_length, const double ego_velocity, const double ego_acceleration,
+  const StopSelectionParams & params, const bool include_possibility) const
 {
   autoware_utils_debug::ScopedTimeTrack st(
     include_possibility ? "plan_single_stop(stop)" : "plan_single_stop(go)", *time_keeper_);
 
-  const auto stop_point_arc_length = select_stop_arc_length(
-    stop_lines, trajectory.points, ego_pose, ego_velocity, ego_acceleration, params,
+  const auto stop_point = select_stop_point(
+    stop_lines, trajectory.points, ego_arc_length, ego_velocity, ego_acceleration, params,
     include_possibility);
-  if (!stop_point_arc_length) return std::nullopt;
+  if (!stop_point) return std::nullopt;
 
   if (autoware::trajectory_modifier::utils::stop_point_exists(
-        trajectory.points, *stop_point_arc_length)) {
+        trajectory.points, stop_point->arc_length)) {
     return std::nullopt;
   }
 
   Trajectory stop_trajectory = trajectory;
   if (!autoware::trajectory_modifier::utils::insert_stop_point(
-        stop_trajectory.points, *stop_point_arc_length)) {
+        stop_trajectory.points, stop_point->arc_length)) {
     return std::nullopt;
   }
-  return SingleStopResult{*stop_point_arc_length, std::move(stop_trajectory)};
+  return SingleStopResult{*stop_point, std::move(stop_trajectory)};
 }
 
 std::vector<StopLine> MapBasedStopPlanner::collect_stop_lines(
@@ -732,12 +736,11 @@ std::vector<StopLine> MapBasedStopPlanner::filter_stop_lines_on_trajectory(
   return intersecting;
 }
 
-std::optional<double> MapBasedStopPlanner::select_stop_arc_length(
+std::optional<StopPoint> MapBasedStopPlanner::select_stop_point(
   const std::vector<StopLine> & stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory_points,
-  const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
-  const double ego_acceleration, const StopSelectionParams & params,
-  const bool include_possibility) const
+  const double ego_arc_length, const double ego_velocity, const double ego_acceleration,
+  const StopSelectionParams & params, const bool include_possibility) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -758,10 +761,8 @@ std::optional<double> MapBasedStopPlanner::select_stop_arc_length(
     autoware::motion_utils::calculate_stop_distance(
       ego_velocity, ego_acceleration, params.max_deceleration, params.max_jerk)
       .value_or(ego_velocity * ego_velocity / (2.0 * params.max_deceleration));
-  const double ego_arc_length =
-    autoware::motion_utils::calcSignedArcLength(trajectory_points, 0UL, ego_pose.position);
 
-  std::optional<double> nearest_stop_point_arc_length;
+  std::optional<StopPoint> nearest_stop_point;
   for (const auto & stop_line : stop_lines) {
     if (!include_possibility && is_possibility_type(stop_line.type)) {
       continue;
@@ -795,14 +796,13 @@ std::optional<double> MapBasedStopPlanner::select_stop_arc_length(
       if (distance_to_stop_point <= 0.0 || distance_to_stop_point < braking_distance) {
         continue;
       }
-      if (
-        !nearest_stop_point_arc_length || stop_point_arc_length < *nearest_stop_point_arc_length) {
-        nearest_stop_point_arc_length = stop_point_arc_length;
+      if (!nearest_stop_point || stop_point_arc_length < nearest_stop_point->arc_length) {
+        nearest_stop_point = StopPoint{stop_point_arc_length, stop_line.type};
       }
     }
   }
 
-  return nearest_stop_point_arc_length;
+  return nearest_stop_point;
 }
 
 visualization_msgs::msg::MarkerArray MapBasedStopPlanner::create_stop_line_marker_array(

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
@@ -44,6 +44,8 @@ enum class StopLineType {
   PrivateArea,   //!< private-area entry/exit transition     -> possibility
 };
 
+const char * to_string(const StopLineType type);
+
 //! A map-defined stop line together with its classified type.
 struct StopLine
 {
@@ -52,6 +54,12 @@ struct StopLine
   //! true when the geometry is a crosswalk/walkway bound used because the map has no explicit
   //! stop line; such targets use the larger stop_distance_from_crosswalk margin.
   bool without_explicit_stop_line{false};
+};
+
+struct StopPoint
+{
+  double arc_length;
+  StopLineType type;
 };
 
 /**
@@ -107,9 +115,11 @@ public:
   {
     //! stops at mandatory targets only (equals the input trajectory when there is none)
     Trajectory go_trajectory;
+    std::optional<StopPoint> go_stop_point;
     //! additionally stops at possibility targets; set only when its stop point differs from the
     //! go trajectory's
     std::optional<Trajectory> stop_trajectory;
+    std::optional<StopPoint> stop_stop_point;
     visualization_msgs::msg::MarkerArray stop_line_markers;
   };
 
@@ -135,9 +145,8 @@ public:
    * inputs for the velocity optimization.
    */
   Result plan(
-    const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose,
-    const double ego_velocity, const double ego_acceleration,
-    const StopSelectionParams & params) const;
+    const Trajectory & trajectory, const double ego_arc_length, const double ego_velocity,
+    const double ego_acceleration, const StopSelectionParams & params) const;
 
   /**
    * @brief Collect stop targets along the given route, tagged by type.
@@ -181,12 +190,11 @@ public:
    * vehicle has passed or can no longer stop for is dropped in favor of a farther reachable one.
    * Returns nullopt when no reachable candidate exists.
    */
-  std::optional<double> select_stop_arc_length(
+  std::optional<StopPoint> select_stop_point(
     const std::vector<StopLine> & stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory_points,
-    const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
-    const double ego_acceleration, const StopSelectionParams & params,
-    const bool include_possibility) const;
+    const double ego_arc_length, const double ego_velocity, const double ego_acceleration,
+    const StopSelectionParams & params, const bool include_possibility) const;
 
   //! Build a MarkerArray (frame "map") of the stop lines with a per-type text label above each.
   visualization_msgs::msg::MarkerArray create_stop_line_marker_array(
@@ -196,14 +204,13 @@ private:
   //! One stop pass: the nearest reachable stop point among the allowed types, embedded on a copy.
   struct SingleStopResult
   {
-    double stop_point_arc_length;
+    StopPoint stop_point;
     Trajectory trajectory;
   };
   std::optional<SingleStopResult> plan_single_stop(
     const std::vector<StopLine> & stop_lines, const Trajectory & trajectory,
-    const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
-    const double ego_acceleration, const StopSelectionParams & params,
-    const bool include_possibility) const;
+    const double ego_arc_length, const double ego_velocity, const double ego_acceleration,
+    const StopSelectionParams & params, const bool include_possibility) const;
 
   rclcpp::Logger logger_;
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -359,7 +359,6 @@ void MinimumRuleBasedPlannerNode::on_timer()
       autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
       autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
       to_string(stop_result.go_stop_point->type));
-    go_planning_factor_interface_->publish();
   }
   if (stop_trajectory && stop_result.stop_stop_point) {
     stop_planning_factor_interface_->add(
@@ -369,8 +368,10 @@ void MinimumRuleBasedPlannerNode::on_timer()
       autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
       autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
       to_string(stop_result.stop_stop_point->type));
-    stop_planning_factor_interface_->publish();
   }
+
+  go_planning_factor_interface_->publish();
+  stop_planning_factor_interface_->publish();
 
   // 10. Publish debug information
   publish_debug_outputs(*path, go_trajectory, stop_trajectory);

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/conversion.hpp>
+#include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/utils/pretty_build.hpp>
 #include <autoware/velocity_smoother/resample.hpp>
@@ -352,15 +353,19 @@ void MinimumRuleBasedPlannerNode::on_timer()
 
   if (stop_result.go_stop_point) {
     go_planning_factor_interface_->add(
-      stop_result.go_stop_point->arc_length - ego_arc_length, go_trajectory.points.back().pose,
+      stop_result.go_stop_point->arc_length - ego_arc_length,
+      autoware::motion_utils::calcInterpolatedPose(
+        trajectory.points, stop_result.go_stop_point->arc_length),
       autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
       autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
       to_string(stop_result.go_stop_point->type));
     go_planning_factor_interface_->publish();
   }
-  if (stop_result.stop_stop_point) {
+  if (stop_trajectory && stop_result.stop_stop_point) {
     stop_planning_factor_interface_->add(
-      stop_result.stop_stop_point->arc_length - ego_arc_length, go_trajectory.points.back().pose,
+      stop_result.stop_stop_point->arc_length - ego_arc_length,
+      autoware::motion_utils::calcInterpolatedPose(
+        stop_trajectory->points, stop_result.stop_stop_point->arc_length),
       autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
       autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
       to_string(stop_result.stop_stop_point->type));

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -112,6 +112,12 @@ MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptio
       "~/debug/processing_time_ms", 1);
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
+  go_planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      this, "backup_planner_go");
+  stop_planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      this, "backup_planner_stop");
 
   params_ = param_listener_->get_params();
 
@@ -323,8 +329,10 @@ void MinimumRuleBasedPlannerNode::on_timer()
   // 7. Plan the go/stop trajectories with map-defined stop points
   map_based_stop_planner_->set_planner_data(
     input_data.lanelet_map_bin_ptr, input_data.route_ptr, path_planner_->route_context());
+  const double ego_arc_length = autoware::motion_utils::calcSignedArcLength(
+    trajectory.points, 0UL, input_data.odometry_ptr->pose.pose.position);
   const auto stop_result = map_based_stop_planner_->plan(
-    trajectory, input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x,
+    trajectory, ego_arc_length, input_data.odometry_ptr->twist.twist.linear.x,
     input_data.acceleration_ptr->accel.accel.linear.x, make_map_based_stop_params());
   pub_stop_lines_marker_->publish(stop_result.stop_line_markers);
 
@@ -341,6 +349,23 @@ void MinimumRuleBasedPlannerNode::on_timer()
 
   // 9. Create and publish CandidateTrajectories message
   publish_candidate_trajectories(go_trajectory, stop_trajectory);
+
+  if (stop_result.go_stop_point) {
+    go_planning_factor_interface_->add(
+      stop_result.go_stop_point->arc_length - ego_arc_length, go_trajectory.points.back().pose,
+      autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
+      to_string(stop_result.go_stop_point->type));
+    go_planning_factor_interface_->publish();
+  }
+  if (stop_result.stop_stop_point) {
+    stop_planning_factor_interface_->add(
+      stop_result.stop_stop_point->arc_length - ego_arc_length, go_trajectory.points.back().pose,
+      autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, 0.0, 0.0,
+      to_string(stop_result.stop_stop_point->type));
+    stop_planning_factor_interface_->publish();
+  }
 
   // 10. Publish debug information
   publish_debug_outputs(*path, go_trajectory, stop_trajectory);

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
@@ -203,6 +203,11 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_trajectory_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_stop_trajectory_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_shifted_trajectory_;
+
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    go_planning_factor_interface_;
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    stop_planning_factor_interface_;
   /** @} */
 };
 

--- a/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
@@ -83,15 +83,6 @@ StopSelectionParams make_params()
   return params;
 }
 
-// Ego pose on the straight trajectory (y = 0, facing +x).
-geometry_msgs::msg::Pose make_ego_pose(double x)
-{
-  geometry_msgs::msg::Pose pose;
-  pose.position.x = x;
-  pose.orientation.w = 1.0;
-  return pose;
-}
-
 }  // namespace
 
 // ============================================================
@@ -142,12 +133,12 @@ TEST(MapBasedStopPlannerTest, SelectAppliesFrontOffsetAndMargin)
   const std::vector<StopLine> stop_lines{make_crossing_stop_line(1, 20.0)};
 
   // Ego stopped: braking distance is 0, so the stop point is reachable.
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   ASSERT_TRUE(arc.has_value());
   // crossing (20) - front offset (4) - margin (1) = 15
-  EXPECT_NEAR(*arc, 15.0, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 15.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectAppliesCrosswalkMarginWithoutExplicitStopLine)
@@ -161,12 +152,12 @@ TEST(MapBasedStopPlannerTest, SelectAppliesCrosswalkMarginWithoutExplicitStopLin
   stop_line.without_explicit_stop_line = true;
   const std::vector<StopLine> stop_lines{stop_line};
 
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   ASSERT_TRUE(arc.has_value());
   // crossing (20) - front offset (4) - (stop_margin (1) + stop_distance_from_crosswalk (3.5))
-  EXPECT_NEAR(*arc, 11.5, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 11.5, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectAppliesIntersectionMargin)
@@ -179,12 +170,12 @@ TEST(MapBasedStopPlannerTest, SelectAppliesIntersectionMargin)
   const std::vector<StopLine> stop_lines{
     make_crossing_stop_line(1, 20.0, StopLineType::Intersection)};
 
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/true);
   ASSERT_TRUE(arc.has_value());
   // crossing (20) - front offset (4) - (stop_margin (1) + stop_distance_from_intersection (1))
-  EXPECT_NEAR(*arc, 14.0, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 14.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectAppliesPrivateAreaMargin)
@@ -197,12 +188,12 @@ TEST(MapBasedStopPlannerTest, SelectAppliesPrivateAreaMargin)
   const std::vector<StopLine> stop_lines{
     make_crossing_stop_line(1, 20.0, StopLineType::PrivateArea)};
 
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/true);
   ASSERT_TRUE(arc.has_value());
   // crossing (20) - front offset (4) - (stop_margin (1) + stop_distance_from_private_area (3))
-  EXPECT_NEAR(*arc, 12.0, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 12.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectPicksNearest)
@@ -212,12 +203,12 @@ TEST(MapBasedStopPlannerTest, SelectPicksNearest)
   const std::vector<StopLine> stop_lines{
     make_crossing_stop_line(1, 40.0), make_crossing_stop_line(2, 20.0)};
 
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), 0.0, 0.0, make_params(),
-    /*include_possibility=*/false);
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+    make_params(), /*include_possibility=*/false);
   ASSERT_TRUE(arc.has_value());
   // nearest crossing is 20 -> 20 - 4 - 1 = 15
-  EXPECT_NEAR(*arc, 15.0, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 15.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectRejectsUnreachableStopPoint)
@@ -228,8 +219,8 @@ TEST(MapBasedStopPlannerTest, SelectRejectsUnreachableStopPoint)
 
   // Stop point arc = 15 m. The jerk-aware braking distance at 20 m/s (a = 4, j = 5) is about
   // 57.9 m > 15 m, so the vehicle cannot stop in time and no stop point should be selected.
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/20.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/20.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   EXPECT_FALSE(arc.has_value());
 }
@@ -243,12 +234,12 @@ TEST(MapBasedStopPlannerTest, SelectSkipsUnreachableNearestForReachableFarther)
   const std::vector<StopLine> stop_lines{
     make_crossing_stop_line(1, 20.0), make_crossing_stop_line(2, 70.0)};
 
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(0.0), /*ego_velocity=*/20.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/20.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   ASSERT_TRUE(arc.has_value());
   // 70 - 4 - 1 = 65
-  EXPECT_NEAR(*arc, 65.0, 1e-6);
+  EXPECT_NEAR(arc->arc_length, 65.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectExcludesPossibilityTargetsForGoTrajectory)
@@ -261,15 +252,15 @@ TEST(MapBasedStopPlannerTest, SelectExcludesPossibilityTargetsForGoTrajectory)
 
   // Go trajectory: possibility targets are ignored -> no stop.
   EXPECT_FALSE(planner
-                 .select_stop_arc_length(
-                   stop_lines, trajectory, make_ego_pose(0.0), 0.0, 0.0, make_params(),
-                   /*include_possibility=*/false)
+                 .select_stop_point(
+                   stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0,
+                   /*ego_acceleration=*/0.0, make_params(), /*include_possibility=*/false)
                  .has_value());
   // Stop trajectory: possibility targets are considered -> stop.
   EXPECT_TRUE(planner
-                .select_stop_arc_length(
-                  stop_lines, trajectory, make_ego_pose(0.0), 0.0, 0.0, make_params(),
-                  /*include_possibility=*/true)
+                .select_stop_point(
+                  stop_lines, trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0,
+                  /*ego_acceleration=*/0.0, make_params(), /*include_possibility=*/true)
                 .has_value());
 }
 
@@ -285,17 +276,17 @@ TEST(MapBasedStopPlannerTest, SelectMeasuresBrakingDistanceFromEgo)
   // distance is only 5 m. The jerk-aware braking distance at 8 m/s (a = 4, j = 5) is ~11.1 m
   // > 5 m -> must be skipped. (Judged from the trajectory start, 15 m > 11.1 m would wrongly
   // keep it.)
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(10.0), /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/10.0, /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   EXPECT_FALSE(arc.has_value());
 
   // With enough remaining distance (ego at x = 2 -> 13 m > 11.1 m) the stop point is kept.
-  const auto arc_reachable = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(2.0), /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
+  const auto arc_reachable = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/2.0, /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   ASSERT_TRUE(arc_reachable.has_value());
-  EXPECT_NEAR(*arc_reachable, 15.0, 1e-6);
+  EXPECT_NEAR(arc_reachable->arc_length, 15.0, 1e-6);
 }
 
 TEST(MapBasedStopPlannerTest, SelectUsesJerkAwareBrakingDistance)
@@ -308,8 +299,8 @@ TEST(MapBasedStopPlannerTest, SelectUsesJerkAwareBrakingDistance)
   // braking distance 8^2/(2*4) = 8 m would keep the candidate, but the jerk-limited ramp-up to
   // the maximum deceleration (j = 5) stretches the real braking distance to ~11.1 m, so the
   // candidate must be skipped.
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(5.0), /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/5.0, /*ego_velocity=*/8.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   EXPECT_FALSE(arc.has_value());
 }
@@ -322,8 +313,8 @@ TEST(MapBasedStopPlannerTest, SelectSkipsStopPointPassedByEgo)
 
   // Stop point arc = 15 m; ego (base_link) is already at x = 16, past the stop point. Even though
   // the arc length from the trajectory start is positive, the candidate must be dropped.
-  const auto arc = planner.select_stop_arc_length(
-    stop_lines, trajectory, make_ego_pose(16.0), /*ego_velocity=*/1.0, /*ego_acceleration=*/0.0,
+  const auto arc = planner.select_stop_point(
+    stop_lines, trajectory, /*ego_arc_length=*/16.0, /*ego_velocity=*/1.0, /*ego_acceleration=*/0.0,
     make_params(), /*include_possibility=*/false);
   EXPECT_FALSE(arc.has_value());
 }
@@ -818,7 +809,8 @@ TEST(MapBasedStopPlannerTest, PlanEmbedsMandatoryStopInGoTrajectory)
 
   const auto trajectory = make_straight_trajectory_msg(30);
   const auto result = planner.plan(
-    trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0, make_params());
+    trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+    make_params());
 
   // The go trajectory ends with a zero-velocity point at the stop point (20 - 4 - 1 = 15).
   ASSERT_FALSE(result.go_trajectory.points.empty());
@@ -844,7 +836,8 @@ TEST(MapBasedStopPlannerTest, PlanReturnsStopTrajectoryOnlyForDistinctStopPoint)
 
   const auto trajectory = make_straight_trajectory_msg(30);
   const auto result = planner.plan(
-    trajectory, make_ego_pose(0.0), /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0, make_params());
+    trajectory, /*ego_arc_length=*/0.0, /*ego_velocity=*/0.0, /*ego_acceleration=*/0.0,
+    make_params());
 
   // The go trajectory ignores possibility targets and stays unchanged.
   ASSERT_EQ(result.go_trajectory.points.size(), trajectory.points.size());


### PR DESCRIPTION
## Description

This PR adds planning factor interfaces for go and stop trajectories introduced in #3192 to enable checking the stop reasons for each trajectory.

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
