### PR TITLE
feat(boundary_departure, trajectory_validator): NEAR BOUNDARY and LOW_CAUTION

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp
@@ -51,7 +51,7 @@ public:
    * @param[in] ego_state current ego dynamic state
    * @return evaluated critical point pairs if successful
    */
-  [[nodiscard]] std::optional<Side<std::optional<CriticalPointPair>>> evaluate(
+  [[nodiscard]] std::optional<Side<std::optional<DeparturePointPair>>> evaluate(
     const TrajectoryPoints & predicted_traj, const FootprintSideSegmentsArray & footprints_sides,
     const EgoDynamicState & ego_state) const;
 

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
@@ -44,9 +44,9 @@ namespace autoware::boundary_departure_checker
  * @brief Type of boundary departure.
  */
 enum class DepartureType {
-  NONE = 0,     ///< no departure
-  APPROACHING,  ///< approaching the boundary
-  CRITICAL,     ///< critical departure from the boundary
+  NONE = 0,       ///< no departure
+  NEAR_BOUNDARY,  ///< footprint is within the near boundary lateral threshold
+  CRITICAL,       ///< critical departure from the boundary
 };
 
 /**
@@ -75,10 +75,13 @@ struct ProjectionToBound
   [[nodiscard]] bool is_none_departure() const { return departure_type == DepartureType::NONE; }
 
   /**
-   * @brief Check if the departure type is APPROACHING.
-   * @return true if APPROACHING
+   * @brief Check if the departure type is NEAR_BOUNDARY.
+   * @return true if NEAR_BOUNDARY
    */
-  [[nodiscard]] bool is_approaching() const { return departure_type == DepartureType::APPROACHING; }
+  [[nodiscard]] bool is_near_boundary() const
+  {
+    return departure_type == DepartureType::NEAR_BOUNDARY;
+  }
 
   /**
    * @brief Check if the departure type is CRITICAL.
@@ -101,9 +104,9 @@ struct ProjectionToBound
 using ProjectionsToBound = std::vector<ProjectionToBound>;
 
 /**
- * @brief A pair of critical points: physical departure point and safety buffer start.
+ * @brief A pair of departure points: physical departure point and safety buffer start.
  */
-struct CriticalPointPair
+struct DeparturePointPair
 {
   ProjectionToBound physical_departure_point;  ///< physical departure point
   ProjectionToBound safety_buffer_start;       ///< point where safety buffer starts
@@ -182,7 +185,9 @@ using FootprintSideSegmentsArray = std::vector<FootprintSideSegments>;
  */
 struct DepartureResult
 {
-  DepartureType status{DepartureType::NONE};           ///< current departure status
+  DepartureType status{DepartureType::NONE};  ///< current departure status
+  double lat_dist_to_uncrossable_bound{
+    std::numeric_limits<double>::max()};  ///< smallest lateral distance to a boundary [m]
   visualization_msgs::msg::MarkerArray debug_markers;  ///< debug markers for visualization
 };
 
@@ -205,6 +210,7 @@ struct DepartureCheckThresholds
   double min_braking_distance{0.0};  ///< minimum braking distance [m]
   double cutoff_time{0.0};           ///< time cutoff for departure check [s]
   double th_lat_critical{0.0};       ///< lateral distance threshold for critical departure [m]
+  double th_near_boundary{0.0};      ///< lateral distance threshold for near boundary [m]
 };
 
 /**

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
@@ -187,7 +187,8 @@ struct DepartureResult
 {
   DepartureType status{DepartureType::NONE};  ///< current departure status
   double lat_dist_to_uncrossable_bound{
-    std::numeric_limits<double>::max()};  ///< smallest lateral distance to a boundary [m]
+    std::numeric_limits<double>::infinity()};  ///< smallest lateral distance to a boundary [m],
+                                               ///< infinity when no boundary was evaluated
   visualization_msgs::msg::MarkerArray debug_markers;  ///< debug markers for visualization
 };
 

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/hysteresis_logic.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/hysteresis_logic.hpp
@@ -51,7 +51,7 @@ struct HysteresisResult
  */
 HysteresisResult update_and_judge(
   const HysteresisState & state,
-  const std::optional<Side<std::optional<CriticalPointPair>>> & evaluation_result,
+  const std::optional<Side<std::optional<DeparturePointPair>>> & evaluation_result,
   const UncrossableBoundaryDepartureParam & param, const double current_time_s);
 
 }  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
@@ -41,7 +41,7 @@ ProjectionsToBound filter_and_assign_departure_types(
  * @param[in] param checker parameters
  * @return evaluated critical point pair if found
  */
-DeparturePointPair apply_backward_buffer_and_filter(
+std::optional<DeparturePointPair> apply_backward_buffer_and_filter(
   const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param);
 
 /**

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
@@ -41,7 +41,7 @@ ProjectionsToBound filter_and_assign_departure_types(
  * @param[in] param checker parameters
  * @return evaluated critical point pair if found
  */
-std::optional<CriticalPointPair> apply_backward_buffer_and_filter(
+DeparturePointPair apply_backward_buffer_and_filter(
   const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param);
 
 /**
@@ -61,7 +61,7 @@ DepartureType assign_departure_type(
  * @param[in] vehicle_info vehicle information
  * @return evaluated critical point pairs for both sides
  */
-Side<std::optional<CriticalPointPair>> evaluate_projections_severity(
+Side<std::optional<DeparturePointPair>> evaluate_projections_severity(
   const Side<ProjectionsToBound> & projections_to_bound,
   const UncrossableBoundaryDepartureParam & param, const EgoDynamicState & ego_state,
   const vehicle_info_utils::VehicleInfo & vehicle_info);
@@ -71,7 +71,22 @@ Side<std::optional<CriticalPointPair>> evaluate_projections_severity(
  * @param[in] evaluated_projections evaluated critical point pairs for both sides
  * @return true if critical
  */
-bool is_critical(const Side<std::optional<CriticalPointPair>> & evaluated_projections);
+bool is_critical(const Side<std::optional<DeparturePointPair>> & evaluated_projections);
+
+/**
+ * @brief Check if any side is near an uncrossable boundary.
+ * @param[in] evaluated_projections evaluated departure point pairs for both sides
+ * @return true if near boundary
+ */
+bool is_near_boundary(const Side<std::optional<DeparturePointPair>> & evaluated_projections);
+
+/**
+ * @brief Get the smallest lateral distance to an uncrossable boundary among both sides.
+ * @param[in] evaluated_projections evaluated departure point pairs for both sides
+ * @return minimum lateral distance [m], or the maximum double value if no projection exists
+ */
+double get_min_lateral_distance_to_bound(
+  const Side<std::optional<DeparturePointPair>> & evaluated_projections);
 
 /**
  * @brief Calculate minimum braking distance.

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -28,6 +28,7 @@ struct UncrossableBoundaryDepartureParam
   int max_lateral_rtree_queries{5};        ///< maximum number of lateral R-tree queries
   double lateral_margin_m{0.01};           ///< lateral margin [m]
   double longitudinal_margin_m{1.0};       ///< longitudinal margin [m]
+  double near_boundary_lateral_th_m{0.2};  ///< lateral distance to flag as near boundary [m]
   double max_deceleration_mps2{-4.0};      ///< maximum deceleration [m/s^2]
   double max_jerk_mps3{-5.0};              ///< maximum jerk [m/s^3]
   double brake_delay_s{1.0};               ///< brake delay [s]

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -25,8 +25,9 @@ namespace autoware::boundary_departure_checker
  */
 struct UncrossableBoundaryDepartureParam
 {
-  int max_lateral_rtree_queries{5};        ///< maximum number of lateral R-tree queries
-  double lateral_margin_m{0.01};           ///< lateral margin [m]
+  int max_lateral_rtree_queries{5};  ///< maximum number of lateral R-tree queries
+  double critical_departure_lateral_th_m{
+    0.01};                                 ///< lateral distance to flag as critical departure [m]
   double longitudinal_margin_m{1.0};       ///< longitudinal margin [m]
   double near_boundary_lateral_th_m{0.2};  ///< lateral distance to flag as near boundary [m]
   double max_deceleration_mps2{-4.0};      ///< maximum deceleration [m/s^2]

--- a/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
+++ b/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
@@ -17,9 +17,9 @@
           "description": "Maximum number of lateral R-tree queries.",
           "default": 5
         },
-        "lateral_margin_m": {
+        "critical_departure_lateral_th_m": {
           "type": "number",
-          "description": "Lateral margin threshold [m].",
+          "description": "Lateral distance to flag as a critical departure [m].",
           "default": 0.01
         },
         "longitudinal_margin_m": {
@@ -66,7 +66,7 @@
       "required": [
         "boundary_types_to_detect",
         "max_lateral_rtree_queries",
-        "lateral_margin_m",
+        "critical_departure_lateral_th_m",
         "longitudinal_margin_m",
         "max_deceleration_mps2",
         "max_jerk_mps3",

--- a/common/autoware_boundary_departure_checker/src/detail/boundary_departure_evaluator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/boundary_departure_evaluator.cpp
@@ -35,7 +35,7 @@ BoundaryDepartureEvaluator::BoundaryDepartureEvaluator(
   }
 }
 
-std::optional<Side<std::optional<CriticalPointPair>>> BoundaryDepartureEvaluator::evaluate(
+std::optional<Side<std::optional<DeparturePointPair>>> BoundaryDepartureEvaluator::evaluate(
   const TrajectoryPoints & predicted_traj, const FootprintSideSegmentsArray & footprints_sides,
   const EgoDynamicState & ego_state) const
 {

--- a/common/autoware_boundary_departure_checker/src/detail/hysteresis_logic.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/hysteresis_logic.cpp
@@ -20,7 +20,7 @@ namespace autoware::boundary_departure_checker
 {
 HysteresisResult update_and_judge(
   const HysteresisState & state,
-  const std::optional<Side<std::optional<CriticalPointPair>>> & evaluation_result,
+  const std::optional<Side<std::optional<DeparturePointPair>>> & evaluation_result,
   const UncrossableBoundaryDepartureParam & param, const double current_time_s)
 {
   HysteresisResult result;

--- a/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
@@ -32,6 +32,7 @@ ProjectionsToBound filter_and_assign_departure_types(
   thresholds.min_braking_distance = min_braking_dist;
   thresholds.cutoff_time = param.time_to_departure_cutoff_s;
   thresholds.th_lat_critical = param.lateral_margin_m;
+  thresholds.th_near_boundary = param.near_boundary_lateral_th_m;
 
   for (size_t idx = 0; idx < side_value.size(); ++idx) {
     const auto & original_candidate = side_value[idx];
@@ -46,26 +47,24 @@ ProjectionsToBound filter_and_assign_departure_types(
     out.push_back(original_candidate);
     out.back().departure_type = assign_departure_type(metrics, thresholds);
 
-    if (out.back().is_critical()) break;
+    if (out.back().is_critical()) {
+      return out;
+    }
   }
 
   return out;
 }
 
-std::optional<CriticalPointPair> apply_backward_buffer_and_filter(
+DeparturePointPair apply_backward_buffer_and_filter(
   const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param)
 {
-  if (side_value.empty() || side_value.back().is_none_departure()) return std::nullopt;
+  DeparturePointPair result;
+  if (side_value.empty()) return result;
 
   const auto & departure_point = side_value.back();
 
-  CriticalPointPair result;
   result.physical_departure_point = departure_point;
   result.safety_buffer_start = departure_point;
-
-  if (!departure_point.is_critical()) {
-    return result;
-  }
 
   for (auto it = std::next(side_value.rbegin()); it != side_value.rend(); ++it) {
     const double dist_between_proj =
@@ -84,39 +83,75 @@ std::optional<CriticalPointPair> apply_backward_buffer_and_filter(
 DepartureType assign_departure_type(
   const ProjectionEvaluationMetrics & metrics, const DepartureCheckThresholds & thresholds)
 {
-  if (metrics.lat_dist > thresholds.th_lat_critical) {
-    return DepartureType::NONE;
+  const auto footprint_overlaps_critical_margin = metrics.lat_dist <= thresholds.th_lat_critical;
+  const auto ego_cannot_stop_before_departure =
+    metrics.lon_dist_to_departure <= thresholds.min_braking_distance ||
+    metrics.time_from_start <= thresholds.cutoff_time;
+
+  if (footprint_overlaps_critical_margin && ego_cannot_stop_before_departure) {
+    return DepartureType::CRITICAL;
   }
 
-  if (
-    metrics.lon_dist_to_departure > thresholds.min_braking_distance &&
-    metrics.time_from_start > thresholds.cutoff_time) {
-    return DepartureType::APPROACHING;
+  if (metrics.lat_dist <= thresholds.th_near_boundary) {
+    return DepartureType::NEAR_BOUNDARY;
   }
 
-  return DepartureType::CRITICAL;
+  return DepartureType::NONE;
 }
 
-Side<std::optional<CriticalPointPair>> evaluate_projections_severity(
+Side<std::optional<DeparturePointPair>> evaluate_projections_severity(
   const Side<ProjectionsToBound> & projections_to_bound,
   const UncrossableBoundaryDepartureParam & param, const EgoDynamicState & ego_state,
   const vehicle_info_utils::VehicleInfo & vehicle_info)
 {
   const auto min_braking_dist = calc_minimum_braking_distance(ego_state, param, vehicle_info);
 
-  return projections_to_bound.transform_each_side([&](const auto & side_value) {
-    const auto min_to_bounds =
-      filter_and_assign_departure_types(side_value, param, min_braking_dist);
-    return apply_backward_buffer_and_filter(min_to_bounds, param);
-  });
+  return projections_to_bound.transform_each_side(
+    [&](const auto & side_value) -> std::optional<DeparturePointPair> {
+      const auto min_to_bounds =
+        filter_and_assign_departure_types(side_value, param, min_braking_dist);
+
+      if (min_to_bounds.empty()) return std::nullopt;
+
+      if (min_to_bounds.back().is_critical()) {
+        return apply_backward_buffer_and_filter(min_to_bounds, param);
+      }
+
+      const auto closest_to_bound = std::min_element(
+        min_to_bounds.begin(), min_to_bounds.end(),
+        [](const ProjectionToBound & lhs, const ProjectionToBound & rhs) {
+          return lhs.lat_dist < rhs.lat_dist;
+        });
+
+      return DeparturePointPair{*closest_to_bound, *closest_to_bound};
+    });
 }
 
-bool is_critical(const Side<std::optional<CriticalPointPair>> & evaluated_projections)
+bool is_critical(const Side<std::optional<DeparturePointPair>> & evaluated_projections)
 {
   return evaluated_projections.any_of_side([](const auto & critical_pair_opt) {
     return critical_pair_opt.has_value() &&
            critical_pair_opt->physical_departure_point.is_critical();
   });
+}
+
+bool is_near_boundary(const Side<std::optional<DeparturePointPair>> & evaluated_projections)
+{
+  return evaluated_projections.any_of_side([](const auto & departure_pair_opt) {
+    return departure_pair_opt.has_value() &&
+           departure_pair_opt->physical_departure_point.is_near_boundary();
+  });
+}
+
+double get_min_lateral_distance_to_bound(
+  const Side<std::optional<DeparturePointPair>> & evaluated_projections)
+{
+  auto min_lat_dist = std::numeric_limits<double>::max();
+  evaluated_projections.for_each_side([&min_lat_dist](const auto & departure_pair_opt) {
+    if (!departure_pair_opt.has_value()) return;
+    min_lat_dist = std::min(min_lat_dist, departure_pair_opt->physical_departure_point.lat_dist);
+  });
+  return min_lat_dist;
 }
 
 double calc_minimum_braking_distance(

--- a/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
@@ -17,7 +17,9 @@
 #include <autoware/motion_utils/distance/distance.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
+#include <optional>
 
 namespace autoware::boundary_departure_checker::severity_evaluator
 {
@@ -31,8 +33,11 @@ ProjectionsToBound filter_and_assign_departure_types(
   DepartureCheckThresholds thresholds;
   thresholds.min_braking_distance = min_braking_dist;
   thresholds.cutoff_time = param.time_to_departure_cutoff_s;
-  thresholds.th_lat_critical = param.lateral_margin_m;
-  thresholds.th_near_boundary = param.near_boundary_lateral_th_m;
+  thresholds.th_lat_critical = param.critical_departure_lateral_th_m;
+  // A near boundary threshold below the critical margin would leave projections inside the critical
+  // margin unclassified, so the advisory band always covers at least the critical margin.
+  thresholds.th_near_boundary =
+    std::max(param.near_boundary_lateral_th_m, param.critical_departure_lateral_th_m);
 
   for (size_t idx = 0; idx < side_value.size(); ++idx) {
     const auto & original_candidate = side_value[idx];
@@ -55,12 +60,12 @@ ProjectionsToBound filter_and_assign_departure_types(
   return out;
 }
 
-DeparturePointPair apply_backward_buffer_and_filter(
+std::optional<DeparturePointPair> apply_backward_buffer_and_filter(
   const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param)
 {
-  DeparturePointPair result;
-  if (side_value.empty()) return result;
+  if (side_value.empty() || !side_value.back().is_critical()) return std::nullopt;
 
+  DeparturePointPair result;
   const auto & departure_point = side_value.back();
 
   result.physical_departure_point = departure_point;
@@ -146,10 +151,14 @@ bool is_near_boundary(const Side<std::optional<DeparturePointPair>> & evaluated_
 double get_min_lateral_distance_to_bound(
   const Side<std::optional<DeparturePointPair>> & evaluated_projections)
 {
-  auto min_lat_dist = std::numeric_limits<double>::max();
+  auto min_lat_dist = std::numeric_limits<double>::infinity();
   evaluated_projections.for_each_side([&min_lat_dist](const auto & departure_pair_opt) {
     if (!departure_pair_opt.has_value()) return;
-    min_lat_dist = std::min(min_lat_dist, departure_pair_opt->physical_departure_point.lat_dist);
+    // A projection that failed to find a segment keeps its sentinel default. Treat it as "no
+    // measurement" instead of letting the sentinel be published as a real distance.
+    const auto lat_dist = departure_pair_opt->physical_departure_point.lat_dist;
+    if (!std::isfinite(lat_dist) || lat_dist >= std::numeric_limits<double>::max()) return;
+    min_lat_dist = std::min(min_lat_dist, lat_dist);
   });
   return min_lat_dist;
 }

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/boundary_departure_checker/detail/debug.hpp"
 #include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
 
 #include <autoware_utils_system/stop_watch.hpp>
 
@@ -60,7 +61,20 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
 
   state = hysteresis_result.updated_state;
 
+  // CRITICAL is hysteresis filtered, whereas NEAR_BOUNDARY is a non-latching advisory taken
+  // directly from the current evaluation.
+  const auto is_near_boundary =
+    evaluation_result && severity_evaluator::is_near_boundary(*evaluation_result);
   result.status = hysteresis_result.status;
+  if (result.status == DepartureType::NONE && is_near_boundary) {
+    result.status = DepartureType::NEAR_BOUNDARY;
+  }
+
+  if (evaluation_result) {
+    result.lat_dist_to_uncrossable_bound =
+      severity_evaluator::get_min_lateral_distance_to_bound(*evaluation_result);
+  }
+
   result.debug_markers =
     debug::create_debug_markers(state, footprints, ego_state, param_.enable_developer_marker);
   return result;

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -62,11 +62,14 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
   state = hysteresis_result.updated_state;
 
   // CRITICAL is hysteresis filtered, whereas NEAR_BOUNDARY is a non-latching advisory taken
-  // directly from the current evaluation.
-  const auto is_near_boundary =
-    evaluation_result && severity_evaluator::is_near_boundary(*evaluation_result);
+  // directly from the current evaluation. A CRITICAL projection that the hysteresis buffer still
+  // suppresses is reported as NEAR_BOUNDARY, so the reported severity never dips back to NONE while
+  // ego closes on the boundary.
+  const auto footprint_is_close_to_bound =
+    evaluation_result && (severity_evaluator::is_near_boundary(*evaluation_result) ||
+                          severity_evaluator::is_critical(*evaluation_result));
   result.status = hysteresis_result.status;
-  if (result.status == DepartureType::NONE && is_near_boundary) {
+  if (result.status == DepartureType::NONE && footprint_is_close_to_bound) {
     result.status = DepartureType::NEAR_BOUNDARY;
   }
 

--- a/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
@@ -42,7 +42,7 @@ UncrossableBoundaryChecker create_default_checker()
 
   // 2. Param
   UncrossableBoundaryDepartureParam param;
-  param.lateral_margin_m = 0.01;   // [m]
+  param.critical_departure_lateral_th_m = 0.01;  // [m]
   param.on_time_buffer_s = 0.15;   // 150ms of continuous violation to trigger CRITICAL
   param.off_time_buffer_s = 0.15;  // 150ms of continuous safety to clear CRITICAL
   param.max_deceleration_mps2 = -4.0;
@@ -185,7 +185,10 @@ TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
   auto res2 = checker.update_departure_status(traj_danger, state_danger, state);
 
   // Assert:
-  EXPECT_TRUE(res2.status == DepartureType::NONE) << "Should be NONE due to ON time buffer.";
+  EXPECT_TRUE(res2.status == DepartureType::NEAR_BOUNDARY)
+    << "CRITICAL is suppressed by the ON time buffer, but the advisory NEAR_BOUNDARY remains so "
+       "the "
+       "reported severity does not dip back to NONE.";
 
   // STEP 3: Wait for ON buffer to expire. Time increases by 0.2 seconds.
   // Act:

--- a/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -314,10 +315,13 @@ TEST(UncrossableBoundaryUtilsTest, TestGetMinLateralDistanceToBound)
   // Arrange:
   Side<std::optional<DeparturePointPair>> projections;
 
-  // Act & Assert: without any projection, the distance is unbounded.
-  EXPECT_DOUBLE_EQ(
-    severity_evaluator::get_min_lateral_distance_to_bound(projections),
-    std::numeric_limits<double>::max());
+  // Act & Assert: without any projection, the distance is infinity so consumers can filter it out.
+  EXPECT_TRUE(std::isinf(severity_evaluator::get_min_lateral_distance_to_bound(projections)));
+
+  // A projection whose segment lookup failed keeps the sentinel default and is ignored.
+  DeparturePointPair pair_without_segment;
+  projections.left = pair_without_segment;
+  EXPECT_TRUE(std::isinf(severity_evaluator::get_min_lateral_distance_to_bound(projections)));
 
   DeparturePointPair pair_left;
   pair_left.physical_departure_point.lat_dist = 0.8;
@@ -366,5 +370,30 @@ TEST(UncrossableBoundaryUtilsTest, TestAssignDepartureType)
   EXPECT_EQ(
     severity_evaluator::assign_departure_type(make_metrics(0.6, 20.0, 3.0), thresholds),
     DepartureType::NONE);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestNearBoundaryThresholdBelowCriticalMargin)
+{
+  // Verifies that a near boundary threshold configured below the critical margin does not leave a
+  // projection inside the critical margin classified as NONE.
+
+  // Arrange:
+  UncrossableBoundaryDepartureParam param;
+  param.critical_departure_lateral_th_m = 0.5;
+  param.near_boundary_lateral_th_m = 0.1;
+  param.time_to_departure_cutoff_s = 2.0;
+
+  ProjectionToBound projection(0);
+  projection.lat_dist = 0.3;  // inside the critical margin, outside the near boundary threshold
+  projection.dist_along_trajectory_m = 20.0;
+  projection.ego_front_to_proj_offset_m = 0.0;
+  projection.time_from_start = 3.0;
+
+  // Act:
+  const auto out = severity_evaluator::filter_and_assign_departure_types({projection}, param, 10.0);
+
+  // Assert:
+  ASSERT_EQ(out.size(), 1U);
+  EXPECT_EQ(out.front().departure_type, DepartureType::NEAR_BOUNDARY);
 }
 }  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
@@ -275,14 +275,96 @@ TEST(UncrossableBoundaryUtilsTest, TestIsSegmentWithinEgoHeight)
 TEST(UncrossableBoundaryUtilsTest, TestIsCritical)
 {
   // Arrange:
-  Side<std::optional<CriticalPointPair>> projections;
+  Side<std::optional<DeparturePointPair>> projections;
 
   // Act & Assert:
   EXPECT_FALSE(severity_evaluator::is_critical(projections));
 
-  CriticalPointPair pair_crit;
+  DeparturePointPair pair_crit;
   pair_crit.physical_departure_point.departure_type = DepartureType::CRITICAL;
   projections.left = pair_crit;
   EXPECT_TRUE(severity_evaluator::is_critical(projections));
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestIsNearBoundary)
+{
+  // Arrange:
+  Side<std::optional<DeparturePointPair>> projections;
+
+  // Act & Assert:
+  EXPECT_FALSE(severity_evaluator::is_near_boundary(projections));
+
+  DeparturePointPair pair_none;
+  pair_none.physical_departure_point.departure_type = DepartureType::NONE;
+  projections.left = pair_none;
+  EXPECT_FALSE(severity_evaluator::is_near_boundary(projections));
+
+  DeparturePointPair pair_near;
+  pair_near.physical_departure_point.departure_type = DepartureType::NEAR_BOUNDARY;
+  projections.right = pair_near;
+  EXPECT_TRUE(severity_evaluator::is_near_boundary(projections));
+
+  // A critical departure is not reported as near boundary.
+  projections.right->physical_departure_point.departure_type = DepartureType::CRITICAL;
+  EXPECT_FALSE(severity_evaluator::is_near_boundary(projections));
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestGetMinLateralDistanceToBound)
+{
+  // Arrange:
+  Side<std::optional<DeparturePointPair>> projections;
+
+  // Act & Assert: without any projection, the distance is unbounded.
+  EXPECT_DOUBLE_EQ(
+    severity_evaluator::get_min_lateral_distance_to_bound(projections),
+    std::numeric_limits<double>::max());
+
+  DeparturePointPair pair_left;
+  pair_left.physical_departure_point.lat_dist = 0.8;
+  projections.left = pair_left;
+  EXPECT_DOUBLE_EQ(severity_evaluator::get_min_lateral_distance_to_bound(projections), 0.8);
+
+  DeparturePointPair pair_right;
+  pair_right.physical_departure_point.lat_dist = 0.3;
+  projections.right = pair_right;
+  EXPECT_DOUBLE_EQ(severity_evaluator::get_min_lateral_distance_to_bound(projections), 0.3);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestAssignDepartureType)
+{
+  // Arrange:
+  DepartureCheckThresholds thresholds;
+  thresholds.min_braking_distance = 10.0;
+  thresholds.cutoff_time = 2.0;
+  thresholds.th_lat_critical = 0.1;
+  thresholds.th_near_boundary = 0.5;
+
+  const auto make_metrics = [](double lat_dist, double lon_dist, double time) {
+    ProjectionEvaluationMetrics metrics;
+    metrics.lat_dist = lat_dist;
+    metrics.lon_dist_to_departure = lon_dist;
+    metrics.time_from_start = time;
+    return metrics;
+  };
+
+  // Act & Assert: within the critical margin and unable to stop in time.
+  EXPECT_EQ(
+    severity_evaluator::assign_departure_type(make_metrics(0.05, 5.0, 3.0), thresholds),
+    DepartureType::CRITICAL);
+
+  // Within the critical margin but far enough ahead to stop: still near the boundary.
+  EXPECT_EQ(
+    severity_evaluator::assign_departure_type(make_metrics(0.05, 20.0, 3.0), thresholds),
+    DepartureType::NEAR_BOUNDARY);
+
+  // Between the two lateral thresholds.
+  EXPECT_EQ(
+    severity_evaluator::assign_departure_type(make_metrics(0.3, 20.0, 3.0), thresholds),
+    DepartureType::NEAR_BOUNDARY);
+
+  // Beyond the near boundary threshold.
+  EXPECT_EQ(
+    severity_evaluator::assign_departure_type(make_metrics(0.6, 20.0, 3.0), thresholds),
+    DepartureType::NONE);
 }
 }  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
@@ -313,7 +313,7 @@ TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityBackwardBuffer
   // Arrange:
   Side<ProjectionsToBound> input;
   UncrossableBoundaryDepartureParam param;
-  param.lateral_margin_m = 0.5;
+  param.critical_departure_lateral_th_m = 0.5;
   param.time_to_departure_cutoff_s = 2.0;
   param.longitudinal_margin_m = 1.0;
   double min_braking_dist = 10.0;
@@ -342,8 +342,12 @@ TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityBackwardBuffer
   });
 
   // Assert:
-  EXPECT_DOUBLE_EQ(result.left.physical_departure_point.dist_along_trajectory_m, 15.0);
-  EXPECT_DOUBLE_EQ(result.left.safety_buffer_start.dist_along_trajectory_m, 14.0);
+  ASSERT_TRUE(result.left.has_value());
+  EXPECT_DOUBLE_EQ(result.left->physical_departure_point.dist_along_trajectory_m, 15.0);
+  EXPECT_DOUBLE_EQ(result.left->safety_buffer_start.dist_along_trajectory_m, 14.0);
+
+  // Without a critical projection there is no departure pair to buffer backwards from.
+  EXPECT_FALSE(severity_evaluator::apply_backward_buffer_and_filter({}, param).has_value());
 }
 
 TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityNearBoundary)
@@ -356,7 +360,7 @@ TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityNearBoundary)
     0.383, 0.235, 2.79, 1.64, 1.0, 1.1, 2.5, 0.128, 0.128, 0.70);
 
   UncrossableBoundaryDepartureParam param;
-  param.lateral_margin_m = 0.01;
+  param.critical_departure_lateral_th_m = 0.01;
   param.near_boundary_lateral_th_m = 0.5;
   param.time_to_departure_cutoff_s = 2.0;
   param.longitudinal_margin_m = 1.0;

--- a/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
@@ -19,6 +19,7 @@
 #include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <gtest/gtest.h>
 
@@ -341,9 +342,63 @@ TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityBackwardBuffer
   });
 
   // Assert:
+  EXPECT_DOUBLE_EQ(result.left.physical_departure_point.dist_along_trajectory_m, 15.0);
+  EXPECT_DOUBLE_EQ(result.left.safety_buffer_start.dist_along_trajectory_m, 14.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityNearBoundary)
+{
+  // Verifies that a footprint that stays outside the critical margin is reported as
+  // NEAR_BOUNDARY at its closest projection.
+
+  // Arrange:
+  const auto vehicle_info = autoware::vehicle_info_utils::createVehicleInfo(
+    0.383, 0.235, 2.79, 1.64, 1.0, 1.1, 2.5, 0.128, 0.128, 0.70);
+
+  UncrossableBoundaryDepartureParam param;
+  param.lateral_margin_m = 0.01;
+  param.near_boundary_lateral_th_m = 0.5;
+  param.time_to_departure_cutoff_s = 2.0;
+  param.longitudinal_margin_m = 1.0;
+
+  EgoDynamicState ego_state;
+  ego_state.velocity = 0.0;
+  ego_state.acceleration = 0.0;
+
+  const auto create_pt = [](size_t idx, double lat_dist) {
+    ProjectionToBound pt(idx);
+    pt.lat_dist = lat_dist;
+    pt.dist_along_trajectory_m = 10.0 + static_cast<double>(idx);
+    pt.ego_front_to_proj_offset_m = 0.0;
+    pt.time_from_start = 3.0 + static_cast<double>(idx);
+    pt.pt_on_ego = {pt.dist_along_trajectory_m, lat_dist};
+    pt.pt_on_bound = {pt.dist_along_trajectory_m, 0.0};
+    return pt;
+  };
+
+  Side<ProjectionsToBound> input;
+  input.left.push_back(create_pt(0, 0.9));
+  input.left.push_back(create_pt(1, 0.4));
+  input.left.push_back(create_pt(2, 0.2));
+  input.left.push_back(create_pt(3, 0.6));
+
+  input.right.push_back(create_pt(0, 3.0));
+
+  // Act:
+  const auto result =
+    severity_evaluator::evaluate_projections_severity(input, param, ego_state, vehicle_info);
+
+  // Assert:
   ASSERT_TRUE(result.left.has_value());
-  EXPECT_DOUBLE_EQ(result.left->physical_departure_point.dist_along_trajectory_m, 15.0);
-  EXPECT_DOUBLE_EQ(result.left->safety_buffer_start.dist_along_trajectory_m, 14.0);
+  EXPECT_EQ(result.left->physical_departure_point.departure_type, DepartureType::NEAR_BOUNDARY);
+  EXPECT_DOUBLE_EQ(result.left->physical_departure_point.lat_dist, 0.2);
+
+  ASSERT_TRUE(result.right.has_value());
+  EXPECT_EQ(result.right->physical_departure_point.departure_type, DepartureType::NONE);
+
+  EXPECT_TRUE(severity_evaluator::is_near_boundary(result));
+  EXPECT_FALSE(severity_evaluator::is_critical(result));
+  EXPECT_DOUBLE_EQ(severity_evaluator::get_min_lateral_distance_to_bound(result), 0.2);
 }
 
 TEST(UncrossableBoundaryUtilsTest, TestBuildUncrossableBoundariesRTree)

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -158,6 +158,7 @@
       enable_developer_marker: false
       lateral_margin_m: 0.01
       longitudinal_margin_m: 1.0
+      near_boundary_lateral_th_m: 0.2
       max_deceleration_mps2: -4.0
       max_jerk_mps3: -5.0
       off_time_buffer_s: 0.10

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -149,6 +149,7 @@
       enable_developer_marker: false
       lateral_margin_m: 0.01
       longitudinal_margin_m: 1.0
+      near_boundary_lateral_th_m: 0.2
       max_deceleration_mps2: -4.0
       max_jerk_mps3: -5.0
       off_time_buffer_s: 0.10

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -533,6 +533,11 @@ validator:
       default_value: 0.01
       description: lateral margin [m]
       read_only: false
+    near_boundary_lateral_th_m:
+      type: double
+      default_value: 0.2
+      description: lateral distance below which the trajectory is flagged as near an uncrossable boundary [m]
+      read_only: false
     longitudinal_margin_m:
       type: double
       default_value: 1.0

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -496,6 +496,11 @@ validator:
       default_value: 0.01
       description: lateral margin [m]
       read_only: false
+    near_boundary_lateral_th_m:
+      type: double
+      default_value: 0.2
+      description: lateral distance below which the trajectory is flagged as near an uncrossable boundary [m]
+      read_only: false
     longitudinal_margin_m:
       type: double
       default_value: 1.0

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -738,6 +738,12 @@
               "description": "Lateral clearance margin from an uncrossable boundary [m]. Trajectories whose footprint comes within this margin are rejected.",
               "default": 0.01
             },
+            "near_boundary_lateral_th_m": {
+              "type": "number",
+              "description": "Lateral distance below which the trajectory is reported as near an uncrossable boundary [m]. Reported as a low caution risk level; it does not reject the trajectory.",
+              "default": 0.2,
+              "minimum": 0.0
+            },
             "longitudinal_margin_m": {
               "type": "number",
               "description": "Longitudinal look-ahead margin applied when projecting the vehicle footprint along the trajectory [m].",

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -675,6 +675,12 @@
               "description": "Lateral clearance margin from an uncrossable boundary [m]. Trajectories whose footprint comes within this margin are rejected.",
               "default": 0.01
             },
+            "near_boundary_lateral_th_m": {
+              "type": "number",
+              "description": "Lateral distance below which the trajectory is reported as near an uncrossable boundary [m]. Reported as a low caution risk level; it does not reject the trajectory.",
+              "default": 0.2,
+              "minimum": 0.0
+            },
             "longitudinal_margin_m": {
               "type": "number",
               "description": "Longitudinal look-ahead margin applied when projecting the vehicle footprint along the trajectory [m].",

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -81,7 +81,7 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
 
 void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Params & params)
 {
-  params_.lateral_margin_m = params.boundary_departure.lateral_margin_m;
+  params_.critical_departure_lateral_th_m = params.boundary_departure.lateral_margin_m;
   params_.near_boundary_lateral_th_m = params.boundary_departure.near_boundary_lateral_th_m;
   params_.longitudinal_margin_m = params.boundary_departure.longitudinal_margin_m;
   params_.max_deceleration_mps2 = params.boundary_departure.max_deceleration_mps2;

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -46,29 +46,43 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
 
   auto status = checker_->update_departure_status(traj_points, ego_state, hysteresis_state);
 
-  const bool is_feasible = status.status != boundary_departure_checker::DepartureType::CRITICAL;
+  const bool is_critical_departure =
+    status.status == boundary_departure_checker::DepartureType::CRITICAL;
 
-  if (!is_feasible) {
+  if (is_critical_departure) {
     std::move(
       status.debug_markers.markers.begin(), status.debug_markers.markers.end(),
       std::back_inserter(debug_markers_.markers));
   }
 
   RiskLevel risk_level;
-  risk_level.level = is_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
+  switch (status.status) {
+    case boundary_departure_checker::DepartureType::NEAR_BOUNDARY:
+      risk_level.level = RiskLevel::LOW_CAUTION;
+      break;
+    case boundary_departure_checker::DepartureType::CRITICAL:
+      risk_level.level = RiskLevel::DANGER;
+      break;
+    default:
+      risk_level.level = RiskLevel::SAFE;
+      break;
+  }
+
   std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
                                       .validator_name(get_name())
                                       .validator_category(category())
-                                      .metric_name("check_critical_departure")
-                                      .metric_value(is_feasible ? 1.0 : 0.0)
+                                      .metric_name("lat_dist_to_uncrossable_bound")
+                                      .metric_value(status.lat_dist_to_uncrossable_bound)
                                       .risk(risk_level)};
 
-  return ValidationResult{is_feasible, std::move(metrics)};
+  // Only a CRITICAL departure rejects the trajectory. NEAR_BOUNDARY is advisory.
+  return ValidationResult{!is_critical_departure, std::move(metrics)};
 }
 
 void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Params & params)
 {
   params_.lateral_margin_m = params.boundary_departure.lateral_margin_m;
+  params_.near_boundary_lateral_th_m = params.boundary_departure.near_boundary_lateral_th_m;
   params_.longitudinal_margin_m = params.boundary_departure.longitudinal_margin_m;
   params_.max_deceleration_mps2 = params.boundary_departure.max_deceleration_mps2;
   params_.max_jerk_mps3 = params.boundary_departure.max_jerk_mps3;

--- a/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-outlier-filter.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-outlier-filter.md
@@ -616,6 +616,7 @@ auto node = std::make_shared<autoware::pointcloud_preprocessor::PolarVoxelOutlie
 #### Mode Selection Guidelines
 
 - **Choose visibility-only mode when**:
+
   - Only diagnostic information is needed
   - Computational resources are limited
   - Running parallel monitoring alongside main processing

--- a/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-outlier-filter.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-outlier-filter.md
@@ -616,7 +616,6 @@ auto node = std::make_shared<autoware::pointcloud_preprocessor::PolarVoxelOutlie
 #### Mode Selection Guidelines
 
 - **Choose visibility-only mode when**:
-
   - Only diagnostic information is needed
   - Computational resources are limited
   - Running parallel monitoring alongside main processing


### PR DESCRIPTION
## Description

The uncrossable boundary departure filter was binary: either a trajectory was rejected as a CRITICAL departure, or it was reported as perfectly SAFE. There was no way to see a trajectory grazing a curb until the moment it became a rejection, and the published metric was a bare 1.0/0.0 flag that carried no distance information.

In this PR

- The `APPROACHING` departure type is replaced by `NEAR_BOUNDARY`, assigned when a footprint projection comes within the new `near_boundary_lateral_th_m` but ego can still brake before the boundary. It maps to `RiskLevel::LOW_CAUTION` and does **not** reject the trajectory; only CRITICAL does.
- The published metric changes from `check_critical_departure` (1.0 good, 0.0 bad) to `lat_dist_to_uncrossable_bound`, the smallest lateral distance to a boundary across both sides, so the metric shows how close trajectory actually came.
- A CRITICAL departure will return LOW_CAUTION if the hysteresis time is less than ON time buffer.
- Also renames `UncrossableBoundaryDepartureParam::lateral_margin_m` to `critical_departure_lateral_th_m` so it reads as the threshold it is and pairs with `near_boundary_lateral_th_m`. Library-internal only; the ROS parameter (trajectory validator side) keeps its name.

## Related links

**Parent Issue:**

- [TIER IV internal ticket](https://tier4.atlassian.net/browse/PDDP-269)

## How was this PR tested?

- Run autoware, place ego vehicle near boundary (near but not enough to trigger critical), and echo validation report. 

```
ros2 topic echo /planning/trajectory_selector/trajectory_selector_node/debug/validator/validation_reports | grep uncrossable_boundary_departure_filter -A 5
```

## Notes for reviewers

`near_boundary_lateral_th_m` defaults to 0.2 m against a `lateral_margin_m` of 0.01 m. On a narrow road an X2 bus will sit in the LOW_CAUTION band for long stretches, which demotes the trajectory in `trajectory_ranker` and inflates the validation error rate when `count_other_than_safe_as_error` is set. There is no MRM effect, since LOW_CAUTION maps to `Action::NONE`. The default needs validation against real logs.

One unrelated line is included: a markdown list-spacing fix in `docs/polar-voxel-outlier-filter.md` applied by pre-commit.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                                     | Type     | Default Value | Description                                                                                                       |
| :---------- | :------------------------------------------------- | :------- | :------------ | :---------------------------------------------------------------------------------------------------------------- |
| Added       | `boundary_departure.near_boundary_lateral_th_m`     | `double` | `0.2`         | Lateral distance below which the trajectory is reported as near an uncrossable boundary [m]. Advisory, not a reject |

No parameter is renamed or removed. `boundary_departure.lateral_margin_m` keeps its name and default.

### Metric changes

| Version | Metric Name                     | Value semantics                                             |
| :------ | :------------------------------ | :---------------------------------------------------------- |
| Old     | `check_critical_departure`      | `1.0` when feasible, `0.0` when a critical departure        |
| New     | `lat_dist_to_uncrossable_bound` | Smallest lateral distance to a boundary [m], smaller is worse |

## Effects on system behavior

A trajectory whose footprint comes within `near_boundary_lateral_th_m` of an uncrossable boundary is now reported as LOW_CAUTION instead of SAFE. It is still not rejected, but it scores lower in `trajectory_ranker`, so a boundary-hugging candidate loses to an equivalent one with more clearance. With the 0.2 m default this fires on narrow roads.

While the ON-time buffer debounces a critical departure, the filter reports LOW_CAUTION where it previously reported SAFE.

No change to when a trajectory is rejected, and no change to when an MRM is requested.
