### PR TITLE
fix(mpc_lateral_controller): infer driving direction from velocity and a metric baseline

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -29,6 +29,7 @@
 
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -241,6 +242,13 @@ void extendTrajectoryInYawDirection(
  * @return clipped trajectory
  */
 MPCTrajectory clipTrajectoryByLength(const MPCTrajectory & trajectory, const double length);
+
+/**
+ * @brief Estimate whether the reference trajectory is driven forward or backward.
+ * @param [in] reference trajectory
+ * @return driving direction, otherwise std::nullopt
+ */
+std::optional<bool> infer_forward_driving(const MPCTrajectory & trajectory);
 
 /**
  * @brief Updates the value of a parameter with the given name.

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -39,7 +39,6 @@ using autoware_utils::rad2deg;
 
 namespace
 {
-
 bool interpolateReferenceStateAtTime(
   const MPCTrajectory & traj, const double target_time, Pose * pose, double * nearest_time,
   size_t * nearest_index)
@@ -293,11 +292,10 @@ void MPC::setReferenceTrajectory(
     mpc_traj_resampled = resampled;
   }
 
-  const auto is_forward_shift =
-    autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
-
-  // if driving direction is unknown, use previous value
-  m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
+  if (const auto is_forward_shift_opt = MPCUtils::infer_forward_driving(mpc_traj_resampled)) {
+    // if driving direction is unknown, use previous value
+    m_is_forward_shift = is_forward_shift_opt.value();
+  }
 
   // path smoothing
   MPCTrajectory mpc_traj_smoothed = mpc_traj_resampled;  // smooth filtered trajectory

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -786,5 +786,38 @@ MPCTrajectory clipTrajectoryByLength(const MPCTrajectory & trajectory, const dou
   return clipped_trajectory;
 }
 
+/**
+ * @brief Estimate whether the reference trajectory is driven forward or backward.
+ */
+std::optional<bool> infer_forward_driving(const MPCTrajectory & trajectory)
+{
+  constexpr double min_velocity_for_direction = 0.1;           // [m/s]
+  constexpr double min_baseline_for_direction_squared = 0.25;  // [m]
+
+  if (trajectory.size() < 2) {
+    return std::nullopt;
+  }
+
+  for (const auto velocity : trajectory.vx) {
+    if (std::abs(velocity) > min_velocity_for_direction) {
+      return velocity > 0.0;
+    }
+  }
+
+  // The trajectory is stop-like. Fall back to the geometry, but only over a baseline long enough to
+  // measure a direction from.
+  const double front_yaw = trajectory.yaw.front();
+  for (size_t i = 1; i < trajectory.size(); ++i) {
+    const double dx = trajectory.x.at(i) - trajectory.x.front();
+    const double dy = trajectory.y.at(i) - trajectory.y.front();
+    const double dist_squared = dx * dx + dy * dy;
+    if (dist_squared < min_baseline_for_direction_squared) {
+      continue;
+    }
+    return std::abs(normalize_radian(front_yaw - std::atan2(dy, dx))) < M_PI_2;
+  }
+
+  return std::nullopt;
+}
 }  // namespace MPCUtils
 }  // namespace autoware::motion::control::mpc_lateral_controller

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -792,7 +792,7 @@ MPCTrajectory clipTrajectoryByLength(const MPCTrajectory & trajectory, const dou
 std::optional<bool> infer_forward_driving(const MPCTrajectory & trajectory)
 {
   constexpr double min_velocity_for_direction = 0.1;           // [m/s]
-  constexpr double min_baseline_for_direction_squared = 0.25;  // [m]
+  constexpr double min_baseline_for_direction_squared = 0.25;  // [m^2]
 
   if (trajectory.size() < 2) {
     return std::nullopt;

--- a/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
@@ -22,6 +22,7 @@
 
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace
@@ -69,7 +70,96 @@ autoware::motion::control::mpc_lateral_controller::MPCTrajectory makeStraightTra
   return traj;
 }
 
+// Builds a trajectory whose points all sit on the heading direction, spaced by point_interval, with
+// a constant velocity. A zero point_interval reproduces a temporal trajectory at standstill, where
+// every point collapses onto the same position.
+autoware::motion::control::mpc_lateral_controller::MPCTrajectory makeDirectionalTrajectory(
+  const int num_points, const double heading_yaw, const double point_interval,
+  const double velocity)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  MPCTrajectory traj;
+  for (int i = 0; i < num_points; ++i) {
+    const double distance_from_start = static_cast<double>(i) * point_interval;
+    traj.push_back(
+      distance_from_start * std::cos(heading_yaw), distance_from_start * std::sin(heading_yaw), 0.0,
+      heading_yaw, velocity, 0.0, 0.0, static_cast<double>(i) * 0.1);
+  }
+  return traj;
+}
+
 /* cppcheck-suppress syntaxError */
+TEST(TestMPCUtils, InferForwardDrivingFromVelocitySign)
+{
+  // Moving trajectories are decided by the velocity sign, independently of point spacing.
+  const auto forward_traj = makeDirectionalTrajectory(10, M_PI, 0.5, 3.0);
+  const auto backward_traj = makeDirectionalTrajectory(10, M_PI, 0.5, -3.0);
+
+  EXPECT_EQ(MPCUtils::infer_forward_driving(forward_traj), std::optional<bool>(true));
+  EXPECT_EQ(MPCUtils::infer_forward_driving(backward_traj), std::optional<bool>(false));
+}
+
+TEST(TestMPCUtils, InferForwardDrivingIgnoresLeadingStopPoints)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  // A trajectory that starts from standstill and accelerates: the first non-negligible velocity
+  // decides the direction.
+  MPCTrajectory traj;
+  traj.push_back(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  traj.push_back(0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.1);
+  traj.push_back(0.1, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.2);
+  traj.push_back(0.5, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.3);
+
+  EXPECT_EQ(MPCUtils::infer_forward_driving(traj), std::optional<bool>(true));
+}
+
+TEST(TestMPCUtils, InferForwardDrivingOnCollapsedStopTrajectory)
+{
+  // Regression: a stopped temporal trajectory has zero point spacing, so the azimuth between the
+  // first two points is meaningless. The direction must be reported as unknown instead of being
+  // derived from atan2(0, 0), which used to flip the direction for headings away from +x and
+  // rotate every reference yaw by pi.
+  for (const double heading_yaw : {0.0, M_PI_2, M_PI, -M_PI_2, 2.5, -2.5}) {
+    const auto stopped_traj = makeDirectionalTrajectory(50, heading_yaw, 0.0, 0.0);
+    EXPECT_EQ(MPCUtils::infer_forward_driving(stopped_traj), std::nullopt)
+      << "heading_yaw = " << heading_yaw;
+  }
+}
+
+TEST(TestMPCUtils, InferForwardDrivingOnCreepingTrajectory)
+{
+  // Below the velocity threshold the point spacing is still too short to measure a direction from,
+  // so the direction stays unknown and the caller keeps its previous value.
+  const auto creeping_traj = makeDirectionalTrajectory(10, M_PI, 0.005, 0.05);
+  EXPECT_EQ(MPCUtils::infer_forward_driving(creeping_traj), std::nullopt);
+}
+
+TEST(TestMPCUtils, InferForwardDrivingFromGeometryWhenStopped)
+{
+  // Zero velocity but a long enough geometric baseline: the direction comes from the trajectory
+  // shape relative to the trajectory heading.
+  const auto forward_traj = makeDirectionalTrajectory(20, M_PI, 0.1, 0.0);
+  EXPECT_EQ(MPCUtils::infer_forward_driving(forward_traj), std::optional<bool>(true));
+
+  // Same points, but the stored heading is reversed, i.e. the trajectory runs behind the vehicle.
+  auto backward_traj = forward_traj;
+  for (auto & yaw : backward_traj.yaw) {
+    yaw = 0.0;
+  }
+  EXPECT_EQ(MPCUtils::infer_forward_driving(backward_traj), std::optional<bool>(false));
+}
+
+TEST(TestMPCUtils, InferForwardDrivingWithTooFewPoints)
+{
+  const auto empty_traj = makeDirectionalTrajectory(0, 0.0, 0.5, 3.0);
+  const auto single_point_traj = makeDirectionalTrajectory(1, 0.0, 0.5, 3.0);
+
+  EXPECT_EQ(MPCUtils::infer_forward_driving(empty_traj), std::nullopt);
+  EXPECT_EQ(MPCUtils::infer_forward_driving(single_point_traj), std::nullopt);
+}
+
 TEST(TestMPC, CalcStopDistance)
 {
   constexpr float MOVE = 1.0f;


### PR DESCRIPTION
## Description

`/control/trajectory_follower/lateral/predicted_trajectory` was published with poses rotated by 180° from the input trajectory, and flipping back and forth between cycles, when ego was at low velocity or stopped.

The driving direction of the reference trajectory was decided by `motion_utils::isDrivingForward()`, which takes the azimuth between the **first two trajectory points** and compares it against the first point's heading. 

https://github.com/user-attachments/assets/4992ec35-f16a-41e1-82d1-6a03bbf2da85

### Change

New `MPCUtils::infer_forward_driving()` replaces the `isDrivingForward()` call in `MPC::setReferenceTrajectory()`:

1. If any trajectory point has `|vx| > 0.1 m/s`, the direction is the sign of that velocity.
2. Otherwise (stop-like trajectory), the azimuth is taken over the first point pair separated by at least 0.5 m, compared against the trajectory heading.
3. If neither is available, it returns `std::nullopt` and the caller keeps the previous `m_is_forward_shift` value, as it already did for the unknown case.

The fix is in the direction estimate itself, not gated on the trajectory mode, so spatial mode gets the same guarantee.

| Before | After |
|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/e428ff0e-ea38-45a2-95d6-1197c43ee7b7" width="100%" controls></video> | <video src="https://github.com/user-attachments/assets/f866345f-cc58-4471-a294-4c7db4985a79" width="100%" controls></video> |


## Related links

**Parent Issue:**

- [TIER IV Internal link](https://tier4.atlassian.net/browse/PDDP-455)

## How was this PR tested?

- rosbag-based testing.

## Notes for reviewers

The same defect exists in `autoware_utils_geometry::is_driving_forward()` for every other caller — it reports a direction from an arbitrarily short baseline and never signals "unknown". Fixing it there would be the broader change; this PR contains the fix at the MPC call site.

## Interface changes

None.

## Effects on system behavior

None