### PR TITLE
fix(mpc_lateral_controller): use minimum distance between points to compute reference yaw

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -68,6 +68,28 @@ bool isTemporalShortSegment(
   const double expected_distance = std::max(std::fabs(vx), min_velocity_floor) * bounded_dt;
   return ds < expected_distance_ratio * expected_distance;
 }
+
+std::pair<size_t, size_t> findYawDifferentiationWindow(
+  const std::vector<double> & arc_length, const size_t idx, const double min_baseline_m)
+{
+  if (arc_length.size() == 1) return {0, 0};
+
+  const size_t last = arc_length.size() - 1;
+  size_t front = (idx > 0) ? idx - 1 : 0;
+  size_t back = (idx < last) ? idx + 1 : last;
+  while (arc_length.at(back) - arc_length.at(front) < min_baseline_m) {
+    if (front == 0 && back == last) {
+      break;
+    }
+    if (front > 0) {
+      --front;
+    }
+    if (back < last) {
+      ++back;
+    }
+  }
+  return {front, back};
+}
 }  // namespace
 
 namespace MPCUtils
@@ -267,54 +289,44 @@ void calcTrajectoryYawFromXY(
 
   const auto input_yaw = traj.yaw;
 
-  // interpolate yaw
-  for (int i = 1; i < static_cast<int>(traj.yaw.size()) - 1; ++i) {
-    const double dx = traj.x.at(i + 1) - traj.x.at(i - 1);
-    const double dy = traj.y.at(i + 1) - traj.y.at(i - 1);
-    const auto curr_idx = static_cast<size_t>(i);
-    const double prev_dist = calcDistance2d(traj, curr_idx, curr_idx - 1);
-    const double next_dist = calcDistance2d(traj, curr_idx + 1, curr_idx);
-    const double prev_dt = traj.relative_time.at(curr_idx) - traj.relative_time.at(curr_idx - 1);
-    const double next_dt = traj.relative_time.at(curr_idx + 1) - traj.relative_time.at(curr_idx);
-    const double prev_vx = 0.5 * (traj.vx.at(curr_idx - 1) + traj.vx.at(curr_idx));
-    const double next_vx = 0.5 * (traj.vx.at(curr_idx) + traj.vx.at(curr_idx + 1));
+  // The differentiation baseline must be a fixed metric length, not a fixed number of index
+  // steps. Point spacing depends on the resampling mode (v * dt for temporal trajectories), so
+  // an index-based baseline shrinks at low speed and amplifies the XY noise into the yaw.
+  std::vector<double> arc_length;
+  calcMPCTrajectoryArcLength(traj, arc_length);
+
+  constexpr double min_yaw_baseline_m = 0.5;
+
+  const auto is_short_segment = [&](const size_t front, const size_t back) {
+    const double ds = calcDistance2d(traj, back, front);
+    const double dt = traj.relative_time.at(back) - traj.relative_time.at(front);
+    const double vx = 0.5 * (traj.vx.at(front) + traj.vx.at(back));
+    return isTemporalShortSegment(ds, dt, vx, use_input_yaw_for_short_segment);
+  };
+
+  for (size_t i = 0; i < traj.yaw.size(); ++i) {
+    // points bunched together (e.g. a stopped vehicle) carry no reliable direction of their own,
+    // regardless of how long a baseline the surrounding points could provide
     if (
-      std::hypot(dx, dy) < 1.0e-3 ||
-      isTemporalShortSegment(prev_dist, prev_dt, prev_vx, use_input_yaw_for_short_segment) ||
-      isTemporalShortSegment(next_dist, next_dt, next_vx, use_input_yaw_for_short_segment)) {
-      traj.yaw.at(i) = use_input_yaw_for_short_segment ? input_yaw.at(i) : traj.yaw.at(i - 1);
+      (i > 0 && is_short_segment(i - 1, i)) ||
+      (i + 1 < traj.yaw.size() && is_short_segment(i, i + 1))) {
+      traj.yaw.at(i) =
+        (use_input_yaw_for_short_segment || i == 0) ? input_yaw.at(i) : traj.yaw.at(i - 1);
+      continue;
+    }
+
+    const auto [front, back] = findYawDifferentiationWindow(arc_length, i, min_yaw_baseline_m);
+    const double dx = traj.x.at(back) - traj.x.at(front);
+    const double dy = traj.y.at(back) - traj.y.at(front);
+    if (
+      arc_length.at(back) - arc_length.at(front) < min_yaw_baseline_m ||
+      std::hypot(dx, dy) < 1.0e-3) {
+      // the trajectory is too short to differentiate reliably: keep the input yaw
+      traj.yaw.at(i) =
+        (use_input_yaw_for_short_segment || i == 0) ? input_yaw.at(i) : traj.yaw.at(i - 1);
       continue;
     }
     traj.yaw.at(i) = is_forward_shift ? std::atan2(dy, dx) : std::atan2(dy, dx) + M_PI;
-  }
-  if (traj.yaw.size() > 1) {
-    const double dx0 = traj.x.at(1) - traj.x.at(0);
-    const double dy0 = traj.y.at(1) - traj.y.at(0);
-    const double ds0 = calcDistance2d(traj, 1, 0);
-    const double dt0 = traj.relative_time.at(1) - traj.relative_time.at(0);
-    const double vx0 = 0.5 * (traj.vx.at(0) + traj.vx.at(1));
-    if (
-      std::hypot(dx0, dy0) >= 1.0e-3 &&
-      !isTemporalShortSegment(ds0, dt0, vx0, use_input_yaw_for_short_segment)) {
-      traj.yaw.at(0) = is_forward_shift ? std::atan2(dy0, dx0) : std::atan2(dy0, dx0) + M_PI;
-    } else {
-      traj.yaw.at(0) = use_input_yaw_for_short_segment ? input_yaw.at(0) : traj.yaw.at(1);
-    }
-
-    const size_t last = traj.yaw.size() - 1;
-    const double dxn = traj.x.at(last) - traj.x.at(last - 1);
-    const double dyn = traj.y.at(last) - traj.y.at(last - 1);
-    const double dsn = calcDistance2d(traj, last, last - 1);
-    const double dtn = traj.relative_time.at(last) - traj.relative_time.at(last - 1);
-    const double vxn = 0.5 * (traj.vx.at(last - 1) + traj.vx.at(last));
-    if (
-      std::hypot(dxn, dyn) >= 1.0e-3 &&
-      !isTemporalShortSegment(dsn, dtn, vxn, use_input_yaw_for_short_segment)) {
-      traj.yaw.back() = is_forward_shift ? std::atan2(dyn, dxn) : std::atan2(dyn, dxn) + M_PI;
-    } else {
-      traj.yaw.back() =
-        use_input_yaw_for_short_segment ? input_yaw.at(last) : traj.yaw.at(last - 1);
-    }
   }
 }
 

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -72,7 +72,7 @@ bool isTemporalShortSegment(
 std::pair<size_t, size_t> findYawDifferentiationWindow(
   const std::vector<double> & arc_length, const size_t idx, const double min_baseline_m)
 {
-  if (arc_length.size() == 1) return {0, 0};
+  if (arc_length.size() <= 1) return {0, 0};
 
   const size_t last = arc_length.size() - 1;
   size_t front = (idx > 0) ? idx - 1 : 0;

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -289,9 +289,6 @@ void calcTrajectoryYawFromXY(
 
   const auto input_yaw = traj.yaw;
 
-  // The differentiation baseline must be a fixed metric length, not a fixed number of index
-  // steps. Point spacing depends on the resampling mode (v * dt for temporal trajectories), so
-  // an index-based baseline shrinks at low speed and amplifies the XY noise into the yaw.
   std::vector<double> arc_length;
   calcMPCTrajectoryArcLength(traj, arc_length);
 

--- a/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
@@ -20,6 +20,7 @@
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <vector>
@@ -65,6 +66,43 @@ autoware::motion::control::mpc_lateral_controller::MPCTrajectory makeStraightTra
   for (int i = 0; i < num_points; ++i) {
     const double s = static_cast<double>(i) / static_cast<double>(num_points - 1) * length;
     traj.push_back(s, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, static_cast<double>(i) * 0.1);
+  }
+  return traj;
+}
+
+// Temporal trajectories are spaced by velocity * time_step, so a low speed produces a very dense
+// trajectory. These helpers keep spacing, velocity and time step mutually consistent so that the
+// short-segment protection treats the points as normally spaced rather than bunched.
+autoware::motion::control::mpc_lateral_controller::MPCTrajectory makeDenseStraightTrajectory(
+  const int num_points, const double point_spacing, const double heading, const double velocity,
+  const double time_step)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  MPCTrajectory traj;
+  for (int i = 0; i < num_points; ++i) {
+    const double distance = static_cast<double>(i) * point_spacing;
+    traj.push_back(
+      distance * std::cos(heading), distance * std::sin(heading), 0.0, 0.0, velocity, 0.0, 0.0,
+      static_cast<double>(i) * time_step);
+  }
+  return traj;
+}
+
+// Constant-curvature arc starting at the origin with zero heading. The heading at index i is
+// exactly i * point_spacing / radius, which gives an analytic reference for the computed yaw.
+autoware::motion::control::mpc_lateral_controller::MPCTrajectory makeDenseArcTrajectory(
+  const int num_points, const double point_spacing, const double radius, const double velocity,
+  const double time_step)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  MPCTrajectory traj;
+  for (int i = 0; i < num_points; ++i) {
+    const double heading = static_cast<double>(i) * point_spacing / radius;
+    traj.push_back(
+      radius * std::sin(heading), radius * (1.0 - std::cos(heading)), 0.0, 0.0, velocity, 0.0, 0.0,
+      static_cast<double>(i) * time_step);
   }
   return traj;
 }
@@ -286,6 +324,92 @@ TEST(TestMPC, TemporalYawAndCurvatureStayStableForShortSegments)
   EXPECT_NEAR(traj.k.at(0), 0.0, 1e-6);
   EXPECT_NEAR(traj.k.at(1), 0.0, 1e-6);
   EXPECT_NEAR(traj.k.at(2), 0.0, 1e-6);
+}
+
+TEST(TestMPC, YawRejectsPositionNoiseOnDenselySpacedTrajectory)
+{
+  // 0.4 m/s with a 0.1 s time step gives 4 cm spacing, the condition under which the defect showed
+  // up on the vehicle. A sub-millimetre lateral offset between the immediate neighbours of a point
+  // used to be divided by an 8 cm baseline and became a ~1.3 deg yaw error.
+  constexpr int num_points = 25;
+  constexpr double point_spacing = 0.04;
+  constexpr double velocity = 0.4;
+  constexpr double time_step = 0.1;
+  constexpr size_t target_index = 10;
+  constexpr double position_noise = 0.9e-3;
+
+  auto traj = makeDenseStraightTrajectory(num_points, point_spacing, 0.0, velocity, time_step);
+  traj.y.at(target_index - 1) = -position_noise;
+  traj.y.at(target_index + 1) = +position_noise;
+
+  MPCUtils::calcTrajectoryYawFromXY(traj, true, true);
+
+  // an index-based baseline would return atan2(1.8e-3, 0.08) = 0.0225 rad here
+  EXPECT_NEAR(traj.yaw.at(target_index), 0.0, 1.0e-6);
+  for (size_t i = 0; i < traj.yaw.size(); ++i) {
+    EXPECT_NEAR(traj.yaw.at(i), 0.0, 5.0e-3) << "yaw at index " << i;
+  }
+}
+
+TEST(TestMPC, YawStaysUnbiasedOnConstantCurvature)
+{
+  // Widening the differentiation window must not cut the corner: a chord spanning a symmetric
+  // window of a circular arc points along the tangent at the middle of that window.
+  constexpr int num_points = 200;
+  constexpr double point_spacing = 0.04;
+  constexpr double radius = 20.0;
+  constexpr double velocity = 0.4;
+  constexpr double time_step = 0.1;
+
+  auto traj = makeDenseArcTrajectory(num_points, point_spacing, radius, velocity, time_step);
+
+  MPCUtils::calcTrajectoryYawFromXY(traj, true, true);
+
+  // the window is symmetric only away from the ends, where it can no longer expand on both sides
+  constexpr size_t window_half_width = 7;
+  for (size_t i = window_half_width; i + window_half_width < traj.yaw.size(); ++i) {
+    const double expected_yaw = static_cast<double>(i) * point_spacing / radius;
+    EXPECT_NEAR(traj.yaw.at(i), expected_yaw, 1.0e-6) << "yaw at index " << i;
+  }
+}
+
+TEST(TestMPC, YawIsUnchangedWhenSpacingAlreadyExceedsBaseline)
+{
+  // At road speed the natural spacing is longer than the minimum baseline, so the window stays at
+  // the immediate neighbours and the result is identical to the previous implementation.
+  constexpr int num_points = 10;
+  constexpr double point_spacing = 1.0;
+  constexpr double heading = M_PI_4;
+  constexpr double velocity = 10.0;
+  constexpr double time_step = 0.1;
+
+  auto traj = makeDenseStraightTrajectory(num_points, point_spacing, heading, velocity, time_step);
+
+  MPCUtils::calcTrajectoryYawFromXY(traj, true, true);
+
+  for (size_t i = 0; i < traj.yaw.size(); ++i) {
+    EXPECT_NEAR(traj.yaw.at(i), heading, 1.0e-9) << "yaw at index " << i;
+  }
+}
+
+TEST(TestMPC, YawFallsBackToInputWhenTrajectoryIsShorterThanBaseline)
+{
+  // The whole trajectory spans 0.2 m, so no window can reach the minimum baseline. Rather than
+  // differentiating over whatever is available, the planner's own yaw is kept.
+  constexpr int num_points = 5;
+  constexpr double point_spacing = 0.05;
+  constexpr double velocity = 0.5;
+  constexpr double time_step = 0.1;
+  constexpr double input_yaw = 0.7;
+
+  auto traj = makeDenseStraightTrajectory(num_points, point_spacing, 0.0, velocity, time_step);
+  std::fill(traj.yaw.begin(), traj.yaw.end(), input_yaw);
+
+  MPCUtils::calcTrajectoryYawFromXY(traj, true, true);
+
+  for (size_t i = 0; i < traj.yaw.size(); ++i) {
+    EXPECT_NEAR(traj.yaw.at(i), input_yaw, 1.0e-9) << "yaw at index " << i;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

At low speed the vehicle footprint drawn from the lateral controller's predicted trajectory appeared visibly rotated against the actual ego pose, enough to swing the footprint corners several centimetres on a long vehicle.

The controller derives the heading of each reference point by differentiating position: it takes two points either side of the point of interest and measures the direction of the line between them. The accuracy of that estimate depends entirely on how far apart those two points are. A small positional inaccuracy divided by a long baseline is a small angle; the same inaccuracy divided by a short baseline is a large one.

Historically the controller resampled the reference trajectory to a fixed spacing before any geometric processing, so "two points apart" was always the same physical distance and the estimate was well conditioned at every speed. Temporal trajectory support removed that resampling in order to preserve the planner's timestamps. Point spacing then became a function of velocity, and at walking pace the differentiation baseline collapsed to a fraction of its intended length. Sub-millimetre round-off in the planner's positions, far too small for any plausibility check to flag, and harmless in itself, was amplified into a degree-scale heading error.


| Before | After |
|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/feea665e-0afa-4427-8c98-3fc452cbbdb3" width="100%" controls></video> | <video src="https://github.com/user-attachments/assets/05da2250-8b12-4ca4-8378-31cba2cc6f91" width="100%" controls></video> |
| Large yaw deviation which triggers boundary departure | Large yaw deviation no longer present |

## Related links

**Parent Issue:**

- [TIER IV Internal link](https://tier4.atlassian.net/browse/PDDP-474)

## How was this PR tested?

- rosbag-based testing.

## Notes for reviewers

Existing guards did not catch this. They check whether a point is anomalously close to its neighbour *given the current velocity*, which detects duplicated or overlapped points. Here the spacing was perfectly consistent with velocity; it was simply too short to measure a direction from. Consistency and adequacy are different properties, and only the first was being tested.

Because the reference heading seeds the world-frame state the controller predicts forward from, and because forward integration contributes almost nothing at low speed, the error passed straight through to the published predicted trajectory. This affected any downstream consumer reasoning about the predicted pose; it did not affect the optimiser's own solution, which works in a relative frame.


## Interface changes

None.

## Effects on system behavior

None








