### PR TITLE
fix(trajectory_validator): refactor large process function

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -160,6 +160,13 @@ if(BUILD_TESTING)
     ${trajectory_validator_lib_target}
   )
 
+  ament_add_gtest(test_trajectory_validator
+    test/detail/test_trajectory_validator.cpp
+  )
+  target_link_libraries(test_trajectory_validator
+    ${trajectory_validator_lib_target}
+  )
+
   ament_add_ros_isolated_gtest(test_diagnostic_core_behavior
     test/diagnostic/diagnostic_core_behavior.cpp
   )

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator.hpp
@@ -16,12 +16,21 @@
 #define AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__TRAJECTORY_VALIDATOR_HPP_
 
 #include "autoware/trajectory_validator/detail/trajectory_validator_report.hpp"
+#include "autoware/trajectory_validator/detail/uuid_hash.hpp"
 #include "autoware/trajectory_validator/detail/validator_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "autoware_trajectory_validator/autoware_trajectory_validator_param.hpp"
 
+#include <autoware_utils_system/stop_watch.hpp>
+
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -29,6 +38,30 @@
 namespace autoware::trajectory_validator
 {
 using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::CandidateTrajectories;
+using autoware_internal_planning_msgs::msg::GeneratorInfo;
+using autoware_trajectory_validator::msg::MetricReport;
+using autoware_trajectory_validator::msg::RiskLevel;
+using autoware_trajectory_validator::msg::ValidationReport;
+
+/** @brief Generator info paired with its hex-string UUID, precomputed once to avoid reconversion.
+ */
+struct GeneratorInfoEntry
+{
+  GeneratorInfo info;
+  std::string hex_generator_id;
+};
+
+using GeneratorInfoMap = std::unordered_map<std::array<uint8_t, 16>, GeneratorInfoEntry, UuidHash>;
+
+/** @brief Per-trajectory output of running every plugin against one candidate trajectory. */
+struct PluginsValidationResult
+{
+  EvaluationTable table;
+  std::vector<MetricReport> combined_metrics;
+  autoware_internal_planning_msgs::msg::PlanningFactorArray planning_factors;
+  std::unordered_map<std::string, double> processing_time_ms;
+};
 
 /**
  * @brief Runs a set of validator plugins against each candidate trajectory.
@@ -62,14 +95,73 @@ public:
    * @param context Current world state snapshot.
    */
   [[nodiscard]] TrajectoryValidatorReport process(
-    const autoware_internal_planning_msgs::msg::CandidateTrajectories & input_trajectories,
+    const CandidateTrajectories & input_trajectories,
     const std::unordered_set<std::string> & active_filter_names,
     const ValidatorContext & context) const;
 
 private:
+  /**
+   * @brief Builds a lookup from each trajectory's raw UUID bytes to its generator info.
+   * @param input_trajectories Candidate trajectories carrying the generator info to index.
+   */
+  [[nodiscard]] GeneratorInfoMap build_uuid_to_generator_info(
+    const CandidateTrajectories & input_trajectories) const;
+
+  /**
+   * @brief Resolves a candidate trajectory's generator info, tolerating a missing lookup entry.
+   * @param generator_id Trajectory's generator UUID.
+   * @param uuid_to_generator_info Lookup built by build_uuid_to_generator_info.
+   */
+  [[nodiscard]] GeneratorInfoEntry resolve_generator_info(
+    const unique_identifier_msgs::msg::UUID & generator_id,
+    const GeneratorInfoMap & uuid_to_generator_info) const;
+
+  /**
+   * @brief Runs every plugin against one candidate trajectory and collects their results.
+   * @param plugins Validator plugins to run.
+   * @param hex_generator_id Trajectory's generator UUID as a hex string.
+   * @param candidate_trajectory Trajectory to evaluate.
+   * @param context Current world state snapshot.
+   */
+  [[nodiscard]] PluginsValidationResult validate_candidate_trajectory(
+    const std::vector<std::shared_ptr<plugin::ValidatorInterface>> & plugins,
+    const std::string & hex_generator_id,
+    const autoware_internal_planning_msgs::msg::CandidateTrajectory & candidate_trajectory,
+    const ValidatorContext & context) const;
+
+  /**
+   * @brief Turns one plugin's feasibility result into a plugin evaluation and risk level.
+   * @param res Plugin's feasibility result, or an error string on failure.
+   * @param plugin_name Name of the plugin that produced the result.
+   * @param is_shadow_mode Whether the plugin is running in shadow mode.
+   */
+  [[nodiscard]] std::pair<PluginEvaluation, RiskLevel> summarize_feasibility(
+    const plugin::ValidatorInterface::result_t & res, const std::string & plugin_name,
+    bool is_shadow_mode) const;
+
+  /**
+   * @brief Assembles the published validation report for one candidate trajectory.
+   * @param candidate_trajectory Trajectory the report is built for.
+   * @param generator_name Trajectory's resolved generator name.
+   * @param active_filter_names Filters whose metrics count toward the trajectory's risk level.
+   * @param combined_metrics Metrics collected from every plugin for this trajectory.
+   */
+  [[nodiscard]] ValidationReport build_validation_report(
+    const autoware_internal_planning_msgs::msg::CandidateTrajectory & candidate_trajectory,
+    const std::string & generator_name, const std::unordered_set<std::string> & active_filter_names,
+    std::vector<MetricReport> combined_metrics) const;
+
+  /**
+   * @brief Backfills generator_info for each trajectory that survived filtering.
+   * @param valid_trajectories Trajectories that passed validation.
+   * @param uuid_to_generator_info Lookup built by build_uuid_to_generator_info.
+   */
+  [[nodiscard]] std::vector<GeneratorInfo> get_valid_trajectories_generator_info(
+    const autoware_internal_planning_msgs::msg::CandidateTrajectories & valid_trajectories,
+    const GeneratorInfoMap & uuid_to_generator_info) const;
+
   std::vector<std::shared_ptr<plugin::ValidatorInterface>> plugins_;
 };
-
 }  // namespace autoware::trajectory_validator
 
 #endif  // AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__TRAJECTORY_VALIDATOR_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator.hpp
@@ -152,7 +152,8 @@ private:
     std::vector<MetricReport> combined_metrics) const;
 
   /**
-   * @brief Backfills generator_info for each trajectory that survived filtering.
+   * @brief Backfills generator_info for each trajectory that survived filtering, with at most one
+   * entry per generator.
    * @param valid_trajectories Trajectories that passed validation.
    * @param uuid_to_generator_info Lookup built by build_uuid_to_generator_info.
    */

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -15,6 +15,7 @@
 #include "autoware/trajectory_validator/detail/trajectory_validator.hpp"
 
 #include "autoware/trajectory_validator/detail/risk_utils.hpp"
+#include "autoware/trajectory_validator/detail/uuid_hash.hpp"
 
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -28,6 +29,7 @@
 
 namespace autoware::trajectory_validator
 {
+using autoware_trajectory_validator::msg::MetricReport;
 using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_trajectory_validator::msg::ValidationReport;
 
@@ -40,99 +42,177 @@ TrajectoryValidatorReport TrajectoryValidator::process(
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic("Total");
 
-  // O(N) Map UUID to generator names upfront to preserve performance
-  std::unordered_map<std::string, std::string> uuid_to_name;
-  uuid_to_name.reserve(input_trajectories.generator_info.size());
-  for (const auto & info : input_trajectories.generator_info) {
-    uuid_to_name[autoware_utils_uuid::to_hex_string(info.generator_id)] = info.generator_name.data;
-  }
+  const auto uuid_to_generator_info = build_uuid_to_generator_info(input_trajectories);
 
   for (const auto & candidate_trajectory : input_trajectories.candidate_trajectories) {
-    EvaluationTable table;
-    const auto hex_generator_id =
-      autoware_utils_uuid::to_hex_string(candidate_trajectory.generator_id);
-    table.generator_id = hex_generator_id;
+    const auto generator_entry =
+      resolve_generator_info(candidate_trajectory.generator_id, uuid_to_generator_info);
 
-    std::vector<autoware_trajectory_validator::msg::MetricReport> combined_metrics;
+    const auto validation_results = validate_candidate_trajectory(
+      plugins_, generator_entry.hex_generator_id, candidate_trajectory, context);
 
-    for (const auto & plugin : plugins_) {
-      PluginEvaluation evaluation;
-      evaluation.plugin_name = plugin->get_name();
-      evaluation.is_shadow_mode = plugin->is_shadow_mode();
-
-      stop_watch.tic(evaluation.plugin_name);
-      const auto res = plugin->is_feasible(candidate_trajectory, context);
-
-      RiskLevel risk_level;
-      if (!res) {
-        evaluation.is_feasible = false;
-        evaluation.reason = res.error();
-        // NOTE: If the plugin fails unexpectedly, treat it as a DANGER risk level.
-        risk_level.level = RiskLevel::DANGER;
-      } else {
-        const auto & val = res.value();
-        evaluation.is_feasible = val.is_feasible;
-        if (!val.is_feasible) {
-          evaluation.reason = "Found failed metrics";
-        }
-        risk_level.level = worst_risk_level(val.metrics);
-        combined_metrics.insert(combined_metrics.end(), val.metrics.begin(), val.metrics.end());
-        std::move(
-          val.planning_factors.factors.begin(), val.planning_factors.factors.end(),
-          std::back_inserter(report.planning_factors.factors));
-      }
-
-      combined_metrics.push_back(
-        autoware_trajectory_validator::build<autoware_trajectory_validator::msg::MetricReport>()
-          .validator_name(plugin->get_name())
-          .validator_category(plugin->category())
-          .metric_name("trajectory_feasibility")
-          .metric_value(evaluation.is_feasible ? 1.0 : 0.0)
-          .risk(risk_level));
-      report.processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
-
-      table.plugin_evaluations.push_back(evaluation);
+    for (const auto & [plugin_name, elapsed_ms] : validation_results.processing_time_ms) {
+      report.processing_time_ms[plugin_name] += elapsed_ms;
     }
 
-    report.evaluation_tables.push_back(table);
+    std::move(
+      validation_results.planning_factors.factors.begin(),
+      validation_results.planning_factors.factors.end(),
+      std::back_inserter(report.planning_factors.factors));
 
-    if (table.all_acceptable()) {
+    report.evaluation_tables.push_back(validation_results.table);
+
+    if (validation_results.table.all_acceptable()) {
       report.valid_trajectories.candidate_trajectories.push_back(candidate_trajectory);
     }
 
-    if (table.all_feasible()) {
+    if (validation_results.table.all_feasible()) {
       report.num_feasible_trajectories++;
     }
 
-    // only consider metrics from active filters for final trajectory risk level
-    std::vector<autoware_trajectory_validator::msg::MetricReport> active_metrics;
-    std::copy_if(
-      combined_metrics.begin(), combined_metrics.end(), std::back_inserter(active_metrics),
-      [&](const auto & metric) { return active_filter_names.count(metric.validator_name) > 0; });
-
-    RiskLevel risk_level;
-    risk_level.level = worst_risk_level(active_metrics);
-    report.validation_reports.push_back(
-      autoware_trajectory_validator::build<ValidationReport>()
-        .trajectory_stamp(candidate_trajectory.header.stamp)
-        .generator_id(candidate_trajectory.generator_id)
-        .generator_name(uuid_to_name.at(hex_generator_id))
-        .risk(risk_level)
-        .metrics(std::move(combined_metrics)));
+    report.validation_reports.push_back(build_validation_report(
+      candidate_trajectory, generator_entry.info.generator_name.data, active_filter_names,
+      std::move(validation_results.combined_metrics)));
   }
 
-  for (const auto & traj : report.valid_trajectories.candidate_trajectories) {
-    auto it = std::find_if(
-      input_trajectories.generator_info.begin(), input_trajectories.generator_info.end(),
-      [&](const auto & info) { return traj.generator_id.uuid == info.generator_id.uuid; });
-
-    if (it != input_trajectories.generator_info.end()) {
-      report.valid_trajectories.generator_info.push_back(*it);
-    }
-  }
+  report.valid_trajectories.generator_info =
+    get_valid_trajectories_generator_info(report.valid_trajectories, uuid_to_generator_info);
 
   report.processing_time_ms["Total"] = stop_watch.toc("Total");
   return report;
 }
 
+GeneratorInfoMap TrajectoryValidator::build_uuid_to_generator_info(
+  const autoware_internal_planning_msgs::msg::CandidateTrajectories & input_trajectories) const
+{
+  GeneratorInfoMap uuid_to_generator_info;
+  uuid_to_generator_info.reserve(input_trajectories.generator_info.size());
+  for (const auto & info : input_trajectories.generator_info) {
+    uuid_to_generator_info[info.generator_id.uuid] =
+      GeneratorInfoEntry{info, autoware_utils_uuid::to_hex_string(info.generator_id)};
+  }
+  return uuid_to_generator_info;
+}
+
+GeneratorInfoEntry TrajectoryValidator::resolve_generator_info(
+  const unique_identifier_msgs::msg::UUID & generator_id,
+  const GeneratorInfoMap & uuid_to_generator_info) const
+{
+  const auto it = uuid_to_generator_info.find(generator_id.uuid);
+  if (it != uuid_to_generator_info.end()) {
+    return it->second;
+  }
+
+  GeneratorInfoEntry fallback;
+  fallback.hex_generator_id = autoware_utils_uuid::to_hex_string(generator_id);
+  fallback.info.generator_name.data = "unknown_generator:" + fallback.hex_generator_id;
+  return fallback;
+}
+
+PluginsValidationResult TrajectoryValidator::validate_candidate_trajectory(
+  const std::vector<std::shared_ptr<plugin::ValidatorInterface>> & plugins,
+  const std::string & hex_generator_id, const CandidateTrajectory & candidate_trajectory,
+  const ValidatorContext & context) const
+{
+  PluginsValidationResult validation_results;
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch;
+
+  for (const auto & plugin : plugins) {
+    const auto plugin_name = plugin->get_name();
+    stop_watch.tic(plugin_name);
+    const auto res = plugin->is_feasible(candidate_trajectory, context);
+    auto [evaluation, risk_level] =
+      summarize_feasibility(res, plugin_name, plugin->is_shadow_mode());
+
+    if (res) {
+      const auto & val = res.value();
+      validation_results.combined_metrics.insert(
+        validation_results.combined_metrics.end(), val.metrics.begin(), val.metrics.end());
+      std::move(
+        val.planning_factors.factors.begin(), val.planning_factors.factors.end(),
+        std::back_inserter(validation_results.planning_factors.factors));
+    }
+
+    validation_results.combined_metrics.push_back(
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(plugin_name)
+        .validator_category(plugin->category())
+        .metric_name("trajectory_feasibility")
+        .metric_value(evaluation.is_feasible ? 1.0 : 0.0)
+        .risk(risk_level));
+    validation_results.processing_time_ms[plugin_name] += stop_watch.toc(plugin_name);
+
+    validation_results.table.plugin_evaluations.push_back(std::move(evaluation));
+  }
+
+  validation_results.table.generator_id = hex_generator_id;
+  return validation_results;
+}
+
+std::pair<PluginEvaluation, RiskLevel> TrajectoryValidator::summarize_feasibility(
+  const plugin::ValidatorInterface::result_t & res, const std::string & plugin_name,
+  bool is_shadow_mode) const
+{
+  PluginEvaluation evaluation;
+  RiskLevel risk_level;
+
+  evaluation.plugin_name = plugin_name;
+  evaluation.is_shadow_mode = is_shadow_mode;
+
+  if (!res) {
+    evaluation.is_feasible = false;
+    evaluation.reason = res.error();
+    // NOTE: If the plugin fails unexpectedly, treat it as a DANGER risk level.
+    risk_level.level = RiskLevel::DANGER;
+    return {evaluation, risk_level};
+  }
+
+  const auto & val = res.value();
+  evaluation.is_feasible = val.is_feasible;
+  if (!evaluation.is_feasible) {
+    evaluation.reason = "Found failed metrics";
+  }
+
+  risk_level.level = worst_risk_level(val.metrics);
+  return {evaluation, risk_level};
+}
+
+ValidationReport TrajectoryValidator::build_validation_report(
+  const CandidateTrajectory & candidate_trajectory, const std::string & generator_name,
+  const std::unordered_set<std::string> & active_filter_names,
+  std::vector<MetricReport> combined_metrics) const
+{
+  // only consider metrics from active filters for final trajectory risk level
+  std::vector<MetricReport> active_metrics;
+  active_metrics.reserve(combined_metrics.size());
+  std::copy_if(
+    combined_metrics.begin(), combined_metrics.end(), std::back_inserter(active_metrics),
+    [&](const auto & metric) { return active_filter_names.count(metric.validator_name) > 0; });
+
+  RiskLevel risk_level;
+  risk_level.level = worst_risk_level(active_metrics);
+
+  return autoware_trajectory_validator::build<ValidationReport>()
+    .trajectory_stamp(candidate_trajectory.header.stamp)
+    .generator_id(candidate_trajectory.generator_id)
+    .generator_name(generator_name)
+    .risk(risk_level)
+    .metrics(std::move(combined_metrics));
+}
+
+std::vector<GeneratorInfo> TrajectoryValidator::get_valid_trajectories_generator_info(
+  const autoware_internal_planning_msgs::msg::CandidateTrajectories & valid_trajectories,
+  const GeneratorInfoMap & uuid_to_generator_info) const
+{
+  std::vector<GeneratorInfo> generator_info;
+
+  for (const auto & traj : valid_trajectories.candidate_trajectories) {
+    const auto it = uuid_to_generator_info.find(traj.generator_id.uuid);
+    if (it != uuid_to_generator_info.end()) {
+      generator_info.push_back(it->second.info);
+    }
+  }
+
+  return generator_info;
+}
 }  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -29,6 +29,7 @@
 
 namespace autoware::trajectory_validator
 {
+using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_trajectory_validator::msg::MetricReport;
 using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_trajectory_validator::msg::ValidationReport;
@@ -205,9 +206,15 @@ std::vector<GeneratorInfo> TrajectoryValidator::get_valid_trajectories_generator
   const GeneratorInfoMap & uuid_to_generator_info) const
 {
   std::vector<GeneratorInfo> generator_info;
+  std::unordered_set<std::array<uint8_t, 16>, UuidHash> seen_generator_ids;
 
   for (const auto & traj : valid_trajectories.candidate_trajectories) {
-    const auto it = uuid_to_generator_info.find(traj.generator_id.uuid);
+    const auto & uuid = traj.generator_id.uuid;
+    if (!seen_generator_ids.insert(uuid).second) {
+      continue;
+    }
+
+    const auto it = uuid_to_generator_info.find(uuid);
     if (it != uuid_to_generator_info.end()) {
       generator_info.push_back(it->second.info);
     }

--- a/planning/autoware_trajectory_validator/test/detail/test_trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/test/detail/test_trajectory_validator.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_validator/detail/trajectory_validator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace autoware::trajectory_validator
+{
+namespace
+{
+
+// Always reports a trajectory as feasible, regardless of its content or context.
+class FakeAlwaysFeasiblePlugin : public plugin::ValidatorInterface
+{
+public:
+  explicit FakeAlwaysFeasiblePlugin(const std::string & name) : ValidatorInterface(name) {}
+
+  result_t is_feasible(
+    const autoware_internal_planning_msgs::msg::CandidateTrajectory & /*candidate_trajectory*/,
+    const FilterContext & /*context*/) override
+  {
+    return plugin::ValidationResult{};
+  }
+
+  void update_parameters(const validator::Params & /*params*/) override {}
+};
+
+unique_identifier_msgs::msg::UUID make_uuid(uint8_t seed)
+{
+  unique_identifier_msgs::msg::UUID uuid;
+  uuid.uuid.fill(seed);
+  return uuid;
+}
+
+autoware_internal_planning_msgs::msg::CandidateTrajectory make_candidate_trajectory(
+  const unique_identifier_msgs::msg::UUID & generator_id)
+{
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.generator_id = generator_id;
+  return candidate_trajectory;
+}
+
+GeneratorInfo make_generator_info(
+  const unique_identifier_msgs::msg::UUID & generator_id, const std::string & name)
+{
+  GeneratorInfo info;
+  info.generator_id = generator_id;
+  info.generator_name.data = name;
+  return info;
+}
+
+TrajectoryValidator make_validator()
+{
+  return TrajectoryValidator({std::make_shared<FakeAlwaysFeasiblePlugin>("fake_plugin")});
+}
+
+TEST(TrajectoryValidatorTest, DedupesGeneratorInfoForTrajectoriesSharingAGenerator)
+{
+  const auto validator = make_validator();
+
+  const auto generator_id = make_uuid(1);
+  CandidateTrajectories input_trajectories;
+  input_trajectories.generator_info.push_back(make_generator_info(generator_id, "generator_a"));
+  input_trajectories.candidate_trajectories.push_back(make_candidate_trajectory(generator_id));
+  input_trajectories.candidate_trajectories.push_back(make_candidate_trajectory(generator_id));
+
+  const auto report =
+    validator.process(input_trajectories, /*active_filter_names=*/{}, ValidatorContext{});
+
+  ASSERT_EQ(report.valid_trajectories.candidate_trajectories.size(), 2U);
+  ASSERT_EQ(report.valid_trajectories.generator_info.size(), 1U);
+  EXPECT_EQ(report.valid_trajectories.generator_info.front().generator_name.data, "generator_a");
+}
+
+TEST(TrajectoryValidatorTest, KeepsOneGeneratorInfoEntryPerDistinctGenerator)
+{
+  const auto validator = make_validator();
+
+  const auto generator_id_a = make_uuid(1);
+  const auto generator_id_b = make_uuid(2);
+  CandidateTrajectories input_trajectories;
+  input_trajectories.generator_info.push_back(make_generator_info(generator_id_a, "generator_a"));
+  input_trajectories.generator_info.push_back(make_generator_info(generator_id_b, "generator_b"));
+  input_trajectories.candidate_trajectories.push_back(make_candidate_trajectory(generator_id_a));
+  input_trajectories.candidate_trajectories.push_back(make_candidate_trajectory(generator_id_b));
+
+  const auto report =
+    validator.process(input_trajectories, /*active_filter_names=*/{}, ValidatorContext{});
+
+  ASSERT_EQ(report.valid_trajectories.generator_info.size(), 2U);
+}
+
+}  // namespace
+}  // namespace autoware::trajectory_validator


### PR DESCRIPTION
## Description

`TrajectoryValidator::process()` in `autoware_trajectory_validator` did all of its work inline: mapping
generator UUIDs to names, running every plugin against a trajectory, building the per-plugin risk
evaluation, assembling the validation report, and backfilling generator info for trajectories that
passed. This split that single function into six named private methods, one per step, called in the
same order they used to run inline:

- `build_uuid_to_generator_info` — builds the UUID → generator info lookup.
- `resolve_generator_info` — resolves one trajectory's generator info, falling back to an
  `unknown_generator:<hex>` name when the UUID has no match.
- `validate_candidate_trajectory` — runs every plugin against one trajectory and collects the results.
- `summarize_feasibility` — turns a single plugin's result into a `PluginEvaluation` and `RiskLevel`.
- `build_validation_report` — assembles the published `ValidationReport` for one trajectory.
- `get_valid_trajectories_generator_info` — backfills `generator_info` for trajectories that passed
  validation.

No behavior change is intended — this is a structural refactor.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

Rebuilt the package and ran its full test suite:

## Notes for reviewers

Pure refactor — `process()`'s public behavior and output messages are unchanged. Reviewing the six new
private methods against the removed inline code should confirm the logic moved without changing.

## Interface changes

None.

## Effects on system behavior

None.
