### PR TITLE
feat(ccf): add timing judge bias

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -30,6 +30,10 @@
         pet_margin:
           ego_earlier: 0.6
           object_earlier: 1.0
+          object_earlier_judgement_bias:
+            base: 0.0
+            pedestrian: 0.0
+            bicycle: 0.0
         ego_footprint_margin:
           lateral:
             base: 0.3

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -121,12 +121,11 @@ validator:
           default_value: .NAN
           description: PET margin when the object reaches the collision point earlier than ego
           read_only: false
-      ego_footprint_margin:
-        lateral:
+        object_earlier_judgement_bias:
           base:
             type: double
             default_value: .NAN
-            description: default lateral margin added to both sides of the ego footprint for DRAC assessment
+            description: default bias for judging that the object reaches the collision point earlier than ego
             read_only: false
           unknown:
             &drac_labeled_double_override {
@@ -135,6 +134,25 @@ validator:
               description: Per-class override. NaN uses the base value.,
               read_only: false,
             }
+          car: *drac_labeled_double_override
+          truck: *drac_labeled_double_override
+          bus: *drac_labeled_double_override
+          trailer: *drac_labeled_double_override
+          motorcycle: *drac_labeled_double_override
+          bicycle: *drac_labeled_double_override
+          pedestrian: *drac_labeled_double_override
+          animal: *drac_labeled_double_override
+          hazard: *drac_labeled_double_override
+          over_drivable: *drac_labeled_double_override
+          under_drivable: *drac_labeled_double_override
+      ego_footprint_margin:
+        lateral:
+          base:
+            type: double
+            default_value: .NAN
+            description: default lateral margin added to both sides of the ego footprint for DRAC assessment
+            read_only: false
+          unknown: *drac_labeled_double_override
           car: *drac_labeled_double_override
           truck: *drac_labeled_double_override
           bus: *drac_labeled_double_override

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -293,6 +293,9 @@
                     "object_earlier": {
                       "type": "number",
                       "description": "PET margin when the object reaches the collision point earlier than ego [s]."
+                    },
+                    "object_earlier_judgement_bias": {
+                      "$ref": "#/definitions/labeled_double"
                     }
                   },
                   "required": [],

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -295,7 +295,9 @@ DracArtifact assess_constant_curvature(
     return drac_artifact;
   }
 
-  if (nominal_collision_result.value().first_collision_timing.pet > 0.0) {
+  if (
+    nominal_collision_result.value().first_collision_timing.pet >
+    drac_params.pet_margin.object_earlier_judgement_bias) {
     if (drac_params.constant_curvature.ego_earlier.enable_assessment) {
       throw std::invalid_argument("constant_curvature.ego_earlier is not implemented.");
     }
@@ -407,7 +409,9 @@ DracArtifact assess_map_based(
     }
 
     if (ego_turn_indicator.command == autoware_vehicle_msgs::msg::TurnIndicatorsCommand::DISABLE) {
-      if (nominal_collision_result.value().first_collision_timing.pet > 0.0) {
+      if (
+        nominal_collision_result.value().first_collision_timing.pet >
+        drac_params.pet_margin.object_earlier_judgement_bias) {
         if (!drac_params.map_based.ego_prioritized_ego_earlier.enable_assessment) {
           continue;
         }
@@ -420,7 +424,9 @@ DracArtifact assess_map_based(
         throw std::invalid_argument("map_based.ego_prioritized_object_earlier is not implemented.");
       }
     } else {
-      if (nominal_collision_result.value().first_collision_timing.pet > 0.0) {
+      if (
+        nominal_collision_result.value().first_collision_timing.pet >
+        drac_params.pet_margin.object_earlier_judgement_bias) {
         if (!drac_params.map_based.object_prioritized_ego_earlier.enable_assessment) {
           continue;
         }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -209,6 +209,7 @@ struct DracParams
   {
     double ego_earlier{1.0};
     double object_earlier{1.0};
+    double object_earlier_judgement_bias{0.0};
   };
 
   struct EgoReactionBrakingDelay
@@ -292,6 +293,8 @@ struct DracParams
       extract_labeled_param<std::vector<std::string>>(drac.enable_assessment, key));
     pet_margin.ego_earlier = extract_labeled_param<double>(drac.pet_margin.ego_earlier, key);
     pet_margin.object_earlier = extract_labeled_param<double>(drac.pet_margin.object_earlier, key);
+    pet_margin.object_earlier_judgement_bias =
+      extract_labeled_param<double>(drac.pet_margin.object_earlier_judgement_bias, key);
     ego_footprint_margin.lateral =
       extract_labeled_param<double>(drac.ego_footprint_margin.lateral, key);
     ego_footprint_margin.front =

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -163,7 +164,125 @@ TrajectoryData create_trajectory_data(const TimeTrajectory & times)
     std::move(footprints)};
 }
 
+DracArtifact assess_stationary_collision(
+  const DracParams & drac_params, const uint8_t turn_indicator_command)
+{
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = create_straight_trajectory_points({0.0, 0.0});
+  for (size_t i = 0; i < candidate_trajectory.points.size(); ++i) {
+    auto & point = candidate_trajectory.points.at(i);
+    point.longitudinal_velocity_mps = 0.0;
+    point.time_from_start = rclcpp::Duration::from_seconds(static_cast<double>(i));
+  }
+
+  autoware_perception_msgs::msg::PredictedPath predicted_path;
+  predicted_path.time_step = rclcpp::Duration::from_seconds(kDefaultTimeResolution);
+  predicted_path.path = {create_pose(0.0, 0.0), create_pose(0.0, 0.0)};
+  const auto object = create_predicted_object(
+    create_pose(0.0, 0.0), create_twist(0.0), create_bounding_box_shape(), {predicted_path});
+
+  nav_msgs::msg::Odometry odometry;
+  odometry.pose.pose = create_pose(0.0, 0.0);
+  odometry.twist.twist = create_twist(0.0);
+
+  autoware_perception_msgs::msg::PredictedObjects predicted_objects;
+  predicted_objects.objects = {object};
+
+  const rclcpp::Time frame_stamp(predicted_objects.header.stamp);
+  const trajectory::EgoTrajectoryCache ego_trajectory_cache(
+    candidate_trajectory, frame_stamp, rclcpp::Time(odometry.header.stamp), kDefaultTimeResolution,
+    create_vehicle_info());
+  trajectory::ObjectTrajectoryCache object_trajectory_cache;
+  object_trajectory_cache.update(frame_stamp, kDefaultTimeResolution);
+
+  autoware_vehicle_msgs::msg::TurnIndicatorsCommand turn_indicator;
+  turn_indicator.command = turn_indicator_command;
+  StopTrackers stop_trackers;
+  const DracParamMap drac_param_map{{"unknown", drac_params}};
+
+  return collision_timing_assessment::assess(
+    ego_trajectory_cache, object_trajectory_cache, turn_indicator, odometry, predicted_objects,
+    stop_trackers, drac_param_map, GlobalParams{});
+}
+
 }  // namespace
+
+TEST(CollisionCheckParameterTest, StoresObjectEarlierJudgementBiasPerClass)
+{
+  validator::Params params;
+  auto & bias = params.collision_check.drac.pet_margin.object_earlier_judgement_bias;
+  bias.base = 0.1;
+  bias.pedestrian = 0.5;
+  bias.bicycle = 0.6;
+
+  const auto param_map = create_param_map_per_object<DracParams>(params);
+
+  EXPECT_DOUBLE_EQ(param_map.at("car").pet_margin.object_earlier_judgement_bias, 0.1);
+  EXPECT_DOUBLE_EQ(param_map.at("pedestrian").pet_margin.object_earlier_judgement_bias, 0.5);
+  EXPECT_DOUBLE_EQ(param_map.at("bicycle").pet_margin.object_earlier_judgement_bias, 0.6);
+}
+
+TEST(CollisionTimingAssessmentTest, ConstantCurvatureUsesObjectEarlierJudgementBias)
+{
+  DracParams params;
+  params.pet_margin.object_earlier_judgement_bias = -0.1;
+  params.constant_curvature.enable_assessment = true;
+  params.constant_curvature.ego_earlier.enable_assessment = true;
+  params.constant_curvature.object_earlier.enable_assessment = false;
+  params.map_based.enable_assessment = false;
+
+  EXPECT_THROW(
+    assess_stationary_collision(params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::DISABLE),
+    std::invalid_argument);
+
+  params.pet_margin.object_earlier_judgement_bias = 0.0;
+  const auto artifact =
+    assess_stationary_collision(params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::DISABLE);
+  EXPECT_TRUE(artifact.evaluations.empty());
+}
+
+TEST(CollisionTimingAssessmentTest, EgoPrioritizedMapBasedUsesObjectEarlierJudgementBias)
+{
+  DracParams params;
+  params.pet_margin.object_earlier_judgement_bias = -0.1;
+  params.constant_curvature.enable_assessment = false;
+  params.map_based.enable_assessment = true;
+  params.map_based.ego_prioritized_ego_earlier.enable_assessment = true;
+  params.map_based.ego_prioritized_object_earlier.enable_assessment = false;
+
+  EXPECT_THROW(
+    assess_stationary_collision(params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::DISABLE),
+    std::invalid_argument);
+
+  params.pet_margin.object_earlier_judgement_bias = 0.0;
+  const auto artifact =
+    assess_stationary_collision(params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::DISABLE);
+  EXPECT_TRUE(artifact.evaluations.empty());
+}
+
+TEST(CollisionTimingAssessmentTest, ObjectPrioritizedMapBasedUsesObjectEarlierJudgementBias)
+{
+  DracParams params;
+  params.pet_margin.object_earlier_judgement_bias = -0.1;
+  params.constant_curvature.enable_assessment = false;
+  params.map_based.enable_assessment = true;
+  params.map_based.object_prioritized_ego_earlier.enable_assessment = false;
+  params.map_based.object_prioritized_object_earlier.enable_assessment = true;
+
+  const auto ego_earlier_artifact = assess_stationary_collision(
+    params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::ENABLE_LEFT);
+  EXPECT_TRUE(ego_earlier_artifact.evaluations.empty());
+
+  params.pet_margin.object_earlier_judgement_bias = 0.0;
+  const auto object_earlier_artifact = assess_stationary_collision(
+    params, autoware_vehicle_msgs::msg::TurnIndicatorsCommand::ENABLE_LEFT);
+  ASSERT_EQ(object_earlier_artifact.evaluations.size(), 1U);
+  EXPECT_EQ(
+    object_earlier_artifact.evaluations.front().method,
+    "map_based, object prioritized, object earlier");
+  EXPECT_DOUBLE_EQ(
+    object_earlier_artifact.evaluations.front().detail.first_collision_timing.pet, 0.0);
+}
 
 TEST(TrajectoryUtilitiesTest, ResolveCoveringIndexRangeHandlesAvailableTimeRange)
 {


### PR DESCRIPTION
自車と他者のどちらか先の判定にバイアスを加える機能を追加します。

パラメータに設定する値としては、
歩行者自転車向け：0.5 ~ 1.0s程度
車向け：0.0s ~ 0.3s程度 
を想定しています。