### PR TITLE
feat(obstacle_stop): improve obstacle stop object filtering to enable per class margins

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -84,21 +84,30 @@
       stopping_jerk: 3.0 # [m/s^3]
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 0.7 # [s]
-      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
         target_objects:
           bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
           polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
+          pointcloud: ["structure", "vegetation"]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
-
-      pointcloud:
-        target_types: ["structure", "vegetation"]
-        height_buffer: 0.5  # height buffer to add above ego height [m]
-        min_height: 0.2  # minimum height of pointcloud [m]
+        pointcloud_height_buffer: 0.5
+        pointcloud_min_height: 0.2
+        lateral_margin:
+          car: 0.2
+          truck: 0.2
+          bus: 0.2
+          trailer: 0.2
+          motorcycle: 0.2
+          bicycle: 0.2
+          pedestrian: 0.2
+          hazard: 0.2
+          structure: 0.2
+          vegetation: 0.2
+          unknown: 0.2
 
       rss_params:
         enable: true

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -355,10 +355,6 @@ minimum_rule_based_planner:
       type: double
       default_value: 1.0
       description: time buffer after obstacle stop [s]
-    lateral_margin:
-      type: double
-      default_value: 0.2
-      description: lateral margin for obstacle stop [m]
     arrived_distance_threshold:
       type: double
       default_value: 0.5
@@ -378,6 +374,11 @@ minimum_rule_based_planner:
           default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
           description: types of polygon shaped objects to consider for obstacle stop
           read_only: false
+        pointcloud:
+          type: string_array
+          default_value: [structure, vegetation]
+          description: types of pointcloud to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.3
@@ -394,24 +395,96 @@ minimum_rule_based_planner:
         description: safety buffer to expand object shape [m]
         validation:
           bounds<>: [0.0, 10.0]
-    pointcloud:
-      target_types:
-        type: string_array
-        default_value: [structure, vegetation]
-        description: pointcloud types to consider for obstacle stop
-        read_only: false
-      height_buffer:
+      pointcloud_height_buffer:
         type: double
         default_value: 0.5
-        description: height buffer to add above ego height [m]
+        description: height buffer to add above ego height for pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
-      min_height:
+      pointcloud_min_height:
         type: double
         default_value: 0.2
         description: minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
+      lateral_margin:
+        car:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for car objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        truck:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for truck objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bus:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for bus objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        trailer:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for trailer objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        motorcycle:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for motorcycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bicycle:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for bicycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        pedestrian:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for pedestrian objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        hazard:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for hazard objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        structure:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for structure pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        vegetation:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for vegetation pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        unknown:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
     rss_params:
       enable:
         type: bool

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -42,6 +42,7 @@ using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_pcd_coll
 using autoware::trajectory_processor::utils::obstacle_stop::LateralMarginMap;
 using autoware::trajectory_processor::utils::obstacle_stop::ObjectType;
 using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
+using autoware::trajectory_processor::utils::obstacle_stop::TargetObject;
 
 void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 {
@@ -189,18 +190,32 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   debug_data_.filtered_objects = *data.predicted_objects_ptr;
 
   object_filter_->filter_objects(debug_data_.filtered_objects);
-  object_filter_->filter_by_target_area(
-    debug_data_.filtered_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
-    lateral_margin_map_, debug_data_.target_polygons);
 
-  autoware_perception_msgs::msg::PredictedObject colliding_object;
+  debug_data_.target_objects.clear();
+  debug_data_.target_objects.reserve(debug_data_.filtered_objects.objects.size());
+  for (const auto & object : debug_data_.filtered_objects.objects) {
+    debug_data_.target_objects.emplace_back(object);
+  }
+
+  object_filter_->filter_by_target_area(
+    debug_data_.target_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    lateral_margin_map_);
+
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, debug_data_.filtered_objects, object_decel_map_,
+    debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+    params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
-  if (collision_point) debug_data_.colliding_object = colliding_object;
+  if (collision_point) {
+    auto it = std::find_if(
+      debug_data_.target_objects.begin(), debug_data_.target_objects.end(),
+      [&](const TargetObject & object) { return !object.is_safe; });
+    if (it != debug_data_.target_objects.end()) {
+      debug_data_.colliding_object = it->object;
+    }
+  }
+
   return collision_point;
 }
 
@@ -347,7 +362,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   ss << "OBSTACLE STOP (Backup Planner):" << "\n";
   ss << "\t\t" << "SAFE: " << is_safe << "\n";
   ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
-     << debug_data_.target_polygons.size() << "\n";
+     << debug_data_.target_objects.size() << "\n";
   ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
@@ -429,6 +444,20 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     marker_array.markers.push_back(marker);
   };
 
+  auto add_text_marker = [&](
+                           const std::string & text, const geometry_msgs::msg::Pose & pose,
+                           const std::string & ns, const int id,
+                           const std_msgs::msg::ColorRGBA & color, const double scale = 0.4) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::TEXT_VIEW_FACING,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose = pose;
+    marker.pose.position.z += 1.0;
+    marker.text = text;
+    marker_array.markers.push_back(marker);
+  };
+
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
     Polygon2d polygon;
@@ -440,8 +469,17 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     id++;
   }
 
-  for (const auto & target_polygon : debug_data_.target_polygons) {
+  for (const auto & obj : debug_data_.target_objects) {
+    const auto & target_polygon = obj.polygon;
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
+    ss << "rss_safe_dist: " << obj.safe_distance << " m" << "\n";
+    ss << "dist_from_ego: " << obj.distance_from_ego << " m";
+    add_text_marker(
+      ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
+      ns + "/target_objects_text", id, white);
     id++;
   }
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -17,9 +17,9 @@
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp>
-#include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <algorithm>
@@ -53,7 +53,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 
   pointcloud_filter_ =
     std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
-      params_.pointcloud.target_types);
+      params_.objects.target_objects.pointcloud);
 
   object_filter_ = std::make_unique<trajectory_processor::utils::obstacle_stop::ObjectFilter>(
     params_.objects.target_objects.bbox, params_.objects.target_objects.polygon,
@@ -67,6 +67,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
     get_node_ptr()->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
 
   update_object_decel_map();
+  update_lateral_margin_map();
 }
 
 void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
@@ -75,7 +76,7 @@ void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data
 
   const auto detected = is_obstacle_detected(traj_points, data);
   publish_debug_string(!detected);
-  publish_debug_data("obstacle_stop", data);
+  publish_debug_data("obstacle_stop");
 
   if (!detected) return;
   if (!nearest_collision_point_) return;
@@ -149,6 +150,7 @@ bool ObstacleStop::is_obstacle_detected(
 
   debug_data_.active_collision_point =
     nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
+  debug_data_.ego_z = data.odometry_ptr->pose.pose.position.z;
 
   return nearest_collision_point_ != std::nullopt;
 }
@@ -189,10 +191,9 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   auto predicted_objects = *data.predicted_objects_ptr;
 
   object_filter_->filter_objects(predicted_objects);
-  const LateralMarginMap lateral_margin_map{{ObjectType::UNKNOWN, params_.lateral_margin}};
   object_filter_->filter_by_target_area(
     predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
-    lateral_margin_map, debug_data_.target_polygons);
+    lateral_margin_map_, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
@@ -227,8 +228,9 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     constexpr double buffer = 1.0;
     const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
     const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.pointcloud.min_height;
-    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
+    const auto min_z = params_.objects.pointcloud_min_height;
+    const auto max_z =
+      context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
     pointcloud_filter_->filter_pointcloud(
       filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
       max_z);
@@ -266,9 +268,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       filtered_pointcloud, *data.predicted_objects_ptr);
   }
 
-  const LateralMarginMap lateral_margin_map{{ObjectType::UNKNOWN, params_.lateral_margin}};
   return get_nearest_pcd_collision(
-    debug_data_.trajectory_shape, filtered_pointcloud, lateral_margin_map,
+    debug_data_.trajectory_shape, filtered_pointcloud, lateral_margin_map_,
     debug_data_.target_pcd_points);
 }
 
@@ -364,33 +365,62 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   pub_debug_text_->publish(string_stamp);
 }
 
-void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData & data) const
+void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
   if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
 
   MarkerArray marker_array;
-  const auto ego_z = data.odometry_ptr->pose.pose.position.z;
+  const auto ego_z = debug_data_.ego_z;
   const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
   const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
 
-  auto add_point_marker = [&](
-                            const geometry_msgs::msg::Point & point, const std::string & marker_ns,
-                            const int id, const std_msgs::msg::ColorRGBA & color,
-                            const double scale = 0.1) {
+  auto add_line_list_marker = [&](
+                                const std::vector<geometry_msgs::msg::Point> & segments,
+                                const std::string & ns, const int id,
+                                const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), marker_ns, id, Marker::SPHERE,
-      autoware_utils::create_marker_scale(scale, scale, scale), color);
+      "map", get_clock()->now(), ns, id, Marker::LINE_LIST,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.pose.position = point;
+    marker.points = segments;
     marker_array.markers.push_back(marker);
   };
 
+  int id = 0;
+  {
+    using autoware_utils_geometry::calc_offset_pose;
+    const auto & shape = debug_data_.trajectory_shape;
+    const auto half_width = shape.ego_half_width;
+    const auto front_offset = std::abs(shape.ego_front_offset);
+    const auto back_offset = std::abs(shape.ego_back_offset);
+    std::vector<geometry_msgs::msg::Point> segments;
+    auto dist = 0.0;
+    for (const auto & footprint : shape.footprints) {
+      if (footprint.arc_length - dist < 1.0) continue;
+      dist = footprint.arc_length;
+      auto front_left = calc_offset_pose(footprint.pose, front_offset, -half_width, 0.0).position;
+      auto front_right = calc_offset_pose(footprint.pose, front_offset, half_width, 0.0).position;
+      auto rear_right = calc_offset_pose(footprint.pose, -back_offset, half_width, 0.0).position;
+      auto rear_left = calc_offset_pose(footprint.pose, -back_offset, -half_width, 0.0).position;
+      segments.emplace_back(rear_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_right);
+      segments.emplace_back(front_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_left);
+    }
+    add_line_list_marker(segments, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
+
   auto add_polygon_marker = [&](
-                              const Polygon2d & polygon, const std::string & marker_ns,
-                              const int id, const std_msgs::msg::ColorRGBA & color) {
+                              const Polygon2d & polygon, const std::string & ns, const int id,
+                              const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), marker_ns, id, Marker::LINE_STRIP,
+      "map", get_clock()->now(), ns, id, Marker::LINE_STRIP,
       autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
 
@@ -402,18 +432,6 @@ void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData
     }
     marker_array.markers.push_back(marker);
   };
-
-  int id = 0;
-  {
-    const auto & shape = debug_data_.trajectory_shape;
-    for (const auto & footprint : shape.footprints) {
-      const auto ego_polygon = autoware_utils::to_footprint(
-        footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
-        2.0 * (shape.ego_half_width + params_.lateral_margin));
-      add_polygon_marker(ego_polygon, ns + "/traj_polygon", id, yellow);
-      id++;
-    }
-  }
 
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
@@ -430,6 +448,18 @@ void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
     id++;
   }
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
 
   for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
     add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -148,8 +148,6 @@ bool ObstacleStop::is_obstacle_detected(
              : nearest_objects_collision_point.value();
   });
 
-  debug_data_.active_collision_point =
-    nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
   debug_data_.ego_z = data.odometry_ptr->pose.pose.position.z;
 
   return nearest_collision_point_ != std::nullopt;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -17,6 +17,7 @@
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp>
+#include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -35,9 +36,9 @@ namespace autoware::minimum_rule_based_planner::plugin
 using autoware::trajectory_processor::utils::clamp_stop_point_arc_length;
 using autoware::trajectory_processor::utils::insert_stop_point;
 using autoware::trajectory_processor::utils::replace_trajectory_with_stop_point;
+using autoware::trajectory_processor::utils::obstacle_stop::build_trajectory_footprint_index;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_pcd_collision;
-using autoware::trajectory_processor::utils::obstacle_stop::get_trajectory_shape;
 using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
 
 void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
@@ -85,11 +86,10 @@ bool ObstacleStop::is_obstacle_detected(
 {
   debug_data_ = DebugData();
   safety_factors_ = SafetyFactorArray{};
-  debug_data_.trajectory_shape = get_trajectory_shape(
+  debug_data_.trajectory_shape = build_trajectory_footprint_index(
     traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
     data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
-    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
-    params_.lateral_margin);
+    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin);
   const auto collision_point_pcd = check_pointcloud(traj_points, data);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points, data);
@@ -188,8 +188,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   object_filter_->filter_objects(predicted_objects);
   object_filter_->filter_by_target_area(
-    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
-    debug_data_.target_polygons);
+    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    params_.lateral_margin, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
@@ -203,7 +203,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
-  const TrajectoryPoints & traj_points, const ModifierData & data)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (!params_.use_pointcloud) return std::nullopt;
 
@@ -264,7 +264,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   }
 
   return get_nearest_pcd_collision(
-    traj_points, debug_data_.trajectory_shape, filtered_pointcloud, debug_data_.target_pcd_points);
+    debug_data_.trajectory_shape, filtered_pointcloud, params_.lateral_margin,
+    debug_data_.target_pcd_points);
 }
 
 void ObstacleStop::update_collision_points_buffer(
@@ -399,9 +400,15 @@ void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData
   };
 
   int id = 0;
-  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
-    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
-    id++;
+  {
+    const auto & shape = debug_data_.trajectory_shape;
+    for (const auto & footprint : shape.footprints) {
+      const auto ego_polygon = autoware_utils::to_footprint(
+        footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
+        2.0 * (shape.ego_half_width + params_.lateral_margin));
+      add_polygon_marker(ego_polygon, ns + "/traj_polygon", id, yellow);
+      id++;
+    }
   }
 
   {

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -39,6 +39,8 @@ using autoware::trajectory_processor::utils::replace_trajectory_with_stop_point;
 using autoware::trajectory_processor::utils::obstacle_stop::build_trajectory_footprint_index;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_pcd_collision;
+using autoware::trajectory_processor::utils::obstacle_stop::LateralMarginMap;
+using autoware::trajectory_processor::utils::obstacle_stop::ObjectType;
 using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
 
 void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
@@ -187,9 +189,10 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   auto predicted_objects = *data.predicted_objects_ptr;
 
   object_filter_->filter_objects(predicted_objects);
+  const LateralMarginMap lateral_margin_map{{ObjectType::UNKNOWN, params_.lateral_margin}};
   object_filter_->filter_by_target_area(
     predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
-    params_.lateral_margin, debug_data_.target_polygons);
+    lateral_margin_map, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
@@ -263,8 +266,9 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       filtered_pointcloud, *data.predicted_objects_ptr);
   }
 
+  const LateralMarginMap lateral_margin_map{{ObjectType::UNKNOWN, params_.lateral_margin}};
   return get_nearest_pcd_collision(
-    debug_data_.trajectory_shape, filtered_pointcloud, params_.lateral_margin,
+    debug_data_.trajectory_shape, filtered_pointcloud, lateral_margin_map,
     debug_data_.target_pcd_points);
 }
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -186,16 +186,16 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   if (!data.predicted_objects_ptr || data.predicted_objects_ptr->objects.empty())
     return std::nullopt;
-  auto predicted_objects = *data.predicted_objects_ptr;
+  debug_data_.filtered_objects = *data.predicted_objects_ptr;
 
-  object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_objects(debug_data_.filtered_objects);
   object_filter_->filter_by_target_area(
-    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    debug_data_.filtered_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
     lateral_margin_map_, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
+    traj_points, context_->vehicle_info, debug_data_.filtered_objects, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
@@ -218,23 +218,6 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   pcl::fromROSMsg(*pointcloud, *filtered_pointcloud);
 
   {
-    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.min_corner().to_3d(), data.odometry_ptr->pose.pose);
-    const auto rel_max_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.max_corner().to_3d(), data.odometry_ptr->pose.pose);
-    constexpr double buffer = 1.0;
-    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
-    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.objects.pointcloud_min_height;
-    const auto max_z =
-      context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
-    pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
-      max_z);
-  }
-
-  {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = context_->tf_buffer.lookupTransform(
@@ -242,6 +225,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
         rclcpp::Duration::from_seconds(0.1));
     } catch (tf2::TransformException & e) {
       RCLCPP_WARN(get_node_ptr()->get_logger(), "no transform found for pointcloud: %s", e.what());
+      return std::nullopt;
     }
 
     Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
@@ -251,6 +235,20 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       p.y = q.y();
       p.z = q.z();
     }
+  }
+
+  {
+    const auto & bbox = debug_data_.trajectory_shape.bounding_box;
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(bbox.min_corner().x(), bbox.max_corner().x());
+    const auto [min_y, max_y] = std::minmax(bbox.min_corner().y(), bbox.max_corner().y());
+    const auto ego_z = data.odometry_ptr->pose.pose.position.z;
+    const auto min_z = ego_z + params_.objects.pointcloud_min_height;
+    const auto max_z =
+      ego_z + context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
+    pointcloud_filter_->filter_pointcloud(
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   {
@@ -332,7 +330,7 @@ std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
 
   auto minimum_arc_length = std::numeric_limits<double>::max();
   for (const auto & cp : collision_points_buffer) {
-    if (cp.arc_length > minimum_arc_length || !cp.is_active) continue;
+    if (cp.arc_length >= minimum_arc_length || !cp.is_active) continue;
     nearest_collision_point = cp;
     minimum_arc_length = cp.arc_length;
   }

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::minimum_rule_based_planner::plugin
@@ -38,6 +39,7 @@ using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using trajectory_processor::utils::obstacle_stop::CollisionPoint;
 using trajectory_processor::utils::obstacle_stop::DebugData;
+using trajectory_processor::utils::obstacle_stop::LateralMarginMap;
 using trajectory_processor::utils::obstacle_stop::ObjectDecelMap;
 using trajectory_processor::utils::obstacle_stop::ObjectType;
 using visualization_msgs::msg::Marker;
@@ -61,14 +63,11 @@ public:
       object_filter_->set_params(
         p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
         p.max_lateral_velocity_th, p.safety_buffer);
-    }
-
-    {
-      const auto & p = params_.pointcloud;
-      pointcloud_filter_->set_params(p.target_types);
+      pointcloud_filter_->set_params(p.target_objects.pointcloud);
     }
 
     update_object_decel_map();
+    update_lateral_margin_map();
   }
   const MinimumRuleBasedPlannerParams::ObstacleStop & get_params() const { return params_; }
 
@@ -97,6 +96,7 @@ private:
   std::unique_ptr<trajectory_processor::utils::obstacle_stop::ObjectFilter> object_filter_;
 
   ObjectDecelMap object_decel_map_;
+  LateralMarginMap lateral_margin_map_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_filtered_pointcloud_;
@@ -113,6 +113,23 @@ private:
       {ObjectType::MOTORCYCLE, p.object_decel.motorcycle},
       {ObjectType::BICYCLE, p.object_decel.bicycle},
       {ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
+  }
+
+  void update_lateral_margin_map()
+  {
+    const auto & p = params_.objects.lateral_margin;
+    lateral_margin_map_ = {
+      {ObjectType::CAR, p.car},
+      {ObjectType::TRUCK, p.truck},
+      {ObjectType::BUS, p.bus},
+      {ObjectType::TRAILER, p.trailer},
+      {ObjectType::MOTORCYCLE, p.motorcycle},
+      {ObjectType::BICYCLE, p.bicycle},
+      {ObjectType::PEDESTRIAN, p.pedestrian},
+      {ObjectType::HAZARD, p.hazard},
+      {ObjectType::STRUCTURE, p.structure},
+      {ObjectType::VEGETATION, p.vegetation},
+      {ObjectType::UNKNOWN, p.unknown}};
   }
 
   bool is_obstacle_detected(const TrajectoryPoints & traj_points, const ModifierData & data);
@@ -132,7 +149,7 @@ private:
   void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
 
   void publish_debug_string(bool is_safe) const;
-  void publish_debug_data(const std::string & ns, const ModifierData & data) const;
+  void publish_debug_data(const std::string & ns) const;
 };
 
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -18,7 +18,6 @@
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
 #include "plugin_interface.hpp"
 
-#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -35,7 +34,6 @@ using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_planning_msgs::msg::TrajectoryPoint;
-using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using trajectory_processor::utils::obstacle_stop::CollisionPoint;
 using trajectory_processor::utils::obstacle_stop::DebugData;

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -421,12 +421,6 @@
               "default": 1.0,
               "minimum": 0.0
             },
-            "lateral_margin": {
-              "type": "number",
-              "description": "Lateral margin [m]",
-              "default": 0.5,
-              "minimum": 0.0
-            },
             "arrived_distance_threshold": {
               "type": "number",
               "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
@@ -472,6 +466,14 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "pointcloud": {
+                      "type": "array",
+                      "description": "Types of pointcloud to consider for obstacle stop",
+                      "default": ["structure", "vegetation"],
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [],
@@ -496,33 +498,92 @@
                   "default": 0.0,
                   "minimum": 0.0,
                   "maximum": 10.0
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            "pointcloud": {
-              "type": "object",
-              "properties": {
-                "target_types": {
-                  "type": "array",
-                  "description": "Pointcloud types to consider for obstacle stop",
-                  "default": ["structure", "vegetation"],
-                  "items": {
-                    "type": "string"
-                  }
                 },
-                "height_buffer": {
+                "pointcloud_height_buffer": {
                   "type": "number",
-                  "description": "Height buffer to add above ego height [m]",
+                  "description": "Height buffer to add above ego height for pointcloud [m]",
                   "default": 0.5,
                   "minimum": 0.0
                 },
-                "min_height": {
+                "pointcloud_min_height": {
                   "type": "number",
                   "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
                   "minimum": 0.0
+                },
+                "lateral_margin": {
+                  "type": "object",
+                  "description": "Lateral margin on top of ego width from trajectory, per object or pointcloud class [m]",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for car objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for truck objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bus objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for trailer objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for motorcycle objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bicycle objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for pedestrian objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "hazard": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for hazard objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "structure": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for structure pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "vegetation": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for vegetation pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "unknown": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -57,7 +57,6 @@
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
       minimum_stop_margin: 3.0 # [m]
-      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
 
       obstacle_tracking:
@@ -72,14 +71,24 @@
         target_objects:
           bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
           polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
+          pointcloud: ["structure", "vegetation"]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
-
-      pointcloud:
-        target_types: ["structure", "vegetation"]
-        height_buffer: 0.5  # height buffer to add above ego height [m]
-        min_height: 0.2  # minimum height of pointcloud [m]
+        pointcloud_height_buffer: 0.2
+        pointcloud_min_height: 0.2
+        lateral_margin:
+          car: 0.1
+          truck: 0.1
+          bus: 0.1
+          trailer: 0.1
+          motorcycle: 0.1
+          bicycle: 0.1
+          pedestrian: 0.1
+          hazard: 0.1
+          structure: 0.1
+          vegetation: 0.1
+          unknown: 0.0
 
       rss_params:
         enable: true

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -86,6 +86,7 @@ private:
   SafetyFactorArray safety_factors_;
 
   std::unordered_map<utils::obstacle_stop::ObjectType, double> object_decel_map_;
+  utils::obstacle_stop::LateralMarginMap lateral_margin_map_;
 
   MarkerArray marker_array_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__OBSTACLE_STOP_HPP_
 
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
-#include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
 #include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -41,7 +40,6 @@ using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_perception_msgs::msg::PredictedObjects;
-using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using sensor_msgs::msg::PointCloud2;
 using utils::obstacle_stop::CollisionPoint;
@@ -64,7 +62,7 @@ public:
 
   const ModifierParams::ObstacleStop & get_params() const { return params_; }
 
-  void publish_debug_data([[maybe_unused]] const std::string & ns) const override;
+  void publish_debug_data(const std::string & ns) const override;
 
 protected:
   void on_initialize(const TrajectoryProcessorParams & params) override;
@@ -88,7 +86,6 @@ private:
   std::unordered_map<utils::obstacle_stop::ObjectType, double> object_decel_map_;
   utils::obstacle_stop::LateralMarginMap lateral_margin_map_;
 
-  MarkerArray marker_array_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_filtered_pointcloud_;
   rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -25,8 +25,10 @@
 #include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <boost/geometry/index/rtree.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_hash.hpp>
@@ -35,11 +37,13 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory_processor::utils::obstacle_stop
@@ -55,6 +59,8 @@ using autoware_perception_msgs::msg::Shape;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using autoware_utils_geometry::MultiPolygon2d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Polygon2d;
 
 enum class ObjectType : uint8_t {
   UNKNOWN = 0,
@@ -168,12 +174,30 @@ struct ObjectState
   geometry_msgs::msg::Point nearest_point;
 };
 
+/// Ego vehicle footprint sampled along the detection trajectory.
+/// Queried as an OBB using TrajectoryShape extents plus a class-specific lateral margin.
+struct EgoFootprint
+{
+  geometry_msgs::msg::Pose pose;
+  size_t traj_index{0};    ///< nearest original trajectory index
+  double arc_length{0.0};  ///< arc length from trajectory start to this pose (baselink)
+};
+
+using FootprintNode = std::pair<autoware_utils_geometry::Box2d, size_t>;
+using FootprintRtree =
+  boost::geometry::index::rtree<FootprintNode, boost::geometry::index::rstar<16>>;
+
 struct TrajectoryShape
 {
   MultiPolygon2d polygon;
   autoware_utils_geometry::Box2d bounding_box;
-  double trajectory_length;
-  double forward_traj_length;
+  double trajectory_length{0.0};
+  double forward_traj_length{0.0};
+  std::vector<EgoFootprint> footprints;
+  FootprintRtree rtree;
+  double ego_half_width{0.0};
+  double ego_front_offset{0.0};  ///< vehicle_info.max_longitudinal_offset_m
+  double ego_back_offset{0.0};   ///< -vehicle_info.min_longitudinal_offset_m
 
   [[nodiscard]] double ego_arc_length() const { return trajectory_length - forward_traj_length; }
 };
@@ -223,6 +247,39 @@ TrajectoryShape get_trajectory_shape(
   const double lateral_margin = 0.0, const double longitudinal_margin = 0.0);
 
 /**
+ * @brief Build an R-tree of ego footprints along the obstacle-detection portion of the trajectory.
+ * @details Uses the same detection-length crop/extend as get_trajectory_shape(). Footprints are
+ * sampled with a minimum spacing of 0.1 m and interpolated to a maximum spacing of 0.5 m. Each
+ * entry stores the pose, nearest original trajectory index, and arc length from the trajectory
+ * start. Vehicle extents are stored without extra lateral margin; class-specific expansion is
+ * applied at query time.
+ * @return TrajectoryShape with footprints, rtree, bounding box, lengths, and ego extents populated.
+ *         The union polygon is left empty.
+ */
+TrajectoryShape build_trajectory_footprint_index(
+  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
+  const double ego_accel, const double decel, const double jerk, const double stop_margin);
+
+/**
+ * @brief Find ego footprints whose expanded OBB contains the given point.
+ * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise vehicle-frame
+ * OBB test: x in [-ego_back_offset, ego_front_offset], |y| <= ego_half_width + lat_margin.
+ * @return Footprint indices sorted by increasing arc_length.
+ */
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Point2d & point, const double lat_margin);
+
+/**
+ * @brief Find ego footprints that intersect the given object polygon.
+ * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise intersection
+ * against the ego footprint expanded laterally by `lat_margin`.
+ * @return Footprint indices sorted by increasing arc_length.
+ */
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin);
+
+/**
  * @brief Find the closest point-cloud obstacle inside the trajectory swept area.
  * @details Points inside `trajectory_shape.polygon` are considered; the collision is the one with
  * minimum arc length along `trajectory_points`. All inlier points are appended to
@@ -238,6 +295,7 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
+using LateralMarginMap = std::unordered_map<ObjectType, double>;
 
 /**
  * @brief Find the nearest predicted object that is not longitudinally safe relative to the ego

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -144,8 +144,12 @@ inline ObjectType to_object_type(const PointCloudClassification classification)
 
 inline double get_lateral_margin(const LateralMarginMap & map, const ObjectType type)
 {
-  if (const auto it = map.find(type); it != map.end()) return it->second;
-  if (const auto it = map.find(ObjectType::UNKNOWN); it != map.end()) return it->second;
+  if (const auto it = map.find(type); it != map.end()) {
+    return it->second;
+  }
+  if (const auto it = map.find(ObjectType::UNKNOWN); it != map.end()) {
+    return it->second;
+  }
   return 0.0;
 }
 
@@ -215,7 +219,6 @@ using FootprintRtree =
 
 struct TrajectoryShape
 {
-  MultiPolygon2d polygon;
   autoware_utils_geometry::Box2d bounding_box;
   double trajectory_length{0.0};
   double forward_traj_length{0.0};
@@ -235,7 +238,6 @@ struct DebugData
   MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
-  geometry_msgs::msg::Point active_collision_point;
   std::optional<PredictedObject> colliding_object;
   double ego_z = 0.0;  // cached for marker placement during publish_debug_data
 };
@@ -248,39 +250,13 @@ struct DebugData
 void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points);
 
 /**
- * @brief Build a 2D swept footprint of the ego vehicle along the portion of the path used for
- * obstacle detection.
- * @details The detection length combines stopping-distance logic (speed, deceleration, jerk,
- * margins) with the path ahead of the ego. The polygon is the union of vehicle footprints
- * sampled along that segment; the returned bounding box encloses that multi-polygon.
- * @param trajectory_points Full reference trajectory.
- * @param ego_pose Current ego pose on the trajectory.
- * @param vehicle_info Vehicle geometry for the footprint polygon.
- * @param ego_vel Current longitudinal speed [m/s].
- * @param ego_accel Current longitudinal acceleration [m/s^2].
- * @param decel Magnitude of comfortable deceleration used for stopping distance [m/s^2].
- * @param jerk Longitudinal jerk limit used for stopping distance [m/s^3].
- * @param stop_margin Extra longitudinal margin added to the detection range [m].
- * @param lateral_margin Lateral expansion of the footprint [m].
- * @param longitudinal_margin Longitudinal expansion of the footprint [m].
- * @return Swept shape, its axis-aligned bounding box, total trajectory length, and forward arc
- * length from the ego.
- */
-TrajectoryShape get_trajectory_shape(
-  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin,
-  const double lateral_margin = 0.0, const double longitudinal_margin = 0.0);
-
-/**
  * @brief Build an R-tree of ego footprints along the obstacle-detection portion of the trajectory.
- * @details Uses the same detection-length crop/extend as get_trajectory_shape(). Footprints are
- * sampled with a minimum spacing of 0.1 m and interpolated to a maximum spacing of 0.5 m. Each
- * entry stores the pose, nearest original trajectory index, and arc length from the trajectory
- * start. Vehicle extents are stored without extra lateral margin; class-specific expansion is
- * applied at query time.
+ * @details Detection length combines stopping-distance logic with the path ahead of the ego.
+ * Footprints are sampled with a minimum spacing of 0.1 m and interpolated to a maximum spacing of
+ * 1.0 m. Each entry stores the pose, nearest original trajectory index, and arc length from the
+ * trajectory start. Vehicle extents are stored without extra lateral margin; class-specific
+ * expansion is applied at query time.
  * @return TrajectoryShape with footprints, rtree, bounding box, lengths, and ego extents populated.
- *         The union polygon is left empty.
  */
 TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -280,19 +280,19 @@ std::vector<size_t> query_overlapping_footprints(
   const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin);
 
 /**
- * @brief Find the closest point-cloud obstacle inside the trajectory swept area.
- * @details Points inside `trajectory_shape.polygon` are considered; the collision is the one with
- * minimum arc length along `trajectory_points`. All inlier points are appended to
- * `target_pcd_points` for visualization or debugging.
- * @param trajectory_points Reference path for arc-length queries.
- * @param trajectory_shape Swept ego region from get_trajectory_shape().
+ * @brief Find the closest point-cloud obstacle that overlaps an ego footprint.
+ * @details Each point is queried against `trajectory_shape.rtree` with `lat_margin`. The collision
+ * is the inlier with minimum arc length (footprint arc length plus longitudinal offset in the
+ * vehicle frame). All inlier points are appended to `target_pcd_points`.
+ * @param trajectory_shape Ego footprint index from build_trajectory_footprint_index().
  * @param pointcloud Input points in the same frame as the trajectory.
- * @param[out] target_pcd_points Points that fell inside the trajectory polygon.
+ * @param lat_margin Lateral expansion of the ego footprint [m].
+ * @param[out] target_pcd_points Points that overlapped at least one footprint.
  * @return Nearest collision by arc length, or nullopt if the cloud is empty or none intersect.
  */
 std::optional<CollisionPoint> get_nearest_pcd_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
+  const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
+  const double lat_margin, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 using LateralMarginMap = std::unordered_map<ObjectType, double>;
@@ -383,19 +383,21 @@ struct ObjectFilter
   }
 
   /**
-   * @brief Keep only objects that intersect the target region, dropping those leaving laterally.
-   * @details Objects disjoint from `target_area` are removed. Moving objects that are judged to be
-   * exiting the corridor (using lateral velocity and a short prediction horizon) are also removed.
-   * Polygons of retained objects are accumulated in `target_polygons`.
+   * @brief Keep only objects that intersect ego footprints, dropping those leaving laterally.
+   * @details Objects with no overlapping footprint (expanded by `lat_margin`) are removed. Moving
+   * objects judged to be exiting the corridor (using lateral velocity and a short prediction
+   * horizon) are also removed. Polygons of retained objects are accumulated in `target_polygons`.
    * @param[in,out] objects Predicted objects to filter in place.
    * @param trajectory_points Reference path for time and geometry queries.
-   * @param target_area Multi-polygon region of interest (e.g. expanded path).
+   * @param trajectory_shape Ego footprint index used for overlap queries.
+   * @param lat_margin Lateral expansion of the ego footprint [m].
    * @param[out] target_polygons Footprints of objects that remain after filtering.
    */
   void filter_by_target_area(
     PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
+    const TrajectoryShape & trajectory_shape, const double lat_margin,
+    MultiPolygon2d & target_polygons);
 
   /**
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -123,6 +123,32 @@ inline static const std::unordered_map<PointCloudClassification, ObjectType>
     {PointCloudClassification::NOISE, ObjectType::NOISE},
     {PointCloudClassification::INVALID, ObjectType::UNKNOWN}};
 
+using ObjectDecelMap = std::unordered_map<ObjectType, double>;
+using LateralMarginMap = std::unordered_map<ObjectType, double>;
+
+inline ObjectType to_object_type(const PredictedObject & object)
+{
+  const auto label =
+    object.classification.empty()
+      ? ObjectClassification::UNKNOWN
+      : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  const auto it = classification_to_object_type.find(label);
+  return it != classification_to_object_type.end() ? it->second : ObjectType::UNKNOWN;
+}
+
+inline ObjectType to_object_type(const PointCloudClassification classification)
+{
+  const auto it = pcd_class_to_object_type.find(classification);
+  return it != pcd_class_to_object_type.end() ? it->second : ObjectType::UNKNOWN;
+}
+
+inline double get_lateral_margin(const LateralMarginMap & map, const ObjectType type)
+{
+  if (const auto it = map.find(type); it != map.end()) return it->second;
+  if (const auto it = map.find(ObjectType::UNKNOWN); it != map.end()) return it->second;
+  return 0.0;
+}
+
 struct CollisionPoint
 {
   geometry_msgs::msg::Point point;
@@ -281,21 +307,19 @@ std::vector<size_t> query_overlapping_footprints(
 
 /**
  * @brief Find the closest point-cloud obstacle that overlaps an ego footprint.
- * @details Each point is queried against `trajectory_shape.rtree` with `lat_margin`. The collision
- * is the inlier with minimum arc length (footprint arc length plus longitudinal offset in the
- * vehicle frame). All inlier points are appended to `target_pcd_points`.
+ * @details Each point is queried against `trajectory_shape.rtree` with the lateral margin for its
+ * class. The collision is the inlier with minimum arc length (footprint arc length plus
+ * longitudinal offset in the vehicle frame). All inlier points are appended to `target_pcd_points`.
  * @param trajectory_shape Ego footprint index from build_trajectory_footprint_index().
  * @param pointcloud Input points in the same frame as the trajectory.
- * @param lat_margin Lateral expansion of the ego footprint [m].
+ * @param lateral_margin_map Per-class lateral expansion of the ego footprint [m].
  * @param[out] target_pcd_points Points that overlapped at least one footprint.
  * @return Nearest collision by arc length, or nullopt if the cloud is empty or none intersect.
  */
 std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
-  const double lat_margin, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
-
-using ObjectDecelMap = std::unordered_map<ObjectType, double>;
-using LateralMarginMap = std::unordered_map<ObjectType, double>;
+  const LateralMarginMap & lateral_margin_map,
+  std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
 /**
  * @brief Find the nearest predicted object that is not longitudinally safe relative to the ego
@@ -390,13 +414,13 @@ struct ObjectFilter
    * @param[in,out] objects Predicted objects to filter in place.
    * @param trajectory_points Reference path for time and geometry queries.
    * @param trajectory_shape Ego footprint index used for overlap queries.
-   * @param lat_margin Lateral expansion of the ego footprint [m].
+   * @param lateral_margin_map Per-class lateral expansion of the ego footprint [m].
    * @param[out] target_polygons Footprints of objects that remain after filtering.
    */
   void filter_by_target_area(
     PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const TrajectoryShape & trajectory_shape, const double lat_margin,
+    const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map,
     MultiPolygon2d & target_polygons);
 
   /**

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -231,10 +231,23 @@ struct TrajectoryShape
   [[nodiscard]] double ego_arc_length() const { return trajectory_length - forward_traj_length; }
 };
 
+struct TargetObject
+{
+  PredictedObject object;
+  Polygon2d polygon;
+  bool is_safe{false};
+  double distance_from_ego{0.0};
+  double safe_distance{0.0};
+
+  explicit TargetObject(const PredictedObject & object) : object(object) {}
+};
+using TargetObjects = std::vector<TargetObject>;
+
 struct DebugData
 {
   PointCloud2::SharedPtr filtered_points;
   PredictedObjects filtered_objects;
+  TargetObjects target_objects;
   MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
@@ -324,11 +337,10 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
  * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
  */
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
-  const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
@@ -395,10 +407,9 @@ struct ObjectFilter
    * @param[out] target_polygons Footprints of objects that remain after filtering.
    */
   void filter_by_target_area(
-    PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map,
-    MultiPolygon2d & target_polygons);
+    const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map);
 
   /**
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
@@ -525,8 +536,7 @@ struct ObstacleTracker
    * @param now Current stamp used for track aging and activation timing
    */
   void update_objects(
-    const PredictedObjects & objects, PredictedObjects & persistent_objects,
-    const rclcpp::Time & now);
+    const PredictedObjects & objects, TargetObjects & persistent_objects, const rclcpp::Time & now);
 
   /**
    * @brief Update tracked points

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -298,8 +298,9 @@ std::vector<size_t> query_overlapping_footprints(
 
 /**
  * @brief Find ego footprints that intersect the given object polygon.
- * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise intersection
- * against the ego footprint expanded laterally by `lat_margin`.
+ * @details Coarse R-tree AABB query (inflated by `lat_margin`), then
+ * `autoware_utils_geometry::sat::intersects` in the footprint frame. The ego OBB (including
+ * `lat_margin`) is built once per query; each candidate only inverse-transforms the object.
  * @return Footprint indices sorted by increasing arc_length.
  */
 std::vector<size_t> query_overlapping_footprints(

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -48,7 +48,6 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
-  <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclpy</depend>

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -150,13 +150,6 @@ trajectory_processor_params:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
-    lateral_margin:
-      type: double
-      default_value: 0.5
-      description: Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
     duplicate_check_threshold:
       type: double
       default_value: 0.5
@@ -222,6 +215,11 @@ trajectory_processor_params:
           default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
           description: Types of polygon shaped objects to consider for obstacle stop
           read_only: false
+        pointcloud:
+          type: string_array
+          default_value: [structure, vegetation]
+          description: Types of pointcloud to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25
@@ -243,26 +241,98 @@ trajectory_processor_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-    pointcloud:
-      target_types:
-        type: string_array
-        default_value: [structure, vegetation]
-        description: Pointcloud types to consider for obstacle stop
-        read_only: false
-      height_buffer:
+      pointcloud_height_buffer:
         type: double
-        default_value: 0.5
-        description: Height buffer to add above ego height [m]
+        default_value: 0.2
+        description: Height buffer to add above ego height for pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      min_height:
+      pointcloud_min_height:
         type: double
         default_value: 0.2
         description: Minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
+      lateral_margin:
+        car:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for car objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        truck:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for truck objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bus:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for bus objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        trailer:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for trailer objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        motorcycle:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for motorcycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bicycle:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for bicycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        pedestrian:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for pedestrian objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        hazard:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for hazard objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        structure:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for structure pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        vegetation:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for vegetation pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        unknown:
+          type: double
+          default_value: 0.0
+          description: Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
 
     rss_params:
       enable:

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -162,12 +162,6 @@
               "default": 3,
               "minimum": 0
             },
-            "lateral_margin": {
-              "type": "number",
-              "description": "Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]",
-              "default": 0.5,
-              "minimum": 0
-            },
             "duplicate_check_threshold": {
               "type": "number",
               "description": "Threshold to check if the stop point is already in the trajectory [m]",
@@ -256,6 +250,14 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "pointcloud": {
+                      "type": "array",
+                      "description": "Types of pointcloud to consider for obstacle stop",
+                      "default": ["structure", "vegetation"],
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [],
@@ -278,33 +280,92 @@
                   "description": "Safety buffer to expand object shape [m]",
                   "default": 0,
                   "minimum": 0
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            "pointcloud": {
-              "type": "object",
-              "properties": {
-                "target_types": {
-                  "type": "array",
-                  "description": "Pointcloud types to consider for obstacle stop",
-                  "default": ["structure", "vegetation"],
-                  "items": {
-                    "type": "string"
-                  }
                 },
-                "height_buffer": {
+                "pointcloud_height_buffer": {
                   "type": "number",
-                  "description": "Height buffer to add above ego height [m]",
-                  "default": 0.5,
-                  "minimum": 0
+                  "description": "Height buffer to add above ego height for pointcloud [m]",
+                  "default": 0.2,
+                  "minimum": 0.0
                 },
-                "min_height": {
+                "pointcloud_min_height": {
                   "type": "number",
                   "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
-                  "minimum": 0
+                  "minimum": 0.0
+                },
+                "lateral_margin": {
+                  "type": "object",
+                  "description": "Lateral margin on top of ego width from trajectory, per object or pointcloud class [m]",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for car objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for truck objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bus objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for trailer objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for motorcycle objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bicycle objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for pedestrian objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "hazard": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for hazard objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "structure": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for structure pointcloud [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "vegetation": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for vegetation pointcloud [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "unknown": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]",
+                      "default": 0.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -17,12 +17,8 @@
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
 #include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
 
-#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/trajectory/trajectory_point.hpp>
-#include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
-#include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/logging.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -190,8 +186,6 @@ bool ObstacleStop::is_trajectory_modification_required(
 
   check_obstacles(traj_points, input);
 
-  debug_data_.active_collision_point =
-    nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
   debug_data_.ego_z = input.current_odometry->pose.pose.position.z;
 
   const bool is_safe = nearest_collision_point_ == std::nullopt;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -223,8 +223,10 @@ bool ObstacleStop::set_stop_point(
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::set_stop_point", *get_time_keeper());
 
+  const auto stop_margin =
+    nearest_collision_point_->is_dynamic ? params_.minimum_stop_margin : params_.stop_margin;
   const auto ego_longitudinal_offset = context_->vehicle_info.max_longitudinal_offset_m;
-  const auto target_stop_margin = params_.stop_margin + ego_longitudinal_offset;
+  const auto target_stop_margin = stop_margin + ego_longitudinal_offset;
   const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
@@ -232,10 +234,10 @@ bool ObstacleStop::set_stop_point(
     stopping_params_.jerk_limit);
 
   // actual stop margin from ego front to collision point
-  const auto stop_margin =
+  const auto actual_stop_margin =
     nearest_collision_point_->arc_length - (target_stop_point_arc_length + ego_longitudinal_offset);
   const auto overlap_th =
-    stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
+    actual_stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
   if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, overlap_th)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -362,26 +362,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
 
   PointCloud::Ptr filtered_pointcloud(new PointCloud);
   pcl::fromROSMsg(*input.obstacle_pointcloud, *filtered_pointcloud);
-  {
-    autoware_utils_debug::ScopedTimeTrack stt(
-      "ObstacleStop::filter_pointcloud", *get_time_keeper());
-    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.min_corner().to_3d(), input.current_odometry->pose.pose);
-    const auto rel_max_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.max_corner().to_3d(), input.current_odometry->pose.pose);
-    constexpr double buffer = 1.0;
-    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
-    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.objects.pointcloud_min_height;
-    const auto max_z =
-      context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
-    pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
-      max_z);
-  }
 
-  if (!filtered_pointcloud->empty()) {
+  {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = context_->tf_buffer.lookupTransform(
@@ -398,6 +380,22 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       p.y = q.y();
       p.z = q.z();
     }
+  }
+
+  {
+    autoware_utils_debug::ScopedTimeTrack stt(
+      "ObstacleStop::filter_pointcloud", *get_time_keeper());
+    const auto & bbox = debug_data_.trajectory_shape.bounding_box;
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(bbox.min_corner().x(), bbox.max_corner().x());
+    const auto [min_y, max_y] = std::minmax(bbox.min_corner().y(), bbox.max_corner().y());
+    const auto ego_z = input.current_odometry->pose.pose.position.z;
+    const auto min_z = ego_z + params_.objects.pointcloud_min_height;
+    const auto max_z =
+      ego_z + context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
+    pointcloud_filter_->filter_pointcloud(
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -67,15 +67,26 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
   }
 
   {
-    const auto & p = params_.pointcloud;
-    pointcloud_filter_ = std::make_unique<utils::obstacle_stop::PointCloudFilter>(p.target_types);
-  }
-
-  {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
       p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
       p.max_lateral_velocity_th, p.safety_buffer);
+    pointcloud_filter_ =
+      std::make_unique<utils::obstacle_stop::PointCloudFilter>(p.target_objects.pointcloud);
+
+    lateral_margin_map_ = {
+      {utils::obstacle_stop::ObjectType::CAR, p.lateral_margin.car},
+      {utils::obstacle_stop::ObjectType::TRUCK, p.lateral_margin.truck},
+      {utils::obstacle_stop::ObjectType::BUS, p.lateral_margin.bus},
+      {utils::obstacle_stop::ObjectType::TRAILER, p.lateral_margin.trailer},
+      {utils::obstacle_stop::ObjectType::MOTORCYCLE, p.lateral_margin.motorcycle},
+      {utils::obstacle_stop::ObjectType::BICYCLE, p.lateral_margin.bicycle},
+      {utils::obstacle_stop::ObjectType::PEDESTRIAN, p.lateral_margin.pedestrian},
+      {utils::obstacle_stop::ObjectType::HAZARD, p.lateral_margin.hazard},
+      {utils::obstacle_stop::ObjectType::STRUCTURE, p.lateral_margin.structure},
+      {utils::obstacle_stop::ObjectType::VEGETATION, p.lateral_margin.vegetation},
+      {utils::obstacle_stop::ObjectType::UNKNOWN, p.lateral_margin.unknown},
+    };
   }
 
   {
@@ -113,15 +124,25 @@ void ObstacleStop::update_params(const TrajectoryProcessorParams & params)
   }
 
   {
-    const auto & p = params_.pointcloud;
-    pointcloud_filter_->set_params(p.target_types);
-  }
-
-  {
     const auto & p = params_.objects;
     object_filter_->set_params(
       p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
       p.max_lateral_velocity_th, p.safety_buffer);
+    pointcloud_filter_->set_params(p.target_objects.pointcloud);
+
+    lateral_margin_map_ = {
+      {utils::obstacle_stop::ObjectType::CAR, p.lateral_margin.car},
+      {utils::obstacle_stop::ObjectType::TRUCK, p.lateral_margin.truck},
+      {utils::obstacle_stop::ObjectType::BUS, p.lateral_margin.bus},
+      {utils::obstacle_stop::ObjectType::TRAILER, p.lateral_margin.trailer},
+      {utils::obstacle_stop::ObjectType::MOTORCYCLE, p.lateral_margin.motorcycle},
+      {utils::obstacle_stop::ObjectType::BICYCLE, p.lateral_margin.bicycle},
+      {utils::obstacle_stop::ObjectType::PEDESTRIAN, p.lateral_margin.pedestrian},
+      {utils::obstacle_stop::ObjectType::HAZARD, p.lateral_margin.hazard},
+      {utils::obstacle_stop::ObjectType::STRUCTURE, p.lateral_margin.structure},
+      {utils::obstacle_stop::ObjectType::VEGETATION, p.lateral_margin.vegetation},
+      {utils::obstacle_stop::ObjectType::UNKNOWN, p.lateral_margin.unknown},
+    };
   }
 
   {
@@ -323,7 +344,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   object_filter_->filter_by_target_area(
     active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
-    params_.lateral_margin, debug_data_.target_polygons);
+    lateral_margin_map_, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
@@ -356,8 +377,9 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     constexpr double buffer = 1.0;
     const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
     const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.pointcloud.min_height;
-    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
+    const auto min_z = params_.objects.pointcloud_min_height;
+    const auto max_z =
+      context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
     pointcloud_filter_->filter_pointcloud(
       filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
       max_z);
@@ -404,7 +426,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     autoware_utils_debug::ScopedTimeTrack stt(
       "ObstacleStop::get_nearest_pcd_collision", *get_time_keeper());
     collision_point = get_nearest_pcd_collision(
-      debug_data_.trajectory_shape, active_points, params_.lateral_margin,
+      debug_data_.trajectory_shape, active_points, lateral_margin_map_,
       debug_data_.target_pcd_points);
   }
 
@@ -443,6 +465,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
 
 void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
+  autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::publish_debug_data", *get_time_keeper());
   if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
 
   MarkerArray marker_array;
@@ -483,11 +506,16 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
 
   int id = 0;
   {
+    double debug_lat_margin = 0.0;
+    for (const auto & [_, lat_margin] : lateral_margin_map_) {
+      debug_lat_margin = std::max(debug_lat_margin, lat_margin);
+    }
+
     const auto & shape = debug_data_.trajectory_shape;
     for (const auto & footprint : shape.footprints) {
       const auto ego_polygon = autoware_utils::to_footprint(
         footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
-        2.0 * (shape.ego_half_width + params_.lateral_margin));
+        2.0 * (shape.ego_half_width + debug_lat_margin));
       add_polygon_marker(ego_polygon, ns + "/traj_polygon", id, yellow);
       id++;
     }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -474,17 +474,46 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
   const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
 
-  auto add_point_marker = [&](
-                            const geometry_msgs::msg::Point & point, const std::string & ns,
-                            const int id, const std_msgs::msg::ColorRGBA & color,
-                            const double scale = 0.1) {
+  auto add_line_list_marker = [&](
+                                const std::vector<geometry_msgs::msg::Point> & segments,
+                                const std::string & ns, const int id,
+                                const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), ns, id, Marker::SPHERE,
-      autoware_utils::create_marker_scale(scale, scale, scale), color);
+      "map", get_clock()->now(), ns, id, Marker::LINE_LIST,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.pose.position = point;
+    marker.points = segments;
     marker_array.markers.push_back(marker);
   };
+
+  int id = 0;
+  {
+    using autoware_utils_geometry::calc_offset_pose;
+    const auto & shape = debug_data_.trajectory_shape;
+    const auto half_width = shape.ego_half_width;
+    const auto front_offset = std::abs(shape.ego_front_offset);
+    const auto back_offset = std::abs(shape.ego_back_offset);
+    std::vector<geometry_msgs::msg::Point> segments;
+    auto dist = 0.0;
+    for (const auto & footprint : shape.footprints) {
+      if (footprint.arc_length - dist < 1.0) continue;
+      dist = footprint.arc_length;
+      auto front_left = calc_offset_pose(footprint.pose, front_offset, -half_width, 0.0).position;
+      auto front_right = calc_offset_pose(footprint.pose, front_offset, half_width, 0.0).position;
+      auto rear_right = calc_offset_pose(footprint.pose, -back_offset, half_width, 0.0).position;
+      auto rear_left = calc_offset_pose(footprint.pose, -back_offset, -half_width, 0.0).position;
+      segments.emplace_back(rear_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_right);
+      segments.emplace_back(front_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_left);
+    }
+    add_line_list_marker(segments, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
 
   auto add_polygon_marker = [&](
                               const autoware_utils_geometry::Polygon2d & polygon,
@@ -504,23 +533,6 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     marker_array.markers.push_back(marker);
   };
 
-  int id = 0;
-  {
-    double debug_lat_margin = 0.0;
-    for (const auto & [_, lat_margin] : lateral_margin_map_) {
-      debug_lat_margin = std::max(debug_lat_margin, lat_margin);
-    }
-
-    const auto & shape = debug_data_.trajectory_shape;
-    for (const auto & footprint : shape.footprints) {
-      const auto ego_polygon = autoware_utils::to_footprint(
-        footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
-        2.0 * (shape.ego_half_width + debug_lat_margin));
-      add_polygon_marker(ego_polygon, ns + "/traj_polygon", id, yellow);
-      id++;
-    }
-  }
-
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
     Polygon2d polygon;
@@ -536,6 +548,18 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
     id++;
   }
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
 
   for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
     add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -20,6 +20,7 @@
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
+#include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
@@ -35,9 +36,9 @@
 
 namespace autoware::trajectory_processor::plugin
 {
+using utils::obstacle_stop::build_trajectory_footprint_index;
 using utils::obstacle_stop::get_nearest_object_collision;
 using utils::obstacle_stop::get_nearest_pcd_collision;
-using utils::obstacle_stop::get_trajectory_shape;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
 
@@ -157,13 +158,13 @@ bool ObstacleStop::is_trajectory_modification_required(
 
   {
     autoware_utils_debug::ScopedTimeTrack st(
-      "ObstacleStop::get_trajectory_shape", *get_time_keeper());
+      "ObstacleStop::build_trajectory_footprint_index", *get_time_keeper());
 
-    debug_data_.trajectory_shape = get_trajectory_shape(
+    debug_data_.trajectory_shape = build_trajectory_footprint_index(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
       input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
-      stopping_params_.jerk_limit, params_.stop_margin, params_.lateral_margin);
+      stopping_params_.jerk_limit, params_.stop_margin);
   }
 
   check_obstacles(traj_points, input);
@@ -321,8 +322,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.filtered_objects, active_objects, get_clock()->now());
 
   object_filter_->filter_by_target_area(
-    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
-    debug_data_.target_polygons);
+    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    params_.lateral_margin, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
@@ -337,7 +338,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
-  const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const InputData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::check_pointcloud", *get_time_keeper());
   if (!params_.use_pointcloud || !input.obstacle_pointcloud) return std::nullopt;
@@ -403,7 +404,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     autoware_utils_debug::ScopedTimeTrack stt(
       "ObstacleStop::get_nearest_pcd_collision", *get_time_keeper());
     collision_point = get_nearest_pcd_collision(
-      traj_points, debug_data_.trajectory_shape, active_points, debug_data_.target_pcd_points);
+      debug_data_.trajectory_shape, active_points, params_.lateral_margin,
+      debug_data_.target_pcd_points);
   }
 
   return collision_point;
@@ -480,9 +482,15 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   };
 
   int id = 0;
-  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
-    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
-    id++;
+  {
+    const auto & shape = debug_data_.trajectory_shape;
+    for (const auto & footprint : shape.footprints) {
+      const auto ego_polygon = autoware_utils::to_footprint(
+        footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
+        2.0 * (shape.ego_half_width + params_.lateral_margin));
+      add_polygon_marker(ego_polygon, ns + "/traj_polygon", id, yellow);
+      id++;
+    }
   }
 
   {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -37,6 +37,8 @@ using utils::obstacle_stop::get_nearest_object_collision;
 using utils::obstacle_stop::get_nearest_pcd_collision;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
+using utils::obstacle_stop::TargetObject;
+using utils::obstacle_stop::TargetObjects;
 
 void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
 {
@@ -334,28 +336,33 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   object_filter_->filter_objects(debug_data_.filtered_objects);
 
-  PredictedObjects active_objects;
   obstacle_tracker_->update_objects(
-    debug_data_.filtered_objects, active_objects, get_clock()->now());
+    debug_data_.filtered_objects, debug_data_.target_objects, get_clock()->now());
 
   object_filter_->filter_by_target_area(
-    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
-    lateral_margin_map_, debug_data_.target_polygons);
+    debug_data_.target_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    lateral_margin_map_);
 
-  autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+    params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
-  if (collision_point) debug_data_.colliding_object = colliding_object;
+  if (collision_point) {
+    auto it = std::find_if(
+      debug_data_.target_objects.begin(), debug_data_.target_objects.end(),
+      [&](const TargetObject & object) { return !object.is_safe; });
+    if (it != debug_data_.target_objects.end()) {
+      debug_data_.colliding_object = it->object;
+    }
+  }
 
   return collision_point;
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
-  [[maybe_unused]] const TrajectoryPoints & traj_points, const InputData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::check_pointcloud", *get_time_keeper());
   if (!params_.use_pointcloud || !input.obstacle_pointcloud) return std::nullopt;
@@ -527,6 +534,20 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     marker_array.markers.push_back(marker);
   };
 
+  auto add_text_marker = [&](
+                           const std::string & text, const geometry_msgs::msg::Pose & pose,
+                           const std::string & ns, const int id,
+                           const std_msgs::msg::ColorRGBA & color, const double scale = 0.4) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::TEXT_VIEW_FACING,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose = pose;
+    marker.pose.position.z += 1.0;
+    marker.text = text;
+    marker_array.markers.push_back(marker);
+  };
+
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
     Polygon2d polygon;
@@ -538,8 +559,17 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     id++;
   }
 
-  for (const auto & target_polygon : debug_data_.target_polygons) {
+  for (const auto & obj : debug_data_.target_objects) {
+    const auto & target_polygon = obj.polygon;
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
+    ss << "rss_safe_dist: " << obj.safe_distance << " m" << "\n";
+    ss << "dist_from_ego: " << obj.distance_from_ego << " m";
+    add_text_marker(
+      ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
+      ns + "/target_objects_text", id, white);
     id++;
   }
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -22,7 +22,6 @@
 #include <autoware_utils/geometry/sat_2d.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
-#include <range/v3/view.hpp>
 
 #include <boost/geometry.hpp>
 
@@ -30,7 +29,6 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -138,103 +136,6 @@ TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, c
   extended_trajectory.insert(
     extended_trajectory.end(), extension_points.begin(), extension_points.end());
   return extended_trajectory;
-}
-
-TrajectoryShape get_trajectory_shape(
-  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin,
-  const double lateral_margin, const double longitudinal_margin)
-{
-  const auto offset_pose =
-    autoware_utils::calc_offset_pose(ego_pose, vehicle_info.max_longitudinal_offset_m, 0, 0);
-  auto start_idx = motion_utils::findNearestSegmentIndex(trajectory_points, offset_pose.position);
-
-  const auto traj_length = motion_utils::calcArcLength(trajectory_points);
-  const auto ego_arc_length =
-    motion_utils::calcSignedArcLength(trajectory_points, 0, ego_pose.position);
-  const auto forward_traj_length = traj_length - ego_arc_length;
-
-  const auto detection_length =
-    get_detection_length(forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin);
-
-  const auto detection_traj = std::invoke([&]() -> TrajectoryPoints {
-    if (detection_length < forward_traj_length) {
-      return motion_utils::cropForwardPoints(
-        trajectory_points, ego_pose.position, start_idx, detection_length);
-    }
-    return extend_trajectory(trajectory_points, stop_margin);
-  });
-
-  autoware_utils_geometry::LineString2d ls_front_right;
-  autoware_utils_geometry::LineString2d ls_front_left;
-  autoware_utils_geometry::LineString2d ls_rear_right;
-  autoware_utils_geometry::LineString2d ls_rear_left;
-  ls_front_right.reserve(detection_traj.size());
-  ls_front_left.reserve(detection_traj.size());
-  ls_rear_right.reserve(detection_traj.size());
-  ls_rear_left.reserve(detection_traj.size());
-
-  autoware_utils_geometry::Polygon2d polygon_front;
-  autoware_utils_geometry::Polygon2d polygon_rear;
-
-  constexpr double min_resolution = 0.1;
-
-  const auto base_footprint = vehicle_info.createFootprint(lateral_margin, longitudinal_margin);
-  for (const auto & [idx, p] : detection_traj | ranges::views::enumerate) {
-    if (idx > 0) {
-      const auto & prev_p = detection_traj[idx - 1];
-      const auto dist = autoware_utils::calc_distance2d(prev_p, p);
-      if (dist < min_resolution) continue;
-    }
-    const autoware_utils_geometry::Point2d base_link(p.pose.position.x, p.pose.position.y);
-    const auto angle = tf2::getYaw(p.pose.orientation);
-    const Eigen::Rotation2Dd rotation(angle);
-    const auto front_left_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::FrontLeftIndex];
-    const auto front_right_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::FrontRightIndex];
-    const auto rear_right_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::RearRightIndex];
-    const auto rear_left_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::RearLeftIndex];
-    ls_front_left.emplace_back(
-      base_link.x() + front_left_offset.x(), base_link.y() + front_left_offset.y());
-    ls_front_right.emplace_back(
-      base_link.x() + front_right_offset.x(), base_link.y() + front_right_offset.y());
-    ls_rear_right.emplace_back(
-      base_link.x() + rear_right_offset.x(), base_link.y() + rear_right_offset.y());
-    ls_rear_left.emplace_back(
-      base_link.x() + rear_left_offset.x(), base_link.y() + rear_left_offset.y());
-  }
-  ls_rear_left.emplace_back(ls_front_left.back());
-  ls_rear_right.emplace_back(ls_front_right.back());
-  ls_front_left.insert(ls_front_left.begin(), ls_rear_left.front());
-  ls_front_right.insert(ls_front_right.begin(), ls_rear_right.front());
-
-  boost::geometry::reverse(ls_front_right);
-  boost::geometry::reverse(ls_rear_right);
-
-  boost::geometry::append(polygon_front, ls_front_left);
-  boost::geometry::append(polygon_front, ls_front_right);
-  boost::geometry::append(polygon_rear, ls_rear_left);
-  boost::geometry::append(polygon_rear, ls_rear_right);
-
-  boost::geometry::correct(polygon_front);
-  boost::geometry::correct(polygon_rear);
-
-  autoware_utils_geometry::MultiPolygon2d trajectory_polygon;
-  boost::geometry::union_(polygon_front, polygon_rear, trajectory_polygon);
-
-  autoware_utils_geometry::Box2d envelope;
-  boost::geometry::envelope(trajectory_polygon, envelope);
-
-  TrajectoryShape shape;
-  shape.polygon = std::move(trajectory_polygon);
-  shape.bounding_box = envelope;
-  shape.trajectory_length = traj_length;
-  shape.forward_traj_length = forward_traj_length;
-  return shape;
 }
 
 TrajectoryShape build_trajectory_footprint_index(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -19,6 +19,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/object_recognition_utils/predicted_path_utils.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils/geometry/sat_2d.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <range/v3/view.hpp>
@@ -369,7 +370,53 @@ bool is_point_within_footprint(
   return rel.x() >= -shape.ego_back_offset && rel.x() <= shape.ego_front_offset &&
          std::abs(rel.y()) <= shape.ego_half_width + lat_margin;
 }
+
+Polygon2d make_local_ego_polygon(const TrajectoryShape & shape, const double lat_margin)
+{
+  const double half_width = shape.ego_half_width + lat_margin;
+  Polygon2d ego;
+  ego.outer() = {
+    {shape.ego_front_offset, half_width},  {shape.ego_front_offset, -half_width},
+    {-shape.ego_back_offset, -half_width}, {-shape.ego_back_offset, half_width},
+    {shape.ego_front_offset, half_width},
+  };
+  return ego;
+}
+
+Polygon2d transform_polygon_to_pose_frame(
+  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose)
+{
+  Polygon2d local;
+  local.outer().reserve(polygon.outer().size());
+  for (const auto & p : polygon.outer()) {
+    const auto rel = autoware_utils::inverse_transform_point(p.to_3d(), pose);
+    local.outer().emplace_back(rel.x(), rel.y());
+  }
+  return local;
+}
 }  // namespace
+
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
+{
+  if (polygon.outer().empty()) return {};
+
+  const auto query_box = inflate_box(
+    boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
+  const auto candidates = query_rtree_candidates(shape, query_box);
+  const auto ego_local = make_local_ego_polygon(shape, lat_margin);
+
+  std::vector<size_t> hits;
+  hits.reserve(candidates.size());
+  for (const auto & node : candidates) {
+    const auto object_local =
+      transform_polygon_to_pose_frame(polygon, shape.footprints[node.second].pose);
+    if (autoware_utils_geometry::sat::intersects(ego_local, object_local)) {
+      hits.push_back(node.second);
+    }
+  }
+  return sort_hits_by_arc_length(shape, std::move(hits));
+}
 
 std::vector<size_t> query_overlapping_footprints(
   const TrajectoryShape & shape, const Point2d & point, const double lat_margin)
@@ -383,29 +430,6 @@ std::vector<size_t> query_overlapping_footprints(
   hits.reserve(candidates.size());
   for (const auto & node : candidates) {
     if (is_point_within_footprint(shape, shape.footprints[node.second], point, lat_margin)) {
-      hits.push_back(node.second);
-    }
-  }
-  return sort_hits_by_arc_length(shape, std::move(hits));
-}
-
-std::vector<size_t> query_overlapping_footprints(
-  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
-{
-  if (polygon.outer().empty()) return {};
-
-  const auto query_box = inflate_box(
-    boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
-  const auto candidates = query_rtree_candidates(shape, query_box);
-
-  std::vector<size_t> hits;
-  hits.reserve(candidates.size());
-  for (const auto & node : candidates) {
-    const auto & footprint = shape.footprints[node.second];
-    const auto ego_polygon = autoware_utils::to_footprint(
-      footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
-      2.0 * (shape.ego_half_width + lat_margin));
-    if (!boost::geometry::disjoint(polygon, ego_polygon)) {
       hits.push_back(node.second);
     }
   }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <string>
 #include <utility>
@@ -227,7 +228,189 @@ TrajectoryShape get_trajectory_shape(
   autoware_utils_geometry::Box2d envelope;
   boost::geometry::envelope(trajectory_polygon, envelope);
 
-  return TrajectoryShape{trajectory_polygon, envelope, traj_length, forward_traj_length};
+  TrajectoryShape shape;
+  shape.polygon = std::move(trajectory_polygon);
+  shape.bounding_box = envelope;
+  shape.trajectory_length = traj_length;
+  shape.forward_traj_length = forward_traj_length;
+  return shape;
+}
+
+TrajectoryShape build_trajectory_footprint_index(
+  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
+  const double ego_accel, const double decel, const double jerk, const double stop_margin)
+{
+  TrajectoryShape shape;
+  shape.trajectory_length = 0.0;
+  shape.forward_traj_length = 0.0;
+  shape.ego_half_width = vehicle_info.vehicle_width_m / 2.0;
+  shape.ego_front_offset = vehicle_info.max_longitudinal_offset_m;
+  shape.ego_back_offset = -vehicle_info.min_longitudinal_offset_m;
+
+  if (trajectory_points.empty()) return shape;
+
+  const auto offset_pose =
+    autoware_utils::calc_offset_pose(ego_pose, vehicle_info.max_longitudinal_offset_m, 0, 0);
+  auto start_idx = motion_utils::findNearestSegmentIndex(trajectory_points, offset_pose.position);
+
+  const auto traj_length = motion_utils::calcArcLength(trajectory_points);
+  const auto ego_arc_length =
+    motion_utils::calcSignedArcLength(trajectory_points, 0, ego_pose.position);
+  const auto forward_traj_length = traj_length - ego_arc_length;
+  shape.trajectory_length = traj_length;
+  shape.forward_traj_length = forward_traj_length;
+
+  const auto detection_length =
+    get_detection_length(forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin);
+
+  const auto detection_traj = std::invoke([&]() -> TrajectoryPoints {
+    if (detection_length < forward_traj_length) {
+      return motion_utils::cropForwardPoints(
+        trajectory_points, ego_pose.position, start_idx, detection_length);
+    }
+    return extend_trajectory(trajectory_points, stop_margin);
+  });
+
+  if (detection_traj.empty()) return shape;
+
+  constexpr double min_ds = 0.1;
+  constexpr double max_ds = 0.5;
+
+  auto add_sample =
+    [&](const geometry_msgs::msg::Pose & pose, const size_t traj_index, const double arc_length) {
+      shape.footprints.push_back(EgoFootprint{pose, traj_index, arc_length});
+    };
+
+  const auto to_original_index = [&](const size_t detection_idx) {
+    return std::min(detection_idx, trajectory_points.size() - 1);
+  };
+
+  auto prev_pose = detection_traj.front().pose;
+  double prev_s = 0.0;
+  size_t prev_idx = 0;
+  add_sample(prev_pose, prev_idx, prev_s);
+
+  for (size_t i = 1; i < detection_traj.size(); ++i) {
+    const auto & curr_pose = detection_traj[i].pose;
+    const auto dist = autoware_utils::calc_distance2d(prev_pose, curr_pose);
+    const bool is_last = (i + 1 == detection_traj.size());
+    if (!is_last && dist < min_ds) continue;
+
+    const auto traj_index = to_original_index(i);
+    if (dist > max_ds) {
+      const auto n_steps = static_cast<size_t>(std::ceil(dist / max_ds));
+      for (size_t k = 1; k < n_steps; ++k) {
+        const auto ratio = static_cast<double>(k) / static_cast<double>(n_steps);
+        const auto interp_pose =
+          autoware_utils_geometry::calc_interpolated_pose(prev_pose, curr_pose, ratio, false);
+        add_sample(interp_pose, prev_idx, prev_s + ratio * dist);
+      }
+    }
+
+    const auto curr_s = prev_s + dist;
+    add_sample(curr_pose, traj_index, curr_s);
+    prev_pose = curr_pose;
+    prev_s = curr_s;
+    prev_idx = traj_index;
+  }
+
+  std::vector<FootprintNode> nodes;
+  nodes.reserve(shape.footprints.size());
+  for (size_t i = 0; i < shape.footprints.size(); ++i) {
+    const auto poly = autoware_utils::to_footprint(
+      shape.footprints[i].pose, shape.ego_front_offset, shape.ego_back_offset,
+      2.0 * shape.ego_half_width);
+    const auto box = boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(poly);
+    nodes.emplace_back(box, i);
+    if (i == 0) {
+      shape.bounding_box = box;
+    } else {
+      boost::geometry::expand(shape.bounding_box, box);
+    }
+  }
+  shape.rtree = FootprintRtree(nodes.begin(), nodes.end());
+  return shape;
+}
+
+namespace
+{
+autoware_utils_geometry::Box2d inflate_box(
+  const autoware_utils_geometry::Box2d & box, const double margin)
+{
+  return {
+    {box.min_corner().x() - margin, box.min_corner().y() - margin},
+    {box.max_corner().x() + margin, box.max_corner().y() + margin}};
+}
+
+std::vector<FootprintNode> query_rtree_candidates(
+  const TrajectoryShape & shape, const autoware_utils_geometry::Box2d & query_box)
+{
+  std::vector<FootprintNode> candidates;
+  if (shape.rtree.empty()) return candidates;
+  shape.rtree.query(
+    boost::geometry::index::intersects(query_box), std::back_inserter(candidates));
+  return candidates;
+}
+
+std::vector<size_t> sort_hits_by_arc_length(
+  const TrajectoryShape & shape, std::vector<size_t> && hits)
+{
+  std::sort(hits.begin(), hits.end(), [&](const size_t a, const size_t b) {
+    return shape.footprints[a].arc_length < shape.footprints[b].arc_length;
+  });
+  return hits;
+}
+
+bool is_point_within_footprint(
+  const TrajectoryShape & shape, const EgoFootprint & footprint, const Point2d & point,
+  const double lat_margin)
+{
+  const auto rel = autoware_utils::inverse_transform_point(point.to_3d(), footprint.pose);
+  return rel.x() >= -shape.ego_back_offset && rel.x() <= shape.ego_front_offset &&
+         std::abs(rel.y()) <= shape.ego_half_width + lat_margin;
+}
+}  // namespace
+
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Point2d & point, const double lat_margin)
+{
+  const autoware_utils_geometry::Box2d query_box{
+    {point.x() - lat_margin, point.y() - lat_margin},
+    {point.x() + lat_margin, point.y() + lat_margin}};
+  const auto candidates = query_rtree_candidates(shape, query_box);
+
+  std::vector<size_t> hits;
+  hits.reserve(candidates.size());
+  for (const auto & node : candidates) {
+    if (is_point_within_footprint(shape, shape.footprints[node.second], point, lat_margin)) {
+      hits.push_back(node.second);
+    }
+  }
+  return sort_hits_by_arc_length(shape, std::move(hits));
+}
+
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
+{
+  if (polygon.outer().empty()) return {};
+
+  const auto query_box =
+    inflate_box(boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
+  const auto candidates = query_rtree_candidates(shape, query_box);
+
+  std::vector<size_t> hits;
+  hits.reserve(candidates.size());
+  for (const auto & node : candidates) {
+    const auto & footprint = shape.footprints[node.second];
+    const auto ego_polygon = autoware_utils::to_footprint(
+      footprint.pose, shape.ego_front_offset, shape.ego_back_offset,
+      2.0 * (shape.ego_half_width + lat_margin));
+    if (!boost::geometry::disjoint(polygon, ego_polygon)) {
+      hits.push_back(node.second);
+    }
+  }
+  return sort_hits_by_arc_length(shape, std::move(hits));
 }
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -646,12 +646,16 @@ void ObjectFilter::filter_by_target_area(
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
   constexpr double time_buffer = 0.5;
   auto time_to_obj_current_pos =
-    [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
+    [&](const auto & object_pose, const size_t nearest_seg_idx) -> std::optional<double> {
     const auto t_to_nearest_seg =
       rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
     const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
+    if (nearest_seg_vel < 1e-3) {
+      if (lon_offset_dist > ego_front_offset) return std::nullopt;
+      return std::max(0.0, t_to_nearest_seg - time_buffer);
+    }
     const auto ego_front_time_offset = ego_front_offset / nearest_seg_vel;
     const auto t_to_obj =
       t_to_nearest_seg + (lon_offset_dist / nearest_seg_vel) - ego_front_time_offset - time_buffer;
@@ -689,7 +693,8 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
     if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
-    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
+    if (!t_to_obj_current_pos) return true;
+    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos.value());
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
     return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
   };

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -275,7 +275,7 @@ TrajectoryShape build_trajectory_footprint_index(
   if (detection_traj.empty()) return shape;
 
   constexpr double min_ds = 0.1;
-  constexpr double max_ds = 0.5;
+  constexpr double max_ds = 1.0;
 
   auto add_sample =
     [&](const geometry_msgs::msg::Pose & pose, const size_t traj_index, const double arc_length) {
@@ -414,7 +414,8 @@ std::vector<size_t> query_overlapping_footprints(
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
-  const double lat_margin, std::vector<geometry_msgs::msg::Point> & target_pcd_points)
+  const LateralMarginMap & lateral_margin_map,
+  std::vector<geometry_msgs::msg::Point> & target_pcd_points)
 {
   if (pointcloud->empty() || trajectory_shape.footprints.empty()) return std::nullopt;
 
@@ -423,6 +424,8 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   bool found_collision = false;
 
   for (const auto & point : *pointcloud) {
+    const auto classification = static_cast<PointCloudClassification>(point.class_id);
+    const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(classification));
     const Point2d query_point{point.x, point.y};
     const auto hits = query_overlapping_footprints(trajectory_shape, query_point, lat_margin);
     if (hits.empty()) continue;
@@ -712,7 +715,7 @@ void PointCloudFilter::filter_pointcloud_by_object(
 void ObjectFilter::filter_by_target_area(
   PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const TrajectoryShape & trajectory_shape, const double lat_margin,
+  const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map,
   MultiPolygon2d & target_polygons)
 {
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
@@ -741,11 +744,11 @@ void ObjectFilter::filter_by_target_area(
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };
 
-  auto overlaps_ego_footprints = [&](const Polygon2d & polygon) {
+  auto overlaps_ego_footprints = [&](const Polygon2d & polygon, const double lat_margin) {
     return !query_overlapping_footprints(trajectory_shape, polygon, lat_margin).empty();
   };
 
-  auto is_exiting = [&](const auto & object) -> bool {
+  auto is_exiting = [&](const auto & object, const double lat_margin) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
@@ -763,17 +766,18 @@ void ObjectFilter::filter_by_target_area(
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
-    return !overlaps_ego_footprints(obj_pred_polygon);
+    return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
   };
 
   objects.objects.erase(
     std::remove_if(
       objects.objects.begin(), objects.objects.end(),
       [&](const auto & object) {
+        const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(object));
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
-        if (!overlaps_ego_footprints(object_polygon)) return true;
-        if (is_exiting(object)) return true;
+        if (!overlaps_ego_footprints(object_polygon, lat_margin)) return true;
+        if (is_exiting(object, lat_margin)) return true;
         target_polygons.emplace_back(object_polygon);
         return false;
       }),

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -722,6 +722,15 @@ void ObstacleTracker::update_objects(
       it++;
   }
 
+  auto estimate_pose = [&](const PersistentObject & object) -> geometry_msgs::msg::Pose {
+    const auto & pose = object.object.kinematics.initial_pose_with_covariance.pose;
+    const auto & twist = object.object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto dt = (now - object.last_seen_time).seconds();
+    const auto dx = twist.x * dt;
+    const auto dy = twist.y * dt;
+    return autoware_utils::calc_offset_pose(pose, dx, dy, 0.0);
+  };
+
   auto get_closest_object_uuid =
     [&](const PredictedObject & object) -> std::optional<boost::uuids::uuid> {
     std::optional<boost::uuids::uuid> closest_uuid = std::nullopt;
@@ -739,9 +748,9 @@ void ObstacleTracker::update_objects(
       if (existing_obj_label != obj_label) continue;
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,
-        existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
+        estimate_pose(existing_object).position);
       if (distance > min_distance) continue;
-      // ignore orientation difference for cylinder objects
+      // ignore orientation difference for symmetric objects
       const bool is_symmetric =
         std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
       const auto yaw_diff =

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -468,22 +469,24 @@ double get_safe_distance(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
-  PredictedObject & colliding_object, const double stopped_vel_th)
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
+  const double stopped_vel_th)
 {
-  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   double obstacle_lon_vel = 0.0;
-  for (const auto & object : target_objects.objects) {
-    const auto obj_state = get_object_state_at_time(trajectory_points, object, 0.0);
+  for (auto & object : target_objects) {
+    const auto obj_state = get_object_state_at_time(trajectory_points, object.object, 0.0);
+    object.is_safe = false;
+    object.safe_distance = obj_state.arc_length;
+    object.distance_from_ego = obj_state.arc_length;
     found_collision = true;
     if (obj_state.arc_length < min_arc_length) {
       min_arc_length = obj_state.arc_length;
       nearest_collision_point = obj_state.nearest_point;
-      colliding_object = object;
       obstacle_lon_vel = obj_state.lon_vel;
     }
   }
@@ -495,19 +498,17 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
-  const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   const bool use_rss_check)
 {
-  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   // If RSS check is disabled, get the nearest object collision by pure geometric overlap.
   if (!use_rss_check) {
-    return get_nearest_object_collision(
-      trajectory_points, target_objects, colliding_object, stopped_vel_th);
+    return get_nearest_object_collision(target_objects, trajectory_points, stopped_vel_th);
   }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
@@ -529,13 +530,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const double obj_arc_length, const double obj_stopping_distance,
-                   const double ego_arc_length, const double ego_vel) -> bool {
-    if (obj_stopping_distance <= eps) return false;
-    const auto safe_dist =
-      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+                   const double ego_arc_length,
+                   const double ego_vel) -> std::tuple<bool, double, double> {
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    return relative_arc_length - safe_dist > 1e-3;
+    if (obj_stopping_distance <= eps)
+      return std::make_tuple(false, relative_arc_length, relative_arc_length);
+    const auto safe_dist =
+      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+    return std::make_tuple(relative_arc_length - safe_dist > 1e-3, safe_dist, relative_arc_length);
   };
 
   auto min_collision_arc_length = std::numeric_limits<double>::max();
@@ -543,25 +546,32 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   bool found_collision = false;
   double obstacle_lon_vel = 0.0;
 
-  for (const auto & object : target_objects.objects) {
+  for (auto & object : target_objects) {
     auto last_p = trajectory_points.front().pose.position;
     auto curr_arc_length = 0.0;
+    bool is_first = true;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
       last_p = traj_p.pose.position;
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
-      const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      const auto obj_stopping_distance = get_object_stopping_distance(object, obj_state.lon_vel);
-      const auto safe =
+      const auto obj_state = get_object_state_at_time(trajectory_points, object.object, t);
+      const auto obj_stopping_distance =
+        get_object_stopping_distance(object.object, obj_state.lon_vel);
+      const auto [safe, safe_distance, distance_from_ego] =
         is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
-      if (safe) continue;
+      object.is_safe = safe;
+      if (is_first) {
+        is_first = false;
+        object.safe_distance = safe_distance;
+        object.distance_from_ego = distance_from_ego;
+      }
+      if (object.is_safe) continue;
       found_collision = true;
       auto collision_arc_length = obj_state.arc_length + obj_stopping_distance;
       if (collision_arc_length < min_collision_arc_length) {
         min_collision_arc_length = collision_arc_length;
-        colliding_object = object;
         const auto collision_point = motion_utils::calcLongitudinalOffsetPose(
           trajectory_points, obj_state.nearest_point, obj_stopping_distance);
         nearest_collision_point =
@@ -638,10 +648,9 @@ void PointCloudFilter::filter_pointcloud_by_object(
 }
 
 void ObjectFilter::filter_by_target_area(
-  PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map,
-  MultiPolygon2d & target_polygons)
+  const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map)
 {
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
   constexpr double time_buffer = 0.5;
@@ -699,23 +708,24 @@ void ObjectFilter::filter_by_target_area(
     return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
   };
 
-  objects.objects.erase(
+  target_objects.erase(
     std::remove_if(
-      objects.objects.begin(), objects.objects.end(),
-      [&](const auto & object) {
+      target_objects.begin(), target_objects.end(),
+      [&](auto & obj) {
+        const auto & object = obj.object;
         const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(object));
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
         if (!overlaps_ego_footprints(object_polygon, lat_margin)) return true;
         if (is_exiting(object, lat_margin)) return true;
-        target_polygons.emplace_back(object_polygon);
+        obj.polygon = object_polygon;
         return false;
       }),
-    objects.objects.end());
+    target_objects.end());
 }
 
 void ObstacleTracker::update_objects(
-  const PredictedObjects & objects, PredictedObjects & persistent_objects, const rclcpp::Time & now)
+  const PredictedObjects & objects, TargetObjects & persistent_objects, const rclcpp::Time & now)
 {
   for (auto it = persistent_objects_map_.begin(); it != persistent_objects_map_.end();) {
     const auto idle_time = (now - it->second.last_seen_time).seconds();
@@ -786,7 +796,7 @@ void ObstacleTracker::update_objects(
 
   for (const auto & [uuid, entry] : persistent_objects_map_) {
     if (entry.is_active) {
-      persistent_objects.objects.push_back(entry.object);
+      persistent_objects.emplace_back(entry.object);
     }
   }
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -348,8 +348,7 @@ std::vector<FootprintNode> query_rtree_candidates(
 {
   std::vector<FootprintNode> candidates;
   if (shape.rtree.empty()) return candidates;
-  shape.rtree.query(
-    boost::geometry::index::intersects(query_box), std::back_inserter(candidates));
+  shape.rtree.query(boost::geometry::index::intersects(query_box), std::back_inserter(candidates));
   return candidates;
 }
 
@@ -395,8 +394,8 @@ std::vector<size_t> query_overlapping_footprints(
 {
   if (polygon.outer().empty()) return {};
 
-  const auto query_box =
-    inflate_box(boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
+  const auto query_box = inflate_box(
+    boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
   const auto candidates = query_rtree_candidates(shape, query_box);
 
   std::vector<size_t> hits;
@@ -414,34 +413,36 @@ std::vector<size_t> query_overlapping_footprints(
 }
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points)
+  const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
+  const double lat_margin, std::vector<geometry_msgs::msg::Point> & target_pcd_points)
 {
-  if (pointcloud->empty() || trajectory_points.size() < 2) return std::nullopt;
-
-  PointCloud::Ptr pointcloud_in_polygon(new PointCloud);
-  for (const auto & point : *pointcloud) {
-    if (boost::geometry::within(
-          autoware_utils::Point2d{point.x, point.y}, trajectory_shape.polygon)) {
-      pointcloud_in_polygon->push_back(point);
-    }
-  }
-
-  if (pointcloud_in_polygon->empty()) return std::nullopt;
+  if (pointcloud->empty() || trajectory_shape.footprints.empty()) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
-  for (const auto & point : *pointcloud_in_polygon) {
+  bool found_collision = false;
+
+  for (const auto & point : *pointcloud) {
+    const Point2d query_point{point.x, point.y};
+    const auto hits = query_overlapping_footprints(trajectory_shape, query_point, lat_margin);
+    if (hits.empty()) continue;
+
+    const auto & footprint = trajectory_shape.footprints[hits.front()];
+    const auto rel = autoware_utils::inverse_transform_point(query_point.to_3d(), footprint.pose);
+    const auto arc_length = footprint.arc_length + rel.x();
+
     geometry_msgs::msg::Point p =
       geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
-    auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
+    target_pcd_points.emplace_back(p);
+
     if (arc_length < min_arc_length) {
       min_arc_length = arc_length;
       nearest_collision_point = p;
+      found_collision = true;
     }
-    target_pcd_points.emplace_back(p);
   }
 
+  if (!found_collision) return std::nullopt;
   return CollisionPoint(nearest_collision_point, min_arc_length, 0.0);
 }
 
@@ -711,7 +712,8 @@ void PointCloudFilter::filter_pointcloud_by_object(
 void ObjectFilter::filter_by_target_area(
   PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
+  const TrajectoryShape & trajectory_shape, const double lat_margin,
+  MultiPolygon2d & target_polygons)
 {
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
   constexpr double time_buffer = 0.5;
@@ -739,6 +741,10 @@ void ObjectFilter::filter_by_target_area(
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };
 
+  auto overlaps_ego_footprints = [&](const Polygon2d & polygon) {
+    return !query_overlapping_footprints(trajectory_shape, polygon, lat_margin).empty();
+  };
+
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
@@ -757,7 +763,7 @@ void ObjectFilter::filter_by_target_area(
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
-    return boost::geometry::disjoint(obj_pred_polygon, target_area);
+    return !overlaps_ego_footprints(obj_pred_polygon);
   };
 
   objects.objects.erase(
@@ -766,7 +772,7 @@ void ObjectFilter::filter_by_target_area(
       [&](const auto & object) {
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
-        if (boost::geometry::disjoint(object_polygon, target_area)) return true;
+        if (!overlaps_ego_footprints(object_polygon)) return true;
         if (is_exiting(object)) return true;
         target_polygons.emplace_back(object_polygon);
         return false;

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -234,7 +234,8 @@ protected:
     p.enable_stop_for_objects = true;
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
-    p.lateral_margin = 0.5;
+    p.objects.lateral_margin.car = 0.5;
+    p.objects.lateral_margin.unknown = 0.5;
 
     p.obstacle_tracking.on_time_buffer = 0.01;
     p.obstacle_tracking.off_time_buffer = 1.0;
@@ -245,10 +246,7 @@ protected:
 
     p.objects.target_objects.bbox = {"car"};
     p.objects.target_objects.polygon = {"car"};
-
-    p.pointcloud.target_types = {"unknown"};
-    p.pointcloud.height_buffer = 0.5;
-    p.pointcloud.min_height = 0.2;
+    p.objects.target_objects.pointcloud = {"unknown"};
 
     p.rss_params.enable = true;
     p.rss_params.object_decel.car = 1.5;


### PR DESCRIPTION
## Description
Until now the `obstacle_stop` created a swept trajectory shape polygon from ego footprints and used it to check for overlapping obstacles. The swept polygon was buffered using a single global lateral_margin.

This PR modifies the logic to use an ego-footprint R-tree and apply a per-class lateral margin at query time, instead of a single swept-union polygon with one global margin. The same filtering and parameter layout is used in both `autoware_trajectory_modifier` and the backup planner (`autoware_minimum_rule_based_planner`).

### Changes 
- Build an R-tree of ego footprints along the detection range. Vehicle extents are stored without extra lateral margin; class-specific expansion is applied only when querying.
- Filter predicted objects and pointcloud points against that index: coarse AABB lookup, then a precise overlap test with the class’s lateral_margin.
- Replace boost::geometry::disjoint polygon checks with 2d SAT in the footprint frame.
- Point queries use a vehicle-frame OBB test (x in bumper range, `|y| <= half_width + lat_margin`).
- Pointcloud collisions use the class of each point so structure, vegetation, and unknown can have different margins.
- Drop the single `obstacle_stop.lateral_margin` and look up `objects.lateral_margin.<class>` .

### Related Links
[Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2846)