### PR TITLE
fix(mppi_optimizer): disable Savitzky–Golay filter

### DIFF
--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp
@@ -307,8 +307,8 @@ public:
     const std::vector<float> & accel_cmd, const std::vector<float> & steer_cmd);
 
   /**
-   * @brief Seed vendor Savitzky–Golay control_history_ (2 previous applied commands).
-   *        Required for offline retune to match online smoothing edge taps.
+   * @brief Seed the legacy vendor control_history_ for debug-log/replay compatibility.
+   *        The restored unfiltered MPPI control sequence does not depend on these values.
    *        Order: (accel/steer) at t-2, then (accel/steer) at t-1.
    */
   void setControlHistory(float accel_tm2, float steer_tm2, float accel_tm1, float steer_tm1);

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_debug_trajectory_logger.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_debug_trajectory_logger.hpp
@@ -80,7 +80,7 @@ struct MppiDebugEgoState
  *   <log_dir>/000000_road_borders.csv
  *   <log_dir>/000000_drivable.csv
  *   <log_dir>/000000_objects.csv
- *   <log_dir>/000000_control_history.csv  (SG taps at cycle start)
+ *   <log_dir>/000000_control_history.csv  (legacy vendor history at cycle start)
  *   <log_dir>/000000_delay_buffer.csv     (per-channel FIFOs before optimize)
  *   <log_dir>/000000_applied.csv          (u[0] applied this cycle)
  *   ...

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -258,13 +258,42 @@ std::string formatCostBreakdown(const CostBreakdown & cost)
   return stream.str();
 }
 
-/** Expose vendor Savitzky–Golay control_history_ for offline retune parity. */
-class MppiWithHistoryAccess : public Mppi
+/**
+ * Restore the reduced MPPI mean after the vendor controller applies its unconditional
+ * Savitzky–Golay post-filter. The sampler retains the unfiltered mean on the device, so this
+ * avoids copying the vendor computeControl implementation while ensuring that returned controls
+ * and the reconstructed state trajectory use the sequence produced by MPPI reduction.
+ */
+class UnfilteredMppiController : public Mppi
 {
 public:
   using Mppi::Mppi;
 
-  /** Replace the vendor-smoothed sequence and keep its host state rollout consistent. */
+  void computeControl(
+    const Eigen::Ref<const Mppi::state_array> & state, const int optimization_stride = 1) override
+  {
+    Mppi::computeControl(state, optimization_stride);
+
+    // The base call may still be copying its filtered host rollout on the visualization stream.
+    // Finish that read before replacing control_ and output_ below.
+    HANDLE_ERROR(cudaStreamSynchronize(this->vis_stream_));
+
+    // smoothControlTrajectory() only overwrites the controller's host control_. The sampling
+    // distribution still owns the final reduced mean on the device.
+    this->sampler_->setHostOptimalControlSequence(this->control_.data(), 0, true);
+
+    // First reconstruct the predicted state at each command. Constraints such as reverse
+    // prevention depend on velocity, so applying them against the vendor's zero_state would erase
+    // every braking command. Then constrain the stored controls against their corresponding
+    // predicted states and replay once more to keep control_, state_, and output_ consistent.
+    this->computeStateTrajectory(state);
+    for (int timestep = 0; timestep < this->getNumTimesteps(); ++timestep) {
+      this->model_->enforceConstraints(this->state_.col(timestep), this->control_.col(timestep));
+    }
+    this->computeStateTrajectory(state);
+  }
+
+  /** Replace the optimized sequence and keep its host state rollout consistent. */
   void setControlSequenceAndRecomputeState(
     const Mppi::control_trajectory & controls, const Mppi::state_array & initial_state)
   {
@@ -696,7 +725,7 @@ struct FirstOrderDubinsMppiInterface::Impl
   FirstOrderDubinsBicycleCostParams<kRefHorizon> cost_params{};
   SAMPLER sampler;
   FB feedback;
-  std::unique_ptr<MppiWithHistoryAccess> controller;
+  std::unique_ptr<UnfilteredMppiController> controller;
   Mppi::control_trajectory u_nom = Mppi::control_trajectory::Zero();
   Mppi::control_trajectory u_opt = Mppi::control_trajectory::Zero();
   DYN::state_array x = DYN::state_array::Zero();
@@ -848,7 +877,7 @@ struct FirstOrderDubinsMppiInterface::Impl
     sampler = SAMPLER(sp);
 
     const float lambda = user_cost_params_.lambda;
-    controller = std::make_unique<MppiWithHistoryAccess>(
+    controller = std::make_unique<UnfilteredMppiController>(
       &model, &cost, &feedback, &sampler, kDt, kMaxIter, lambda, 0.0F, kMppiHorizon, u_nom);
     auto cp = controller->getParams();
     cp.lambda_ = lambda;
@@ -1421,7 +1450,8 @@ struct FirstOrderDubinsMppiInterface::Impl
 
   FirstOrderDubinsMppiControl runStep()
   {
-    // History taps used by this cycle's Savitzky–Golay (before slideControlSequence).
+    // Retain the legacy vendor-history snapshot for debug-log format compatibility. The restored
+    // unfiltered MPPI result is independent of these Savitzky–Golay edge taps.
     snapshotControlHistoryForLog();
 
     // Measured ego IC; per-channel delay lives in dynamics taps (no host pre-roll / ref shift).
@@ -1525,8 +1555,8 @@ struct FirstOrderDubinsMppiInterface::Impl
         u_opt_traj(accel_idx, timestep) =
           active_velocity_limit_profile.controls[static_cast<std::size_t>(timestep)].accel_cmd;
       }
-      // The vendor Savitzky-Golay filter remains unchanged and executes first. Project its
-      // longitudinal result onto the active profile and reconstruct the host state rollout.
+      // Project the restored unfiltered result onto the active longitudinal profile and
+      // reconstruct the host state rollout.
       controller->setControlSequenceAndRecomputeState(u_opt_traj, x);
     }
     u_opt = u_opt_traj;
@@ -1829,8 +1859,8 @@ FirstOrderDubinsMppiControl FirstOrderDubinsMppiInterface::computeStep(
   impl_->sim_time = sim_time;
   const FirstOrderDubinsMppiControl control = impl_->runStep();
   state = toHostState(impl_->x);
-  // Advance the vendor control history after the applied command is consumed so the
-  // next cycle's Savitzky-Golay left-edge taps are the previously applied controls.
+  // Advance the sequence after consuming its first command. Vendor history is retained only for
+  // API/debug compatibility; it does not affect the restored unfiltered result.
   impl_->controller->slideControlSequence(1);
   return control;
 }
@@ -2087,8 +2117,8 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
         : "unknown");
   }
 
-  // Advance the vendor control history after all getControlSeq / getActualStateSeq reads
-  // so the next cycle's Savitzky-Golay left-edge taps are the previously applied controls.
+  // Advance the sequence after all getControlSeq / getActualStateSeq reads. Vendor history is
+  // retained only for API/debug compatibility.
   impl_->controller->slideControlSequence(1);
 
   return result;

--- a/planning/autoware_mppi_optimizer/src/tools/mppi_offline_retune.cpp
+++ b/planning/autoware_mppi_optimizer/src/tools/mppi_offline_retune.cpp
@@ -635,13 +635,6 @@ int run(int argc, char ** argv)
     if (loadMppiDebugControlHistoryCsv(
           log_dir + "/" + tag + "_control_history.csv", hist_a0, hist_s0, hist_a1, hist_s1)) {
       frame_mppi.setControlHistory(hist_a0, hist_s0, hist_a1, hist_s1);
-    } else {
-      static bool warned_missing_history = false;
-      if (!warned_missing_history) {
-        std::cerr << "WARNING: missing *_control_history.csv; Savitzky–Golay edge taps are zero "
-                     "(re-log for exact online match).\n";
-        warned_missing_history = true;
-      }
     }
     const bool force_nominal = !nominal_csv_override.empty() || !reseed_nominal_from_reference;
     if (force_nominal) {

--- a/planning/autoware_mppi_optimizer/test/test_first_order_dubins_mppi_interface.cpp
+++ b/planning/autoware_mppi_optimizer/test/test_first_order_dubins_mppi_interface.cpp
@@ -306,6 +306,41 @@ TEST_F(FirstOrderDubinsMppiInterfaceGpuTest, InactiveVelocityLimitProducesIdenti
   }
 }
 
+TEST_F(FirstOrderDubinsMppiInterfaceGpuTest, UnfilteredControlDoesNotDependOnPostFilterHistory)
+{
+  FirstOrderDubinsMppiVehicleParams vehicle_params;
+  vehicle_params.acc_time_delay = 0.0F;
+  vehicle_params.steer_time_delay = 0.0F;
+  const auto input = makeStraightTrajectory(85U);
+  FirstOrderDubinsMppiOptimizationResult negative_history_result;
+  FirstOrderDubinsMppiOptimizationResult positive_history_result;
+  std::vector<float> negative_history_acceleration;
+  std::vector<float> negative_history_steering;
+  std::vector<float> positive_history_acceleration;
+  std::vector<float> positive_history_steering;
+
+  {
+    FirstOrderDubinsMppiInterface interface;
+    interface.setVehicleParams(vehicle_params);
+    interface.setControlHistory(-6.0F, -0.45F, -6.0F, -0.45F);
+    negative_history_result = optimize(interface, input);
+    ASSERT_TRUE(
+      interface.copyLastOptimizedControl(negative_history_acceleration, negative_history_steering));
+  }
+  {
+    FirstOrderDubinsMppiInterface interface;
+    interface.setVehicleParams(vehicle_params);
+    interface.setControlHistory(4.0F, 0.45F, 4.0F, 0.45F);
+    positive_history_result = optimize(interface, input);
+    ASSERT_TRUE(
+      interface.copyLastOptimizedControl(positive_history_acceleration, positive_history_steering));
+  }
+
+  EXPECT_EQ(negative_history_acceleration, positive_history_acceleration);
+  EXPECT_EQ(negative_history_steering, positive_history_steering);
+  EXPECT_TRUE(negative_history_result.trajectory == positive_history_result.trajectory);
+}
+
 TEST_F(
   FirstOrderDubinsMppiInterfaceGpuTest,
   PointwiseLimitsAboveExternalLimitPreserveExternalOutputExactly)


### PR DESCRIPTION
Implement a custom `UnfilteredMppiController` that disable the broken Savitzky–Golay filter performed by the `MPPI-Generic` library.