### PR TITLE
feat(diffusion_planner): add acados kinematic bicycle trajectory optimization

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(onnxruntime QUIET)
 
 # Options
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
+option(ENABLE_ACADOS "Enable acados trajectory optimization when available" ON)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/AddAcadosSolver.cmake")
 
 # Find CUDA
 option(CUDA_AVAIL "CUDA available" OFF)
@@ -100,6 +102,15 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     )
   endif()
 
+  set(DIFFUSION_PLANNER_HAS_ACADOS FALSE)
+  if(ENABLE_ACADOS)
+    diffusion_planner_add_acados_solver(DIFFUSION_PLANNER_ACADOS_TARGET)
+    if(DIFFUSION_PLANNER_ACADOS_TARGET)
+      set(DIFFUSION_PLANNER_HAS_ACADOS TRUE)
+      list(APPEND DIFFUSION_PLANNER_SOURCES src/optimization/trajectory_optimizer.cpp)
+    endif()
+  endif()
+
   # Add your component library
   ament_auto_add_library(autoware_diffusion_planner_component SHARED
     ${DIFFUSION_PLANNER_SOURCES}
@@ -124,6 +135,15 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     ${CUDA_LIBRARIES}
     ${CUBLAS_LIBRARIES}
   )
+
+  if(DIFFUSION_PLANNER_HAS_ACADOS)
+    target_link_libraries(autoware_diffusion_planner_component
+      ${DIFFUSION_PLANNER_ACADOS_TARGET}
+    )
+    target_compile_definitions(autoware_diffusion_planner_component PUBLIC
+      AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+    )
+  endif()
 
   if(onnxruntime_FOUND)
     if(TARGET onnxruntime::onnxruntime)
@@ -153,7 +173,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
   if(BUILD_TESTING)
-    ament_add_ros_isolated_gtest(test_diffusion_planner
+    set(DIFFUSION_PLANNER_TEST_SOURCES
       test/agent_test.cpp
       test/agent_history_resampler_test.cpp
       test/agent_lifecycle_test.cpp
@@ -171,6 +191,12 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       test/diffusion_planner_integration_test.cpp
       test/rtc_prefix_test.cpp
       test/planning_factor_utils_test.cpp)
+    if(DIFFUSION_PLANNER_HAS_ACADOS)
+      list(APPEND DIFFUSION_PLANNER_TEST_SOURCES test/trajectory_optimizer_test.cpp)
+    endif()
+
+    ament_add_ros_isolated_gtest(test_diffusion_planner
+      ${DIFFUSION_PLANNER_TEST_SOURCES})
 
     target_link_libraries(test_diffusion_planner autoware_diffusion_planner_component)
     ament_target_dependencies(test_diffusion_planner

--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -79,6 +79,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/conversion/agent.cpp
     src/conversion/agent_history_resampler.cpp
     src/postprocessing/postprocessing_utils.cpp
+    src/postprocessing/road_border_avoidance.cpp
     src/preprocessing/lane_segments.cpp
     src/preprocessing/preprocessing_utils.cpp
     src/preprocessing/traffic_signals.cpp
@@ -190,7 +191,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       test/lanelet_edge_case_test.cpp
       test/diffusion_planner_integration_test.cpp
       test/rtc_prefix_test.cpp
-      test/planning_factor_utils_test.cpp)
+      test/planning_factor_utils_test.cpp
+      test/road_border_avoidance_test.cpp)
     if(DIFFUSION_PLANNER_HAS_ACADOS)
       list(APPEND DIFFUSION_PLANNER_TEST_SOURCES test/trajectory_optimizer_test.cpp)
     endif()

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -18,6 +18,24 @@ The node publishes raw diffusion trajectories. The downstream `autoware_trajecto
 
 ---
 
+## Trajectory optimization
+
+The raw model output is a noisy, pose-only 80-point sequence (x, y, cos(yaw), sin(yaw) at t = 0.1 .. 8.0 s) that does not necessarily start at base_link. Finite-difference velocity smoothing is used only when `trajectory_optimization.enable` is false or the solver fails. When enable is true, an [acados](https://docs.acados.org/)-based OCP refines the ego trajectory before publishing:
+
+- **Model**: kinematic bicycle with steering-angle state — states (x, y, yaw, v, delta), inputs (acceleration, steering rate)
+- **Horizon**: N = 80, dt = 0.1 s (aligned 1:1 with the model output)
+- **Cost**: tracks the raw positions (and weakly heading), with longitudinal/lateral weights split along the reference heading. Acceleration and steering rate are regularized. Velocity and steering have no tracking reference.
+- **Constraints**: initial state fixed to the current ego state (base_link pose, odometry velocity, measured steering angle), velocity/steering/input box bounds, soft lateral acceleration bound
+- **Fallback**: if acados is missing at build time, or a solve fails, the previous finite-difference velocity smoothing (`velocity_smoothing_window`, `stopping_threshold`) is used
+
+The OCP is defined in `scripts/generate_solver.py` (vehicle model in `scripts/vehicle_model.py`); C code is generated at build time. Cost weights and constraint bounds are injected at node startup from ROS parameters. Building requires acados at `ACADOS_SOURCE_DIR` (default `/opt/acados`) with its Python venv; without it the package builds with optimization disabled.
+
+acados is a kinematic projector. Finite-difference velocity smoothing is used only when optimization is disabled or the solver fails.
+
+Debug topics: `~/debug/optimization/raw_trajectory`, `~/debug/optimization/solver_status`, `~/debug/optimization/solve_time_ms`.
+
+---
+
 ## How to use
 
 ### (1) Prerequisites
@@ -187,7 +205,8 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 | `~/input/traffic_signals` | autoware_perception_msgs/msg/TrafficLightGroupArray | Traffic light states       |
 | `~/input/vector_map`      | autoware_map_msgs/msg/LaneletMapBin                 | Lanelet2 map               |
 | `~/input/route`           | autoware_planning_msgs/msg/LaneletRoute             | Route information          |
-| `~/input/turn_indicators` | autoware_vehicle_msgs/msg/TurnIndicatorsReport      | Turn indicator information |
+| `~/input/turn_indicators` | autoware_vehicle_msgs/msg/TurnIndicatorsReport      | Turn indicator information                                    |
+| `~/input/steering_status` | autoware_vehicle_msgs/msg/SteeringReport            | Measured steering angle (used by trajectory optimization) |
 
 ## Outputs
 
@@ -200,6 +219,9 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 | `~/output/debug/traffic_signal` | autoware_perception_msgs/msg/TrafficLightGroup            | First traffic light on route (ego forward) for RViz/ad_api |
 | `~/debug/lane_marker`           | visualization_msgs/msg/MarkerArray                        | Lane debug markers                                         |
 | `~/debug/route_marker`          | visualization_msgs/msg/MarkerArray                        | Route debug markers                                        |
+| `~/debug/optimization/raw_trajectory` | autoware_planning_msgs/msg/Trajectory               | Pose-only model output before acados optimization          |
+| `~/debug/optimization/solver_status` | std_msgs/msg/Int32                                  | acados solver status (0 = success)                         |
+| `~/debug/optimization/solve_time_ms` | std_msgs/msg/Float64                                | acados solve time                                          |
 
 ---
 

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -36,6 +36,16 @@ Debug topics: `~/debug/optimization/raw_trajectory`, `~/debug/optimization/solve
 
 ---
 
+## Road border avoidance
+
+When `road_border_avoidance.enable` is true, the raw model output is checked against lanelet `type=road_border` line strings **before** acados tracking. For every trajectory point the ego footprint, inflated by `footprint_margin_m`, is placed at the point's pose and tested for overlap (boost::geometry). Overlapping points are shifted perpendicular to their heading, away from the nearest border, in `shift_step_m` increments until the footprint clears all borders (the total offset is capped at `max_lateral_shift_m`; if the cap is reached the shift is kept as best effort and a warning is logged). With `propagate_shift` enabled (default) the offset is carried over to all subsequent points along each point's own lateral direction, so the path stays shifted after passing the border instead of snapping back to the raw output. Yaw and all other fields stay untouched. The shifted poses become the OCP reference when trajectory optimization is enabled.
+
+The parameter is off by default. Changing it requires a node restart.
+
+Debug topics: `~/debug/road_border_avoidance/adjusted_trajectory`, `~/debug/road_border_avoidance/shifted_point_count`.
+
+---
+
 ## How to use
 
 ### (1) Prerequisites

--- a/planning/autoware_diffusion_planner/cmake/AddAcadosSolver.cmake
+++ b/planning/autoware_diffusion_planner/cmake/AddAcadosSolver.cmake
@@ -1,0 +1,100 @@
+include_guard(GLOBAL)
+
+set(ACADOS_SOURCE_DIR "$ENV{ACADOS_SOURCE_DIR}" CACHE PATH "Path to the acados installation")
+if(NOT ACADOS_SOURCE_DIR)
+  set(ACADOS_SOURCE_DIR "/opt/acados" CACHE PATH "Path to the acados installation" FORCE)
+endif()
+
+function(diffusion_planner_add_acados_solver output_target)
+  find_library(ACADOS_LIBRARY acados HINTS "${ACADOS_SOURCE_DIR}/lib")
+  find_library(BLASFEO_LIBRARY blasfeo HINTS "${ACADOS_SOURCE_DIR}/lib")
+  find_library(HPIPM_LIBRARY hpipm HINTS "${ACADOS_SOURCE_DIR}/lib")
+  set(acados_python "${ACADOS_SOURCE_DIR}/.venv/bin/python3")
+
+  if(NOT ACADOS_LIBRARY OR NOT BLASFEO_LIBRARY OR NOT HPIPM_LIBRARY OR
+     NOT EXISTS "${acados_python}")
+    message(WARNING
+      "acados was not found under ${ACADOS_SOURCE_DIR}; "
+      "trajectory optimization support will be disabled")
+    set(${output_target} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(acados_model diffusion_planner_optimizer)
+  set(generated_root "${CMAKE_CURRENT_BINARY_DIR}/acados_generated")
+  set(generated_dir "${generated_root}/c_generated_code")
+  file(MAKE_DIRECTORY "${generated_root}")
+  set(generated_files
+    "${generated_dir}/acados_solver_${acados_model}.h"
+    "${generated_dir}/acados_solver_${acados_model}.c"
+    "${generated_dir}/${acados_model}_model/${acados_model}_expl_ode_fun.c"
+    "${generated_dir}/${acados_model}_model/${acados_model}_expl_vde_forw.c"
+    "${generated_dir}/${acados_model}_model/${acados_model}_expl_vde_adj.c"
+    "${generated_dir}/${acados_model}_constraints/${acados_model}_constr_h_fun.c"
+    "${generated_dir}/${acados_model}_constraints/${acados_model}_constr_h_fun_jac_uxt_zt.c"
+  )
+
+  set_source_files_properties(${generated_files} PROPERTIES GENERATED TRUE)
+  add_custom_command(
+    OUTPUT ${generated_files}
+    COMMAND ${CMAKE_COMMAND} -E env
+      "ACADOS_SOURCE_DIR=${ACADOS_SOURCE_DIR}"
+      "PYTHONPATH=${ACADOS_SOURCE_DIR}/interfaces/acados_template:${CMAKE_CURRENT_SOURCE_DIR}/scripts:$ENV{PYTHONPATH}"
+      "${acados_python}" "${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_solver.py"
+    WORKING_DIRECTORY "${generated_root}"
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_solver.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/scripts/vehicle_model.py"
+    COMMENT "Generating acados trajectory optimization solver"
+    VERBATIM
+  )
+
+  add_custom_target(generate_diffusion_planner_acados_code DEPENDS ${generated_files})
+  add_library(autoware_diffusion_planner_acados SHARED
+    src/optimization/acados_solver_wrapper.cpp
+    ${generated_files}
+  )
+  add_dependencies(
+    autoware_diffusion_planner_acados
+    generate_diffusion_planner_acados_code
+  )
+
+  target_include_directories(autoware_diffusion_planner_acados
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    PRIVATE
+      "${generated_root}"
+      "${generated_dir}"
+      "${ACADOS_SOURCE_DIR}/include"
+      "${ACADOS_SOURCE_DIR}/include/acados"
+      "${ACADOS_SOURCE_DIR}/include/acados_c"
+      "${ACADOS_SOURCE_DIR}/include/blasfeo/include"
+      "${ACADOS_SOURCE_DIR}/include/hpipm/include"
+  )
+  target_link_libraries(autoware_diffusion_planner_acados PRIVATE
+    "${ACADOS_LIBRARY}"
+    "${BLASFEO_LIBRARY}"
+    "${HPIPM_LIBRARY}"
+  )
+  set_target_properties(autoware_diffusion_planner_acados PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    BUILD_RPATH "${ACADOS_SOURCE_DIR}/lib"
+    INSTALL_RPATH "${ACADOS_SOURCE_DIR}/lib"
+  )
+
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set_source_files_properties(${generated_files} PROPERTIES
+      COMPILE_OPTIONS "-Wno-unused-variable;-Wno-unused-parameter;-Wno-unused-function"
+    )
+  endif()
+
+  install(TARGETS autoware_diffusion_planner_acados
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+
+  set(${output_target} autoware_diffusion_planner_acados PARENT_SCOPE)
+endfunction()

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -44,6 +44,21 @@
       max_position_error_m: 0.3       # [m]   skip the snap when the actual ego pose is farther than this from the snapped pose
       max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
+    trajectory_optimization:
+      enable: true
+      weight_longitudinal: 0.5       # tracking weight along the reference heading [1/m^2]
+      weight_lateral: 0.5            # tracking weight perpendicular to the reference heading [1/m^2]
+      weight_yaw: 0.05               # tracking weight for heading [1/rad^2]
+      weight_acceleration: 0.1       # regularization weight on acceleration input
+      weight_steering_rate: 10.0     # regularization weight on steering rate input
+      terminal_weight_scale: 2.5     # terminal state weight = scale * stage weight
+      min_velocity_mps: 0.0          # lower velocity bound; 0 prevents backward motion [m/s]
+      max_velocity_mps: 30.0         # upper velocity bound [m/s]
+      min_acceleration_mps2: -4.0    # [m/s^2]
+      max_acceleration_mps2: 3.0     # [m/s^2]
+      max_steering_rate_rps: 1.0     # [rad/s]
+      max_lateral_acceleration_mps2: 3.0  # soft constraint bound [m/s^2]
+      max_sqp_iterations: 50
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -59,6 +59,13 @@
       max_steering_rate_rps: 1.0     # [rad/s]
       max_lateral_acceleration_mps2: 3.0  # soft constraint bound [m/s^2]
       max_sqp_iterations: 50
+    road_border_avoidance:
+      enable: false
+      footprint_margin_m: 0.2     # ego footprint inflation for the overlap check [m]
+      search_radius_m: 120.0      # road borders farther than this from ego are ignored [m]
+      shift_step_m: 0.1           # lateral shift resolution [m]
+      max_lateral_shift_m: 1.5    # cap on the total lateral offset from the raw position [m]
+      propagate_shift: true       # carry the offset over to all subsequent points
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -21,6 +21,10 @@
 #include "autoware/diffusion_planner/inference/guidance/start_guidance.hpp"
 #include "autoware/diffusion_planner/inference/guidance/stop_guidance.hpp"
 #include "autoware/diffusion_planner/inference/inference.hpp"
+#include "autoware/diffusion_planner/optimization/optimizer_params.hpp"
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+#include "autoware/diffusion_planner/optimization/trajectory_optimizer.hpp"
+#endif
 #include "autoware/diffusion_planner/postprocessing/turn_indicator_manager.hpp"
 #include "autoware/diffusion_planner/preprocessing/lane_segments.hpp"
 #include "autoware/diffusion_planner/preprocessing/traffic_signals.hpp"
@@ -90,6 +94,14 @@ struct VehicleSpec
   }
 };
 
+struct TrajectoryOptimizationDebug
+{
+  bool attempted{false};
+  bool optimized{false};
+  int solver_status{0};
+  double solve_time_ms{0.0};
+};
+
 struct PlannerOutput
 {
   Trajectory trajectory;
@@ -98,6 +110,8 @@ struct PlannerOutput
   TurnIndicatorsCommand turn_indicators_command;
   Float32MultiArray denoising_steps;
   std::unordered_map<std::string, std::vector<bool>> guidance_triggered;
+  std::optional<Trajectory> raw_trajectory;
+  TrajectoryOptimizationDebug optimization_debug;
 };
 
 struct FrameContext
@@ -178,6 +192,7 @@ struct DiffusionPlannerParams
   double start_guidance_max_scale;
   double stop_guidance_stop_acceleration_mps2;
   double centerline_guidance_start_time_s;
+  optimization::TrajectoryOptimizationParams trajectory_optimization;
 };
 
 /**
@@ -319,11 +334,14 @@ public:
    * @param frame_context Context of the current frame.
    * @param timestamp The ROS time stamp for the messages.
    * @param generator_uuid The unique identifier for the planner instance.
+   * @param current_steering_angle_rad Measured steering angle used by trajectory optimization
+   *        (estimated from yaw rate when not available).
    * @return PlannerOutput containing all output messages.
    */
   PlannerOutput create_planner_output(
     const InferenceOutput & inference_output, const FrameContext & frame_context,
-    const rclcpp::Time & timestamp, const UUID & generator_uuid);
+    const rclcpp::Time & timestamp, const UUID & generator_uuid,
+    const std::optional<double> & current_steering_angle_rad = std::nullopt);
 
   /**
    * @brief Get the first traffic light on the route for debugging.
@@ -361,6 +379,9 @@ private:
 
   // Inference engine
   std::unique_ptr<Inference> diffusion_planner_inference_{nullptr};
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+  std::unique_ptr<optimization::TrajectoryOptimizer> trajectory_optimizer_{nullptr};
+#endif
   std::shared_ptr<StartGuidance> start_guidance_{nullptr};
   std::shared_ptr<StopGuidance> stop_guidance_{nullptr};
   std::shared_ptr<CenterlineGuidance> centerline_guidance_{nullptr};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -25,6 +25,7 @@
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
 #include "autoware/diffusion_planner/optimization/trajectory_optimizer.hpp"
 #endif
+#include "autoware/diffusion_planner/postprocessing/road_border_avoidance.hpp"
 #include "autoware/diffusion_planner/postprocessing/turn_indicator_manager.hpp"
 #include "autoware/diffusion_planner/preprocessing/lane_segments.hpp"
 #include "autoware/diffusion_planner/preprocessing/traffic_signals.hpp"
@@ -102,6 +103,13 @@ struct TrajectoryOptimizationDebug
   double solve_time_ms{0.0};
 };
 
+struct RoadBorderAvoidanceDebug
+{
+  bool active{false};
+  int shifted_points{0};
+  int unresolved_points{0};
+};
+
 struct PlannerOutput
 {
   Trajectory trajectory;
@@ -112,6 +120,8 @@ struct PlannerOutput
   std::unordered_map<std::string, std::vector<bool>> guidance_triggered;
   std::optional<Trajectory> raw_trajectory;
   TrajectoryOptimizationDebug optimization_debug;
+  std::optional<Trajectory> avoidance_adjusted_trajectory;
+  RoadBorderAvoidanceDebug avoidance_debug;
 };
 
 struct FrameContext
@@ -193,6 +203,7 @@ struct DiffusionPlannerParams
   double stop_guidance_stop_acceleration_mps2;
   double centerline_guidance_start_time_s;
   optimization::TrajectoryOptimizationParams trajectory_optimization;
+  postprocess::RoadBorderAvoidanceParams road_border_avoidance;
 };
 
 /**
@@ -382,6 +393,7 @@ private:
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
   std::unique_ptr<optimization::TrajectoryOptimizer> trajectory_optimizer_{nullptr};
 #endif
+  std::unique_ptr<postprocess::RoadBorderAvoidance> road_border_avoidance_{nullptr};
   std::shared_ptr<StartGuidance> start_guidance_{nullptr};
   std::shared_ptr<StopGuidance> stop_guidance_{nullptr};
   std::shared_ptr<CenterlineGuidance> centerline_guidance_{nullptr};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -248,6 +248,8 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_raw_trajectory_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_optimization_status_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_optimization_time_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_avoidance_trajectory_{nullptr};
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_avoidance_shifted_count_{nullptr};
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
     pub_guidance_status_{nullptr};
   rclcpp::Service<SetBool>::SharedPtr set_start_guidance_enabled_service_{nullptr};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -38,10 +38,12 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -56,6 +58,7 @@ using autoware_internal_planning_msgs::msg::CandidateTrajectories;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::SteeringReport;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware::vehicle_info_utils::VehicleInfo;
@@ -242,6 +245,9 @@ private:
     pub_snap_interpolation_time_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_inference_time_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_denoising_steps_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_raw_trajectory_{nullptr};
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_optimization_status_{nullptr};
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_optimization_time_{nullptr};
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
     pub_guidance_status_{nullptr};
   rclcpp::Service<SetBool>::SharedPtr set_start_guidance_enabled_service_{nullptr};
@@ -250,6 +256,8 @@ private:
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
   autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
     this, "~/input/odometry"};
+  autoware_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_status_{
+    this, "~/input/steering_status"};
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
     sub_current_acceleration_{this, "~/input/acceleration"};
   autoware_utils::InterProcessPollingSubscriber<TrackedObjects> sub_tracked_objects_{

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/acados_solver_wrapper.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/acados_solver_wrapper.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__ACADOS_SOLVER_WRAPPER_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__ACADOS_SOLVER_WRAPPER_HPP_
+
+#include "autoware/diffusion_planner/optimization/optimizer_params.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+namespace autoware::diffusion_planner::optimization
+{
+
+// OCP dimensions. Must match scripts/generate_solver.py (static_asserts in the .cpp
+// verify them against the generated code).
+constexpr size_t opt_horizon = 80;  // = OUTPUT_T model output steps
+constexpr size_t opt_nx = 5;        // x, y, yaw, velocity, steering angle
+constexpr size_t opt_nu = 2;        // acceleration, steering rate
+constexpr double opt_dt_s = 0.1;    // = PREDICTION_TIME_STEP_S
+
+/// Per-stage tracking reference (positions in the solver's local frame).
+/// Only pose is tracked: the model outputs positions and headings only, so no velocity
+/// reference exists. The velocity profile emerges from the time-indexed position tracking
+/// and the input regularization/bounds.
+struct StageReference
+{
+  double x{0.0};
+  double y{0.0};
+  double yaw{0.0};
+};
+
+struct SolverSolution
+{
+  int status{-1};  // acados status, 0 on success
+  int sqp_iterations{0};
+  double solve_time_s{0.0};
+  std::array<std::array<double, opt_nx>, opt_horizon + 1> states{};
+  std::array<std::array<double, opt_nu>, opt_horizon> inputs{};
+
+  [[nodiscard]] bool success() const { return status == 0; }
+};
+
+/**
+ * @brief Thin RAII wrapper around the generated acados OCP solver.
+ *
+ * Owns the solver capsule and hides the generated C headers (pimpl), so this header
+ * stays usable without the code-generated sources. Weights and bounds are written into
+ * the solver once at construction.
+ */
+class AcadosSolverWrapper
+{
+public:
+  AcadosSolverWrapper(
+    const TrajectoryOptimizationParams & params, double wheelbase_m, double max_steering_angle_rad);
+  ~AcadosSolverWrapper();
+
+  AcadosSolverWrapper(const AcadosSolverWrapper &) = delete;
+  AcadosSolverWrapper & operator=(const AcadosSolverWrapper &) = delete;
+  AcadosSolverWrapper(AcadosSolverWrapper &&) = delete;
+  AcadosSolverWrapper & operator=(AcadosSolverWrapper &&) = delete;
+
+  /**
+   * @brief Solve the OCP.
+   *
+   * @param initial_state Stage-0 state (equality constrained): x, y, yaw, v, delta.
+   * @param references Tracking references for stages 1..N; the last entry doubles as the
+   *                   terminal reference. Positions must share the frame of initial_state.
+   * @param warm_start Previous solution in the same frame, or nullptr for a cold start.
+   */
+  SolverSolution solve(
+    const std::array<double, opt_nx> & initial_state,
+    const std::array<StageReference, opt_horizon> & references, const SolverSolution * warm_start);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace autoware::diffusion_planner::optimization
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__ACADOS_SOLVER_WRAPPER_HPP_

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/optimizer_params.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/optimizer_params.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__OPTIMIZER_PARAMS_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__OPTIMIZER_PARAMS_HPP_
+
+namespace autoware::diffusion_planner::optimization
+{
+
+/**
+ * @brief Runtime parameters for the acados-based trajectory optimization.
+ *
+ * Cost weights and constraint bounds are injected into the generated solver at startup,
+ * so tuning them does not require regenerating the acados code
+ * (see scripts/generate_solver.py for the baked-in defaults and the OCP definition).
+ */
+struct TrajectoryOptimizationParams
+{
+  bool enable{false};
+
+  // Cost weights (LINEAR_LS).
+  // The position error is split along the reference heading: longitudinal errors
+  // (ahead/behind the time schedule, i.e. velocity-profile freedom) and lateral errors
+  // (path deviation) are weighted separately via a per-stage rotated 2x2 weight block.
+  // Velocity and steering angle carry no tracking weight: the model outputs positions
+  // and headings only, so no reference exists for them.
+  double weight_longitudinal{0.5};
+  double weight_lateral{0.5};
+  double weight_yaw{0.05};
+  double weight_acceleration{0.1};
+  double weight_steering_rate{10.0};
+  // Terminal state weight = terminal_weight_scale * stage state weight.
+  double terminal_weight_scale{2.5};
+
+  // State bounds (stages 1..N). min_velocity_mps >= 0 prevents backward motion.
+  double min_velocity_mps{0.0};
+  double max_velocity_mps{30.0};
+
+  // Input bounds.
+  double min_acceleration_mps2{-4.0};
+  double max_acceleration_mps2{3.0};
+  double max_steering_rate_rps{1.0};
+
+  // Soft nonlinear constraint |v^2 * tan(delta) / wheelbase| <= max_lateral_acceleration_mps2.
+  double max_lateral_acceleration_mps2{3.0};
+
+  int max_sqp_iterations{50};
+};
+
+}  // namespace autoware::diffusion_planner::optimization
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__OPTIMIZER_PARAMS_HPP_

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/trajectory_optimizer.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/optimization/trajectory_optimizer.hpp
@@ -1,0 +1,92 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__TRAJECTORY_OPTIMIZER_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__TRAJECTORY_OPTIMIZER_HPP_
+
+#include "autoware/diffusion_planner/optimization/acados_solver_wrapper.hpp"
+#include "autoware/diffusion_planner/optimization/optimizer_params.hpp"
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::diffusion_planner::optimization
+{
+using autoware_planning_msgs::msg::Trajectory;
+using nav_msgs::msg::Odometry;
+
+struct OptimizationResult
+{
+  Trajectory trajectory;
+  bool optimized{false};
+  int solver_status{0};
+  double solve_time_ms{0.0};
+};
+
+/**
+ * @brief Optimizes the raw diffusion planner trajectory with an acados OCP.
+ *
+ * The raw model output is a noisy, pose-only 80-point sequence (t = 0.1..8.0 s) that
+ * does not start at base_link. This class solves a kinematic bicycle OCP (inputs:
+ * acceleration and steering rate) tracking that sequence, with the initial state fixed to
+ * the current ego state. The result is an 80-point trajectory (t = 0.1..8.0 s, same timing
+ * convention as the raw output) that is dynamically consistent with the current ego state
+ * and carries velocity, acceleration and steering profiles.
+ */
+class TrajectoryOptimizer
+{
+public:
+  TrajectoryOptimizer(
+    const TrajectoryOptimizationParams & params,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, size_t batch_size);
+
+  /**
+   * @brief Optimize one candidate trajectory.
+   *
+   * @param raw_trajectory Raw trajectory from the model (>= 80 points, map frame).
+   * @param ego_odometry Current ego kinematic state (base_link in map frame).
+   * @param current_steering_angle_rad Measured steering angle; estimated from yaw rate
+   *                                   when not available.
+   * @param batch_index Candidate index; warm starts are kept per candidate.
+   * @return Optimized trajectory, or the raw trajectory when the solver fails.
+   */
+  OptimizationResult optimize(
+    const Trajectory & raw_trajectory, const Odometry & ego_odometry,
+    const std::optional<double> & current_steering_angle_rad, size_t batch_index);
+
+private:
+  TrajectoryOptimizationParams params_;
+  double wheelbase_m_;
+  double max_steering_angle_rad_;
+  std::unique_ptr<AcadosSolverWrapper> solver_;
+
+  // Previous solutions in map frame, per candidate, used as warm starts.
+  struct PreviousSolution
+  {
+    SolverSolution solution;
+    rclcpp::Time stamp;
+  };
+  std::vector<std::optional<PreviousSolution>> previous_solutions_;
+};
+
+}  // namespace autoware::diffusion_planner::optimization
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__OPTIMIZATION__TRAJECTORY_OPTIMIZER_HPP_

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -94,6 +94,16 @@ Trajectory create_ego_trajectory(
   const double stopping_threshold);
 
 /**
+ * @brief Creates a pose-only ego Trajectory from parsed agent poses.
+ *
+ * Velocity, acceleration, and steering are left at zero. Used as the tracking
+ * reference for trajectory optimization (and as a raw-output debug message).
+ */
+Trajectory create_ego_pose_trajectory(
+  const std::vector<std::vector<std::vector<Eigen::Matrix4d>>> & agent_poses,
+  const rclcpp::Time & stamp, const int64_t batch_index);
+
+/**
  * @brief Counts valid elements in a tensor with shape (B, len, dim2, dim3).
  * An element is considered valid if not all values in the (dim2, dim3) block are zero.
  *

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/road_border_avoidance.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/road_border_avoidance.hpp
@@ -1,0 +1,105 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__POSTPROCESSING__ROAD_BORDER_AVOIDANCE_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__POSTPROCESSING__ROAD_BORDER_AVOIDANCE_HPP_
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace autoware::diffusion_planner::postprocess
+{
+using autoware_planning_msgs::msg::Trajectory;
+
+struct RoadBorderAvoidanceParams
+{
+  bool enable{false};
+  // Longitudinal and lateral inflation of the ego footprint used for the overlap check.
+  double footprint_margin_m{0.2};
+  // Road borders farther than this from the current ego position are ignored.
+  double search_radius_m{120.0};
+  // Lateral shift resolution and cap (total offset from the raw position) per point.
+  double shift_step_m{0.1};
+  double max_lateral_shift_m{1.5};
+  // When true, the lateral offset of an overlapping point is carried over to all
+  // subsequent points (the path stays shifted instead of snapping back to the raw
+  // output right after the border). When false, only overlapping points are shifted.
+  bool propagate_shift{true};
+};
+
+struct RoadBorderAvoidanceResult
+{
+  Trajectory trajectory;
+  // Points shifted and now clear of all road borders.
+  size_t num_shifted_points{0};
+  // Points still overlapping after the maximum shift (shift kept, best effort).
+  size_t num_unresolved_points{0};
+
+  [[nodiscard]] bool modified() const { return num_shifted_points + num_unresolved_points > 0; }
+};
+
+/**
+ * @brief Shifts raw model-output trajectory points laterally away from road borders.
+ *
+ * For every trajectory point the ego footprint (inflated by footprint_margin_m) is placed
+ * at the point's pose and checked for overlap against the road border line strings of the
+ * lanelet map (boost::geometry). Overlapping points are moved perpendicular to their
+ * heading, away from the nearest border, in shift_step_m increments until the footprint
+ * clears all borders or the total offset reaches max_lateral_shift_m. With
+ * propagate_shift enabled the resulting offset is carried over to all subsequent points
+ * (applied along each point's own lateral direction), so the path stays shifted after
+ * passing the border instead of snapping back. Yaw and all non-position fields are left
+ * untouched. The adjusted trajectory is meant to be fed to the acados-based trajectory
+ * optimization as its tracking reference.
+ */
+class RoadBorderAvoidance
+{
+public:
+  RoadBorderAvoidance(
+    const RoadBorderAvoidanceParams & params,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+
+  /// Extract and cache the road border line strings (map frame) from the lanelet map.
+  void set_map(const lanelet::LaneletMap & lanelet_map);
+
+  /// Directly set the road borders (map frame). Used by set_map() and unit tests.
+  void set_road_borders(std::vector<autoware_utils_geometry::LineString2d> road_borders);
+
+  /**
+   * @brief Check and adjust one raw trajectory (map frame).
+   * @param raw_trajectory Raw model-output trajectory.
+   * @param ego_pose Current ego pose, used to pre-filter faraway borders.
+   */
+  [[nodiscard]] RoadBorderAvoidanceResult adjust(
+    const Trajectory & raw_trajectory, const geometry_msgs::msg::Pose & ego_pose) const;
+
+private:
+  RoadBorderAvoidanceParams params_;
+  // Inflated ego footprint in base_link frame.
+  autoware_utils_geometry::LinearRing2d base_footprint_;
+  // Road border line strings in map frame.
+  std::vector<autoware_utils_geometry::LineString2d> road_borders_;
+};
+
+}  // namespace autoware::diffusion_planner::postprocess
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__POSTPROCESSING__ROAD_BORDER_AVOIDANCE_HPP_

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -10,6 +10,7 @@
   <arg name="output_turn_indicators" default="~/output/turn_indicators"/>
   <arg name="debug/output_traffic_signal" default="~/output/debug/traffic_signal"/>
   <arg name="input_odometry" default="~/input/odometry"/>
+  <arg name="input_steering_status" default="/vehicle/status/steering_status"/>
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_route" default="~/input/route"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
@@ -27,6 +28,7 @@
     <remap from="~/output/turn_indicators" to="$(var output_turn_indicators)"/>
     <remap from="~/output/debug/traffic_signal" to="$(var debug/output_traffic_signal)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/steering_status" to="$(var input_steering_status)"/>
     <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
     <remap from="~/input/route" to="$(var input_route)"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -233,6 +233,83 @@
             "max_search_segment_count"
           ]
         },
+        "trajectory_optimization": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable acados-based trajectory optimization of the raw model output. Falls back to finite-difference velocity smoothing when disabled or when the solver fails."
+            },
+            "weight_longitudinal": {
+              "type": "number",
+              "default": 0.5,
+              "description": "Position tracking weight along the reference heading (schedule/velocity-profile freedom)"
+            },
+            "weight_lateral": {
+              "type": "number",
+              "default": 0.5,
+              "description": "Position tracking weight perpendicular to the reference heading (path deviation)"
+            },
+            "weight_yaw": {
+              "type": "number",
+              "default": 0.05,
+              "description": "Tracking weight for heading"
+            },
+            "weight_acceleration": {
+              "type": "number",
+              "default": 0.1,
+              "description": "Regularization weight on the acceleration input"
+            },
+            "weight_steering_rate": {
+              "type": "number",
+              "default": 10.0,
+              "description": "Regularization weight on the steering rate input"
+            },
+            "terminal_weight_scale": {
+              "type": "number",
+              "default": 2.5,
+              "description": "Terminal state weight = scale * stage weight"
+            },
+            "min_velocity_mps": {
+              "type": "number",
+              "default": 0.0,
+              "description": "Lower velocity bound [m/s]; 0 prevents backward motion"
+            },
+            "max_velocity_mps": {
+              "type": "number",
+              "default": 30.0,
+              "description": "Upper velocity bound [m/s]"
+            },
+            "min_acceleration_mps2": {
+              "type": "number",
+              "default": -4.0,
+              "description": "Lower acceleration bound [m/s^2]"
+            },
+            "max_acceleration_mps2": {
+              "type": "number",
+              "default": 3.0,
+              "description": "Upper acceleration bound [m/s^2]"
+            },
+            "max_steering_rate_rps": {
+              "type": "number",
+              "default": 1.0,
+              "description": "Steering rate bound [rad/s]"
+            },
+            "max_lateral_acceleration_mps2": {
+              "type": "number",
+              "default": 3.0,
+              "description": "Soft lateral acceleration constraint bound [m/s^2]"
+            },
+            "max_sqp_iterations": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "description": "Maximum SQP iterations per solve"
+            }
+          },
+          "required": ["enable"]
+        },
         "guidance": {
           "type": "object",
           "properties": {
@@ -352,7 +429,10 @@
         "turn_indicator_hold_duration",
         "planning_factor",
         "debug_params",
-        "guidance"
+        "guidance",
+        "trajectory_optimization",
+        "object_motion_resampling",
+        "ego_snap_to_prev_trajectory"
       ]
     }
   },

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -310,6 +310,46 @@
           },
           "required": ["enable"]
         },
+        "road_border_avoidance": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": false,
+              "description": "Shift raw model-output trajectory points laterally away from road borders before the trajectory optimization"
+            },
+            "footprint_margin_m": {
+              "type": "number",
+              "default": 0.2,
+              "minimum": 0.0,
+              "description": "Ego footprint inflation used for the border overlap check [m]"
+            },
+            "search_radius_m": {
+              "type": "number",
+              "default": 120.0,
+              "exclusiveMinimum": 0.0,
+              "description": "Road borders farther than this from the current ego position are ignored [m]"
+            },
+            "shift_step_m": {
+              "type": "number",
+              "default": 0.1,
+              "exclusiveMinimum": 0.0,
+              "description": "Lateral shift resolution [m]"
+            },
+            "max_lateral_shift_m": {
+              "type": "number",
+              "default": 1.5,
+              "exclusiveMinimum": 0.0,
+              "description": "Cap on the total lateral offset from the raw position [m]"
+            },
+            "propagate_shift": {
+              "type": "boolean",
+              "default": true,
+              "description": "Carry the lateral offset of an overlapping point over to all subsequent points instead of shifting only the overlapping points"
+            }
+          },
+          "required": ["enable"]
+        },
         "guidance": {
           "type": "object",
           "properties": {
@@ -431,6 +471,7 @@
         "debug_params",
         "guidance",
         "trajectory_optimization",
+        "road_border_avoidance",
         "object_motion_resampling",
         "ego_snap_to_prev_trajectory"
       ]

--- a/planning/autoware_diffusion_planner/scripts/.gitignore
+++ b/planning/autoware_diffusion_planner/scripts/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+c_generated_code/
+acados_ocp.json
+optimizer_result.png

--- a/planning/autoware_diffusion_planner/scripts/generate_solver.py
+++ b/planning/autoware_diffusion_planner/scripts/generate_solver.py
@@ -1,0 +1,167 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the acados OCP solver used by the diffusion planner trajectory optimization.
+
+Invoked by CMake at build time with CWD set to the build directory; the generated C code
+is exported to ./c_generated_code/ and never touches the source tree.
+
+The horizon must stay aligned with the model output: N = 80 steps of dt = 0.1 s (OUTPUT_T
+and PREDICTION_TIME_STEP_S on the C++ side). Cost weights and constraint bounds baked here
+are only defaults; the C++ wrapper overrides them at runtime from ROS parameters.
+"""
+
+from acados_template import AcadosModel
+from acados_template import AcadosOcp
+from acados_template import AcadosOcpSolver
+import numpy as np
+from vehicle_model import kinematic_bicycle_model
+
+HORIZON_N = 80
+HORIZON_TF_S = 8.0
+
+# Default cost weights (see config/diffusion_planner.param.yaml for the runtime values).
+# Velocity and steering angle carry no tracking weight: the model outputs positions and
+# headings only, so no reference exists for them. The velocity profile emerges from the
+# time-indexed position tracking and the input regularization/bounds.
+# Note: the C++ wrapper overwrites W every solve with a position block rotated to the
+# per-stage reference heading (separate longitudinal/lateral weights); the isotropic
+# position weight baked here is only a placeholder.
+DEFAULT_WEIGHT_POSITION = 0.5
+DEFAULT_WEIGHT_YAW = 0.05
+DEFAULT_WEIGHT_VELOCITY = 0.0
+DEFAULT_WEIGHT_STEERING = 0.0
+DEFAULT_WEIGHT_ACCELERATION = 0.1
+DEFAULT_WEIGHT_STEERING_RATE = 10.0
+DEFAULT_TERMINAL_WEIGHT_SCALE = 2.5
+
+DEFAULT_A_LAT_MAX_MPS2 = 3.0
+DEFAULT_WHEELBASE_M = 2.75
+
+SQP_MAX_ITER = 50
+SQP_TOL = 1e-4
+
+
+def build_ocp(N=HORIZON_N, Tf=HORIZON_TF_S):
+    ocp = AcadosOcp()
+
+    model = kinematic_bicycle_model()
+
+    model_ac = AcadosModel()
+    model_ac.f_impl_expr = model.f_impl_expr
+    model_ac.f_expl_expr = model.f_expl_expr
+    model_ac.x = model.x
+    model_ac.xdot = model.xdot
+    model_ac.u = model.u
+    model_ac.p = model.p
+    model_ac.con_h_expr = model.con_h_expr
+    model_ac.name = model.name
+    ocp.model = model_ac
+
+    ocp.code_export_directory = "c_generated_code"
+
+    nx = model.x.rows()  # 5: x, y, psi, v, delta
+    nu = model.u.rows()  # 2: a, delta_rate
+    ny = nx + nu
+    ny_e = nx
+
+    ocp.solver_options.N_horizon = N
+
+    q_diag = np.array(
+        [
+            DEFAULT_WEIGHT_POSITION,
+            DEFAULT_WEIGHT_POSITION,
+            DEFAULT_WEIGHT_YAW,
+            DEFAULT_WEIGHT_VELOCITY,
+            DEFAULT_WEIGHT_STEERING,
+        ]
+    )
+    r_diag = np.array([DEFAULT_WEIGHT_ACCELERATION, DEFAULT_WEIGHT_STEERING_RATE])
+
+    # acados scales stage costs by the step length dt = Tf / N; multiply by N / Tf so the
+    # configured weights keep their intuitive per-sample magnitude (same convention on the
+    # C++ side when overriding W at runtime).
+    unscale = N / Tf
+    ocp.cost.cost_type = "LINEAR_LS"
+    ocp.cost.cost_type_e = "LINEAR_LS"
+    ocp.cost.W = unscale * np.diag(np.concatenate([q_diag, r_diag]))
+    ocp.cost.W_e = (DEFAULT_TERMINAL_WEIGHT_SCALE / unscale) * np.diag(q_diag)
+
+    Vx = np.zeros((ny, nx))
+    Vx[:nx, :nx] = np.eye(nx)
+    ocp.cost.Vx = Vx
+
+    Vu = np.zeros((ny, nu))
+    Vu[nx:, :] = np.eye(nu)
+    ocp.cost.Vu = Vu
+
+    ocp.cost.Vx_e = np.eye(ny_e, nx)
+
+    ocp.cost.yref = np.zeros(ny)
+    ocp.cost.yref_e = np.zeros(ny_e)
+
+    # Input box constraints
+    ocp.constraints.lbu = np.array([model.a_min, -model.delta_rate_max])
+    ocp.constraints.ubu = np.array([model.a_max, model.delta_rate_max])
+    ocp.constraints.idxbu = np.array([0, 1])
+
+    # State box constraints on v and delta (stages 1..N-1 and terminal stage)
+    ocp.constraints.idxbx = np.array([3, 4])
+    ocp.constraints.lbx = np.array([model.v_min, -model.delta_max])
+    ocp.constraints.ubx = np.array([model.v_max, model.delta_max])
+    ocp.constraints.idxbx_e = np.array([3, 4])
+    ocp.constraints.lbx_e = np.array([model.v_min, -model.delta_max])
+    ocp.constraints.ubx_e = np.array([model.v_max, model.delta_max])
+
+    # Initial state equality constraint (stage-0 lbx == ubx, set per solve)
+    ocp.constraints.x0 = np.zeros(nx)
+
+    # Soft lateral acceleration constraint: |v^2 * tan(delta) / wheelbase| <= a_lat_max.
+    # Softened with slacks so a violating initial state cannot make the OCP infeasible.
+    ocp.constraints.lh = np.array([-DEFAULT_A_LAT_MAX_MPS2])
+    ocp.constraints.uh = np.array([DEFAULT_A_LAT_MAX_MPS2])
+    ocp.constraints.idxsh = np.array([0])
+    ocp.cost.zl = np.array([1.0e2])
+    ocp.cost.zu = np.array([1.0e2])
+    ocp.cost.Zl = np.array([1.0e3])
+    ocp.cost.Zu = np.array([1.0e3])
+
+    ocp.parameter_values = np.array([DEFAULT_WHEELBASE_M])
+
+    ocp.solver_options.tf = Tf
+    ocp.solver_options.qp_solver = "FULL_CONDENSING_HPIPM"
+    ocp.solver_options.nlp_solver_type = "SQP"
+    ocp.solver_options.hessian_approx = "GAUSS_NEWTON"
+    ocp.solver_options.integrator_type = "ERK"
+    ocp.solver_options.sim_method_num_stages = 4
+    ocp.solver_options.sim_method_num_steps = 1
+    ocp.solver_options.nlp_solver_max_iter = SQP_MAX_ITER
+    ocp.solver_options.tol = SQP_TOL
+
+    return ocp
+
+
+def create_solver(N=HORIZON_N, Tf=HORIZON_TF_S):
+    """Build a solver usable from Python (offline tuning / visualization)."""
+    ocp = build_ocp(N, Tf)
+    return AcadosOcpSolver(ocp, json_file="acados_ocp.json")
+
+
+def main():
+    ocp = build_ocp()
+    AcadosOcpSolver.generate(ocp, json_file="acados_ocp.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/planning/autoware_diffusion_planner/scripts/run_optimizer_offline.py
+++ b/planning/autoware_diffusion_planner/scripts/run_optimizer_offline.py
@@ -1,0 +1,192 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline runner for the diffusion planner trajectory optimization OCP.
+
+Solves the OCP against a pose-only reference (positions and headings, matching what the
+model outputs) and plots reference vs. solution (position, yaw, velocity, acceleration,
+steering angle, steering rate).
+
+Reference file format (whitespace-separated, one line per point):
+    line 1        : x0  ->  x y psi v delta          (initial state, base_link)
+    lines 2..N+1  : ref ->  x y psi                  (one line per 0.1 s step, t=0.1..8.0)
+
+Without --input, a synthetic noisy curved reference is generated.
+
+Usage (inside the acados venv):
+    /opt/acados/.venv/bin/python3 run_optimizer_offline.py [--input ref.txt] [--output out.png]
+"""
+
+import argparse
+from pathlib import Path
+
+from generate_solver import DEFAULT_TERMINAL_WEIGHT_SCALE
+from generate_solver import DEFAULT_WEIGHT_ACCELERATION
+from generate_solver import DEFAULT_WEIGHT_STEERING_RATE
+from generate_solver import DEFAULT_WEIGHT_YAW
+from generate_solver import HORIZON_N
+from generate_solver import HORIZON_TF_S
+from generate_solver import create_solver
+import numpy as np
+
+DT = HORIZON_TF_S / HORIZON_N
+
+
+def rotated_position_block(yaw, w_lon, w_lat):
+    """W_pos = R(yaw) diag(w_lon, w_lat) R(yaw)^T, mirroring the C++ wrapper."""
+    c, s = np.cos(yaw), np.sin(yaw)
+    return np.array(
+        [
+            [w_lon * c * c + w_lat * s * s, (w_lon - w_lat) * c * s],
+            [(w_lon - w_lat) * c * s, w_lon * s * s + w_lat * c * c],
+        ]
+    )
+
+
+def set_weights(solver, x0, refs, w_lon, w_lat):
+    unscale = HORIZON_N / HORIZON_TF_S
+    W = np.diag(
+        [
+            0.0,
+            0.0,
+            DEFAULT_WEIGHT_YAW,
+            0.0,
+            0.0,
+            DEFAULT_WEIGHT_ACCELERATION,
+            DEFAULT_WEIGHT_STEERING_RATE,
+        ]
+    )
+    for k in range(HORIZON_N):
+        yaw = x0[2] if k == 0 else refs[k - 1, 2]
+        W[:2, :2] = rotated_position_block(yaw, w_lon, w_lat)
+        solver.cost_set(k, "W", unscale * W)
+    W_e = np.diag([0.0, 0.0, DEFAULT_WEIGHT_YAW, 0.0, 0.0])
+    W_e[:2, :2] = rotated_position_block(refs[-1, 2], w_lon, w_lat)
+    solver.cost_set(HORIZON_N, "W", (DEFAULT_TERMINAL_WEIGHT_SCALE / unscale) * W_e)
+
+
+def make_synthetic_reference(rng):
+    """Constant-speed arc with position noise, mimicking raw model output (poses only)."""
+    v = 8.0
+    kappa = 0.02
+    t = np.arange(1, HORIZON_N + 1) * DT
+    psi = kappa * v * t
+    x = np.cumsum(v * DT * np.cos(psi))
+    y = np.cumsum(v * DT * np.sin(psi))
+    x += rng.normal(0.0, 0.15, HORIZON_N)
+    y += rng.normal(0.0, 0.15, HORIZON_N)
+    x0 = np.array([0.0, 0.0, 0.0, v, 0.0])
+    return x0, np.stack([x, y, psi], axis=1)
+
+
+def load_reference(path):
+    data = np.loadtxt(path)
+    x0 = data[0, :5]
+    refs = data[1:, :3]
+    if refs.shape[0] < HORIZON_N:
+        raise ValueError(f"need {HORIZON_N} reference lines, got {refs.shape[0]}")
+    return x0, refs[:HORIZON_N]
+
+
+def solve(solver, x0, refs, wheelbase):
+    ny = 7
+    for stage in range(HORIZON_N + 1):
+        solver.set(stage, "p", np.array([wheelbase]))
+
+    solver.set(0, "lbx", x0)
+    solver.set(0, "ubx", x0)
+    solver.set(0, "yref", np.concatenate([x0, np.zeros(2)]))
+    for k in range(1, HORIZON_N):
+        yref = np.zeros(ny)
+        yref[:3] = refs[k - 1]
+        solver.set(k, "yref", yref)
+    yref_e = np.zeros(5)
+    yref_e[:3] = refs[-1]
+    solver.set(HORIZON_N, "yref", yref_e)
+
+    for k in range(HORIZON_N + 1):
+        solver.set(k, "x", x0.copy())
+
+    status = solver.solve()
+    xs = np.array([solver.get(k, "x") for k in range(HORIZON_N + 1)])
+    us = np.array([solver.get(k, "u") for k in range(HORIZON_N)])
+    solve_time = solver.get_stats("time_tot")
+    return status, xs, us, solve_time
+
+
+def plot(x0, refs, xs, us, output):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    t_ref = np.arange(1, HORIZON_N + 1) * DT
+    t_x = np.arange(HORIZON_N + 1) * DT
+    t_u = np.arange(HORIZON_N) * DT
+
+    fig, axes = plt.subplots(2, 3, figsize=(16, 8))
+    ax = axes[0][0]
+    ax.plot(refs[:, 0], refs[:, 1], ".", ms=3, label="reference")
+    ax.plot(xs[:, 0], xs[:, 1], "-", lw=1.5, label="optimized")
+    ax.plot(x0[0], x0[1], "k*", ms=10, label="base_link")
+    ax.set_title("path (x-y)")
+    ax.axis("equal")
+    ax.legend()
+
+    for a, (title, ref, sol, ts) in zip(
+        axes.flat[1:],
+        [
+            ("yaw [rad]", refs[:, 2], xs[:, 2], t_x),
+            ("velocity [m/s]", None, xs[:, 3], t_x),
+            ("acceleration [m/s^2]", None, us[:, 0], t_u),
+            ("steering angle [rad]", None, xs[:, 4], t_x),
+            ("steering rate [rad/s]", None, us[:, 1], t_u),
+        ],
+    ):
+        if ref is not None:
+            a.plot(t_ref, ref, ".", ms=3, label="reference")
+        a.plot(ts, sol, "-", lw=1.5, label="optimized")
+        a.set_title(title)
+        a.set_xlabel("t [s]")
+        a.legend()
+
+    fig.tight_layout()
+    fig.savefig(output, dpi=120)
+    print(f"saved plot to {output}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=None, help="reference trajectory file")
+    parser.add_argument("--output", type=Path, default=Path("optimizer_result.png"))
+    parser.add_argument("--wheelbase", type=float, default=2.75)
+    parser.add_argument("--w-lon", type=float, default=0.5, help="longitudinal position weight")
+    parser.add_argument("--w-lat", type=float, default=0.5, help="lateral position weight")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.input is not None:
+        x0, refs = load_reference(args.input)
+    else:
+        x0, refs = make_synthetic_reference(np.random.default_rng(args.seed))
+
+    solver = create_solver()
+    set_weights(solver, x0, refs, args.w_lon, args.w_lat)
+    status, xs, us, solve_time = solve(solver, x0, refs, args.wheelbase)
+    print(f"status={status} (0 = success), solve_time={solve_time * 1e3:.2f} ms")
+    plot(x0, refs, xs, us, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/planning/autoware_diffusion_planner/scripts/vehicle_model.py
+++ b/planning/autoware_diffusion_planner/scripts/vehicle_model.py
@@ -1,0 +1,109 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kinematic bicycle model with steering-angle state for trajectory optimization.
+
+States  (nx=5): x [m], y [m], psi [rad], v [m/s], delta [rad]
+Inputs  (nu=2): a [m/s^2] (longitudinal acceleration), delta_rate [rad/s] (steering angle rate)
+Params  (np=1): wheelbase [m]
+
+Dynamics:
+    x_dot     = v * cos(psi)
+    y_dot     = v * sin(psi)
+    psi_dot   = v * tan(delta) / wheelbase
+    v_dot     = a
+    delta_dot = delta_rate
+
+Nonlinear constraint expression (soft-bounded in the OCP):
+    a_lat = v^2 * tan(delta) / wheelbase
+"""
+
+from types import SimpleNamespace
+
+from casadi import SX
+from casadi import cos
+from casadi import sin
+from casadi import tan
+from casadi import vertcat
+
+MODEL_NAME = "diffusion_planner_optimizer"
+
+# Default input bounds baked into the generated solver.
+# The C++ wrapper overrides them at runtime from ROS parameters.
+DEFAULT_A_MIN_MPS2 = -4.0
+DEFAULT_A_MAX_MPS2 = 3.0
+DEFAULT_DELTA_RATE_MAX_RPS = 1.0
+
+# Default state bounds (stages 1..N). Overridden at runtime as well.
+DEFAULT_V_MIN_MPS = 0.0
+DEFAULT_V_MAX_MPS = 30.0
+DEFAULT_DELTA_MAX_RAD = 0.7
+
+
+def kinematic_bicycle_model():
+    """Build the symbolic model consumed by generate_solver.py."""
+    # States
+    x = SX.sym("x")
+    y = SX.sym("y")
+    psi = SX.sym("psi")
+    v = SX.sym("v")
+    delta = SX.sym("delta")
+    states = vertcat(x, y, psi, v, delta)
+
+    # Inputs
+    a = SX.sym("a")
+    delta_rate = SX.sym("delta_rate")
+    inputs = vertcat(a, delta_rate)
+
+    # Online parameters
+    wheelbase = SX.sym("wheelbase")
+    params = vertcat(wheelbase)
+
+    # Explicit dynamics
+    f_expl = vertcat(
+        v * cos(psi),
+        v * sin(psi),
+        v * tan(delta) / wheelbase,
+        a,
+        delta_rate,
+    )
+
+    xdot = vertcat(
+        SX.sym("x_dot"),
+        SX.sym("y_dot"),
+        SX.sym("psi_dot"),
+        SX.sym("v_dot"),
+        SX.sym("delta_dot"),
+    )
+
+    model = SimpleNamespace()
+    model.name = MODEL_NAME
+    model.x = states
+    model.xdot = xdot
+    model.u = inputs
+    model.p = params
+    model.f_expl_expr = f_expl
+    model.f_impl_expr = xdot - f_expl
+
+    # Lateral acceleration for the soft nonlinear constraint
+    model.con_h_expr = v * v * tan(delta) / wheelbase
+
+    model.a_min = DEFAULT_A_MIN_MPS2
+    model.a_max = DEFAULT_A_MAX_MPS2
+    model.delta_rate_max = DEFAULT_DELTA_RATE_MAX_RPS
+    model.v_min = DEFAULT_V_MIN_MPS
+    model.v_max = DEFAULT_V_MAX_MPS
+    model.delta_max = DEFAULT_DELTA_MAX_RAD
+
+    return model

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -78,6 +78,12 @@ DiffusionPlannerCore::DiffusionPlannerCore(
 : params_(params), vehicle_spec_(vehicle_info)
 {
   sync_turn_indicator_managers();
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+  if (params_.trajectory_optimization.enable) {
+    trajectory_optimizer_ = std::make_unique<optimization::TrajectoryOptimizer>(
+      params_.trajectory_optimization, vehicle_info, static_cast<size_t>(params_.batch_size));
+  }
+#endif
 }
 
 void DiffusionPlannerCore::sync_turn_indicator_managers()
@@ -601,7 +607,8 @@ InferenceResult DiffusionPlannerCore::run_inference(const InputDataMap & input_d
 
 PlannerOutput DiffusionPlannerCore::create_planner_output(
   const InferenceOutput & inference_output, const FrameContext & frame_context,
-  const rclcpp::Time & timestamp, const UUID & generator_uuid)
+  const rclcpp::Time & timestamp, const UUID & generator_uuid,
+  const std::optional<double> & current_steering_angle_rad)
 {
   const auto & [raw_predictions, turn_indicator_logit] = inference_output.outputs;
   const std::vector<float> denormalized_predictions =
@@ -622,6 +629,10 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
   last_agent_poses_map_ = agent_poses;
   last_ego_to_map_transform_ = frame_context.ego_to_map_transform;
 
+#ifndef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+  (void)current_steering_angle_rad;
+#endif
+
   const bool enable_force_stop =
     frame_context.ego_kinematic_state.twist.twist.linear.x > std::numeric_limits<double>::epsilon();
 
@@ -635,13 +646,49 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
 
   // Trajectory and CandidateTrajectories
   for (int i = 0; i < params_.batch_size; i++) {
-    auto trajectory = postprocess::create_ego_trajectory(
-      agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
-      params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
-
-    if (params_.shift_x) {
-      for (auto & point : trajectory.points) {
-        point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
+    Trajectory trajectory;
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+    if (trajectory_optimizer_) {
+      trajectory = postprocess::create_ego_pose_trajectory(agent_poses, timestamp, i);
+      if (params_.shift_x) {
+        for (auto & point : trajectory.points) {
+          point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
+        }
+      }
+      if (i == 0) {
+        output.raw_trajectory = trajectory;
+      }
+      auto optimization_result = trajectory_optimizer_->optimize(
+        trajectory, frame_context.ego_kinematic_state, current_steering_angle_rad,
+        static_cast<size_t>(i));
+      if (i == 0) {
+        output.optimization_debug.attempted = true;
+        output.optimization_debug.optimized = optimization_result.optimized;
+        output.optimization_debug.solver_status = optimization_result.solver_status;
+        output.optimization_debug.solve_time_ms = optimization_result.solve_time_ms;
+      }
+      if (optimization_result.optimized) {
+        trajectory = std::move(optimization_result.trajectory);
+      } else {
+        trajectory = postprocess::create_ego_trajectory(
+          agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
+          params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
+        if (params_.shift_x) {
+          for (auto & point : trajectory.points) {
+            point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
+          }
+        }
+      }
+    } else
+#endif
+    {
+      trajectory = postprocess::create_ego_trajectory(
+        agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
+        params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
+      if (params_.shift_x) {
+        for (auto & point : trajectory.points) {
+          point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
+        }
       }
     }
 

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -84,6 +84,10 @@ DiffusionPlannerCore::DiffusionPlannerCore(
       params_.trajectory_optimization, vehicle_info, static_cast<size_t>(params_.batch_size));
   }
 #endif
+  if (params_.road_border_avoidance.enable) {
+    road_border_avoidance_ = std::make_unique<postprocess::RoadBorderAvoidance>(
+      params_.road_border_avoidance, vehicle_info);
+  }
 }
 
 void DiffusionPlannerCore::sync_turn_indicator_managers()
@@ -260,6 +264,9 @@ void DiffusionPlannerCore::set_map(
 {
   lane_segment_context_ = std::make_unique<preprocess::LaneSegmentContext>(
     lanelet_map_ptr, params_.line_string_max_step_m);
+  if (road_border_avoidance_ && lanelet_map_ptr) {
+    road_border_avoidance_->set_map(*lanelet_map_ptr);
+  }
 }
 
 std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
@@ -645,19 +652,65 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
                                 : turn_indicators_history_.back().report;
 
   // Trajectory and CandidateTrajectories
-  for (int i = 0; i < params_.batch_size; i++) {
-    Trajectory trajectory;
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
-    if (trajectory_optimizer_) {
-      trajectory = postprocess::create_ego_pose_trajectory(agent_poses, timestamp, i);
-      if (params_.shift_x) {
-        for (auto & point : trajectory.points) {
-          point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
-        }
+  const bool use_optimizer = static_cast<bool>(trajectory_optimizer_);
+#else
+  const bool use_optimizer = false;
+#endif
+
+  for (int i = 0; i < params_.batch_size; i++) {
+    auto apply_shift_x = [this](Trajectory & trajectory) {
+      if (!params_.shift_x) {
+        return;
       }
+      for (auto & point : trajectory.points) {
+        point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
+      }
+    };
+
+    auto make_fd_trajectory = [&]() {
+      auto trajectory = postprocess::create_ego_trajectory(
+        agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
+        params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
+      apply_shift_x(trajectory);
+      return trajectory;
+    };
+
+    auto apply_avoidance = [&](Trajectory trajectory) {
+      if (!road_border_avoidance_) {
+        return trajectory;
+      }
+      auto avoidance_result = road_border_avoidance_->adjust(
+        trajectory, frame_context.ego_kinematic_state.pose.pose);
       if (i == 0) {
-        output.raw_trajectory = trajectory;
+        output.avoidance_debug.active = true;
+        output.avoidance_debug.shifted_points =
+          static_cast<int>(avoidance_result.num_shifted_points);
+        output.avoidance_debug.unresolved_points =
+          static_cast<int>(avoidance_result.num_unresolved_points);
+        output.avoidance_adjusted_trajectory = avoidance_result.trajectory;
       }
+      return std::move(avoidance_result.trajectory);
+    };
+
+    Trajectory trajectory;
+    if (use_optimizer) {
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+      trajectory = postprocess::create_ego_pose_trajectory(agent_poses, timestamp, i);
+      apply_shift_x(trajectory);
+#endif
+    } else {
+      trajectory = make_fd_trajectory();
+    }
+
+    if (i == 0 && (use_optimizer || road_border_avoidance_)) {
+      output.raw_trajectory = trajectory;
+    }
+
+    trajectory = apply_avoidance(std::move(trajectory));
+
+#ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+    if (use_optimizer) {
       auto optimization_result = trajectory_optimizer_->optimize(
         trajectory, frame_context.ego_kinematic_state, current_steering_angle_rad,
         static_cast<size_t>(i));
@@ -670,27 +723,10 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
       if (optimization_result.optimized) {
         trajectory = std::move(optimization_result.trajectory);
       } else {
-        trajectory = postprocess::create_ego_trajectory(
-          agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
-          params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
-        if (params_.shift_x) {
-          for (auto & point : trajectory.points) {
-            point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
-          }
-        }
-      }
-    } else
-#endif
-    {
-      trajectory = postprocess::create_ego_trajectory(
-        agent_poses, timestamp, frame_context.ego_kinematic_state.pose.pose.position, i,
-        params_.velocity_smoothing_window, enable_force_stop, params_.stopping_threshold);
-      if (params_.shift_x) {
-        for (auto & point : trajectory.points) {
-          point.pose = utils::shift_x(point.pose, -vehicle_spec_.base_link_to_center);
-        }
+        trajectory = apply_avoidance(make_fd_trajectory());
       }
     }
+#endif
 
     if (i == 0) {
       // Use the first trajectory as the main output trajectory

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -107,6 +107,10 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     this->create_publisher<std_msgs::msg::Int32>("~/debug/optimization/solver_status", 1);
   pub_optimization_time_ =
     this->create_publisher<std_msgs::msg::Float64>("~/debug/optimization/solve_time_ms", 1);
+  pub_avoidance_trajectory_ =
+    this->create_publisher<Trajectory>("~/debug/road_border_avoidance/adjusted_trajectory", 1);
+  pub_avoidance_shifted_count_ = this->create_publisher<std_msgs::msg::Int32>(
+    "~/debug/road_border_avoidance/shifted_point_count", 1);
   pub_guidance_status_ = this->create_publisher<autoware_internal_debug_msgs::msg::StringStamped>(
     "~/debug/guidance_status", 1);
 
@@ -268,6 +272,20 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("trajectory_optimization.max_lateral_acceleration_mps2", 3.0);
   opt.max_sqp_iterations =
     this->declare_parameter<int>("trajectory_optimization.max_sqp_iterations", 50);
+
+  // Road border avoidance params (static; changing them requires a restart).
+  auto & avoidance = params_.road_border_avoidance;
+  avoidance.enable = this->declare_parameter<bool>("road_border_avoidance.enable", false);
+  avoidance.footprint_margin_m =
+    this->declare_parameter<double>("road_border_avoidance.footprint_margin_m", 0.2);
+  avoidance.search_radius_m =
+    this->declare_parameter<double>("road_border_avoidance.search_radius_m", 120.0);
+  avoidance.shift_step_m =
+    this->declare_parameter<double>("road_border_avoidance.shift_step_m", 0.1);
+  avoidance.max_lateral_shift_m =
+    this->declare_parameter<double>("road_border_avoidance.max_lateral_shift_m", 1.5);
+  avoidance.propagate_shift =
+    this->declare_parameter<bool>("road_border_avoidance.propagate_shift", true);
 #ifndef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
   if (opt.enable) {
     RCLCPP_WARN(
@@ -336,6 +354,9 @@ void DiffusionPlanner::load_model()
   }
   if (params_.trajectory_optimization.enable) {
     RCLCPP_INFO(get_logger(), "acados trajectory optimization is enabled");
+  }
+  if (params_.road_border_avoidance.enable) {
+    RCLCPP_INFO(get_logger(), "road border avoidance is enabled");
   }
 }
 
@@ -726,8 +747,25 @@ void DiffusionPlanner::on_timer()
     pub_denoising_steps_->publish(planner_output.denoising_steps);
   }
 
+  const auto & avoidance_debug = planner_output.avoidance_debug;
+  if (avoidance_debug.active) {
+    if (planner_output.avoidance_adjusted_trajectory) {
+      pub_avoidance_trajectory_->publish(*planner_output.avoidance_adjusted_trajectory);
+    }
+    std_msgs::msg::Int32 shifted_count_msg;
+    shifted_count_msg.data = avoidance_debug.shifted_points + avoidance_debug.unresolved_points;
+    pub_avoidance_shifted_count_->publish(shifted_count_msg);
+    if (avoidance_debug.unresolved_points > 0) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+        "Road border avoidance could not clear %d trajectory points within the maximum "
+        "lateral shift.",
+        avoidance_debug.unresolved_points);
+    }
+  }
+
   const auto & optimization_debug = planner_output.optimization_debug;
-  if (optimization_debug.attempted && planner_output.raw_trajectory) {
+  if ((optimization_debug.attempted || avoidance_debug.active) && planner_output.raw_trajectory) {
     pub_raw_trajectory_->publish(*planner_output.raw_trajectory);
   }
   if (optimization_debug.attempted) {

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -23,6 +23,8 @@
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
 
+#include <std_msgs/msg/int32.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -99,6 +101,12 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     this->create_publisher<std_msgs::msg::Float64>("~/debug/inference_time_ms", 1);
   pub_denoising_steps_ =
     this->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/denoising_steps", 1);
+  pub_raw_trajectory_ =
+    this->create_publisher<Trajectory>("~/debug/optimization/raw_trajectory", 1);
+  pub_optimization_status_ =
+    this->create_publisher<std_msgs::msg::Int32>("~/debug/optimization/solver_status", 1);
+  pub_optimization_time_ =
+    this->create_publisher<std_msgs::msg::Float64>("~/debug/optimization/solve_time_ms", 1);
   pub_guidance_status_ = this->create_publisher<autoware_internal_debug_msgs::msg::StringStamped>(
     "~/debug/guidance_status", 1);
 
@@ -233,6 +241,43 @@ void DiffusionPlanner::set_up_params()
   params_.centerline_guidance_start_time_s =
     this->declare_parameter<double>("guidance.centerline_guidance.start_time_s", 2.0);
 
+  auto & opt = params_.trajectory_optimization;
+  opt.enable = this->declare_parameter<bool>("trajectory_optimization.enable", true);
+  opt.weight_longitudinal =
+    this->declare_parameter<double>("trajectory_optimization.weight_longitudinal", 0.5);
+  opt.weight_lateral =
+    this->declare_parameter<double>("trajectory_optimization.weight_lateral", 0.5);
+  opt.weight_yaw = this->declare_parameter<double>("trajectory_optimization.weight_yaw", 0.05);
+  opt.weight_acceleration =
+    this->declare_parameter<double>("trajectory_optimization.weight_acceleration", 0.1);
+  opt.weight_steering_rate =
+    this->declare_parameter<double>("trajectory_optimization.weight_steering_rate", 10.0);
+  opt.terminal_weight_scale =
+    this->declare_parameter<double>("trajectory_optimization.terminal_weight_scale", 2.5);
+  opt.min_velocity_mps =
+    this->declare_parameter<double>("trajectory_optimization.min_velocity_mps", 0.0);
+  opt.max_velocity_mps =
+    this->declare_parameter<double>("trajectory_optimization.max_velocity_mps", 30.0);
+  opt.min_acceleration_mps2 =
+    this->declare_parameter<double>("trajectory_optimization.min_acceleration_mps2", -4.0);
+  opt.max_acceleration_mps2 =
+    this->declare_parameter<double>("trajectory_optimization.max_acceleration_mps2", 3.0);
+  opt.max_steering_rate_rps =
+    this->declare_parameter<double>("trajectory_optimization.max_steering_rate_rps", 1.0);
+  opt.max_lateral_acceleration_mps2 =
+    this->declare_parameter<double>("trajectory_optimization.max_lateral_acceleration_mps2", 3.0);
+  opt.max_sqp_iterations =
+    this->declare_parameter<int>("trajectory_optimization.max_sqp_iterations", 50);
+#ifndef AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS
+  if (opt.enable) {
+    RCLCPP_WARN(
+      get_logger(),
+      "trajectory_optimization.enable is true but this build has no acados support; "
+      "trajectory optimization is disabled.");
+    opt.enable = false;
+  }
+#endif
+
   // planning factor params
   planning_factor_params_.enable_stop =
     this->declare_parameter<bool>("planning_factor.enable_stop", false);
@@ -288,6 +333,9 @@ void DiffusionPlanner::load_model()
   if (params_.ignore_neighbors) {
     RCLCPP_INFO(
       get_logger(), "Neighbor agents disabled for diffusion inference (ignore_neighbors)");
+  }
+  if (params_.trajectory_optimization.enable) {
+    RCLCPP_INFO(get_logger(), "acados trajectory optimization is enabled");
   }
 }
 
@@ -657,10 +705,16 @@ void DiffusionPlanner::on_timer()
   inference_time_msg.data = inference_result->inference_time_ms;
   pub_inference_time_->publish(inference_time_msg);
 
+  const auto steering_status = sub_steering_status_.take_data();
+  std::optional<double> current_steering_angle_rad;
+  if (steering_status) {
+    current_steering_angle_rad = static_cast<double>(steering_status->steering_tire_angle);
+  }
+
   PlannerOutput planner_output;
   try {
-    planner_output =
-      core_->create_planner_output(*inference_result, *frame_context, frame_time, generator_uuid_);
+    planner_output = core_->create_planner_output(
+      *inference_result, *frame_context, frame_time, generator_uuid_, current_steering_angle_rad);
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(get_logger(), "Postprocessing failed: " << e.what());
     diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());
@@ -670,6 +724,28 @@ void DiffusionPlanner::on_timer()
 
   if (!planner_output.denoising_steps.data.empty()) {
     pub_denoising_steps_->publish(planner_output.denoising_steps);
+  }
+
+  const auto & optimization_debug = planner_output.optimization_debug;
+  if (optimization_debug.attempted && planner_output.raw_trajectory) {
+    pub_raw_trajectory_->publish(*planner_output.raw_trajectory);
+  }
+  if (optimization_debug.attempted) {
+    std_msgs::msg::Int32 status_msg;
+    status_msg.data = optimization_debug.solver_status;
+    pub_optimization_status_->publish(status_msg);
+    std_msgs::msg::Float64 solve_time_msg;
+    solve_time_msg.data = optimization_debug.solve_time_ms;
+    pub_optimization_time_->publish(solve_time_msg);
+    if (!optimization_debug.optimized) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+        "Trajectory optimization failed (acados status %d); publishing the finite-difference "
+        "trajectory.",
+        optimization_debug.solver_status);
+      diagnostics_inference_->update_level_and_message(
+        DiagnosticStatus::WARN, "Trajectory optimization failed");
+    }
   }
 
   publish_guidance_status(planner_output.guidance_triggered, frame_time);

--- a/planning/autoware_diffusion_planner/src/optimization/acados_solver_wrapper.cpp
+++ b/planning/autoware_diffusion_planner/src/optimization/acados_solver_wrapper.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/optimization/acados_solver_wrapper.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <stdexcept>
+
+extern "C" {
+#include "c_generated_code/acados_solver_diffusion_planner_optimizer.h"
+}
+
+namespace autoware::diffusion_planner::optimization
+{
+namespace
+{
+constexpr size_t gen_nx = DIFFUSION_PLANNER_OPTIMIZER_NX;
+constexpr size_t gen_nu = DIFFUSION_PLANNER_OPTIMIZER_NU;
+constexpr size_t gen_np = DIFFUSION_PLANNER_OPTIMIZER_NP;
+constexpr size_t gen_n = DIFFUSION_PLANNER_OPTIMIZER_N;
+constexpr size_t gen_ny = DIFFUSION_PLANNER_OPTIMIZER_NY;
+constexpr size_t gen_nyn = DIFFUSION_PLANNER_OPTIMIZER_NYN;
+
+static_assert(gen_nx == opt_nx, "generated solver NX mismatch, re-run generate_solver.py");
+static_assert(gen_nu == opt_nu, "generated solver NU mismatch, re-run generate_solver.py");
+static_assert(gen_np == 1, "generated solver NP mismatch, re-run generate_solver.py");
+static_assert(gen_n == opt_horizon, "generated solver N mismatch, re-run generate_solver.py");
+static_assert(gen_ny == opt_nx + opt_nu, "generated solver NY mismatch");
+static_assert(gen_nyn == opt_nx, "generated solver NYN mismatch");
+}  // namespace
+
+struct AcadosSolverWrapper::Impl
+{
+  diffusion_planner_optimizer_solver_capsule * capsule{nullptr};
+  ocp_nlp_config * config{nullptr};
+  ocp_nlp_dims * dims{nullptr};
+  ocp_nlp_in * in{nullptr};
+  ocp_nlp_out * out{nullptr};
+  ocp_nlp_solver * solver{nullptr};
+  void * opts{nullptr};
+  TrajectoryOptimizationParams params{};
+};
+
+AcadosSolverWrapper::AcadosSolverWrapper(
+  const TrajectoryOptimizationParams & params, const double wheelbase_m,
+  const double max_steering_angle_rad)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->capsule = diffusion_planner_optimizer_acados_create_capsule();
+  if (diffusion_planner_optimizer_acados_create(impl_->capsule) != 0) {
+    diffusion_planner_optimizer_acados_free_capsule(impl_->capsule);
+    impl_->capsule = nullptr;
+    throw std::runtime_error("failed to create acados solver");
+  }
+  impl_->config = diffusion_planner_optimizer_acados_get_nlp_config(impl_->capsule);
+  impl_->dims = diffusion_planner_optimizer_acados_get_nlp_dims(impl_->capsule);
+  impl_->in = diffusion_planner_optimizer_acados_get_nlp_in(impl_->capsule);
+  impl_->out = diffusion_planner_optimizer_acados_get_nlp_out(impl_->capsule);
+  impl_->solver = diffusion_planner_optimizer_acados_get_nlp_solver(impl_->capsule);
+  impl_->opts = diffusion_planner_optimizer_acados_get_nlp_opts(impl_->capsule);
+
+  // Cost weights depend on the per-stage reference heading (longitudinal/lateral split),
+  // so they are written in solve(). Only the reference-independent settings are set here.
+  impl_->params = params;
+
+  // Input bounds (all stages).
+  std::array<double, gen_nu> lbu{params.min_acceleration_mps2, -params.max_steering_rate_rps};
+  std::array<double, gen_nu> ubu{params.max_acceleration_mps2, params.max_steering_rate_rps};
+  for (size_t stage = 0; stage < gen_n; ++stage) {
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "lbu",
+      lbu.data());
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "ubu",
+      ubu.data());
+  }
+
+  // State bounds on v and delta (stages 1..N; stage 0 is the initial state equality).
+  std::array<double, 2> lbx{params.min_velocity_mps, -max_steering_angle_rad};
+  std::array<double, 2> ubx{params.max_velocity_mps, max_steering_angle_rad};
+  for (size_t stage = 1; stage <= gen_n; ++stage) {
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "lbx",
+      lbx.data());
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "ubx",
+      ubx.data());
+  }
+
+  // Soft lateral acceleration bounds (stages 0..N-1).
+  std::array<double, 1> lh{-params.max_lateral_acceleration_mps2};
+  std::array<double, 1> uh{params.max_lateral_acceleration_mps2};
+  for (size_t stage = 0; stage < gen_n; ++stage) {
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "lh", lh.data());
+    ocp_nlp_constraints_model_set(
+      impl_->config, impl_->dims, impl_->in, impl_->out, static_cast<int>(stage), "uh", uh.data());
+  }
+
+  // Vehicle parameter (all stages).
+  std::array<double, gen_np> p{wheelbase_m};
+  for (size_t stage = 0; stage <= gen_n; ++stage) {
+    diffusion_planner_optimizer_acados_update_params(
+      impl_->capsule, static_cast<int>(stage), p.data(), static_cast<int>(gen_np));
+  }
+
+  int max_iter = std::max(params.max_sqp_iterations, 1);
+  ocp_nlp_solver_opts_set(impl_->config, impl_->opts, "max_iter", &max_iter);
+}
+
+AcadosSolverWrapper::~AcadosSolverWrapper()
+{
+  if (impl_ && impl_->capsule) {
+    diffusion_planner_optimizer_acados_free(impl_->capsule);
+    diffusion_planner_optimizer_acados_free_capsule(impl_->capsule);
+  }
+}
+
+SolverSolution AcadosSolverWrapper::solve(
+  const std::array<double, opt_nx> & initial_state,
+  const std::array<StageReference, opt_horizon> & references, const SolverSolution * warm_start)
+{
+  auto x0 = initial_state;
+
+  // Initial state equality constraint.
+  ocp_nlp_constraints_model_set(
+    impl_->config, impl_->dims, impl_->in, impl_->out, 0, "lbx", x0.data());
+  ocp_nlp_constraints_model_set(
+    impl_->config, impl_->dims, impl_->in, impl_->out, 0, "ubx", x0.data());
+
+  // Cost weights. The 2x2 position block is rotated to the reference heading of each
+  // stage so longitudinal and lateral tracking errors are weighted separately:
+  //   W_pos = R(yaw_ref) * diag(w_lon, w_lat) * R(yaw_ref)^T.
+  // acados scales stage costs by dt; multiply by 1/dt (= N/Tf) so the configured weights
+  // keep a per-sample magnitude (same convention as generate_solver.py).
+  // y = [x, y, yaw, v, delta, a, delta_rate]; v and delta have no reference (see header).
+  const double unscale = 1.0 / opt_dt_s;
+  const double w_lon = impl_->params.weight_longitudinal;
+  const double w_lat = impl_->params.weight_lateral;
+  auto position_block = [&](const double yaw) {
+    const double c = std::cos(yaw);
+    const double s = std::sin(yaw);
+    return std::array<double, 3>{
+      w_lon * c * c + w_lat * s * s,  // xx
+      w_lon * s * s + w_lat * c * c,  // yy
+      (w_lon - w_lat) * c * s};       // xy = yx
+  };
+  std::array<double, gen_ny * gen_ny> stage_weight_matrix{};
+  stage_weight_matrix[2 * gen_ny + 2] = unscale * impl_->params.weight_yaw;
+  stage_weight_matrix[5 * gen_ny + 5] = unscale * impl_->params.weight_acceleration;
+  stage_weight_matrix[6 * gen_ny + 6] = unscale * impl_->params.weight_steering_rate;
+  for (size_t stage = 0; stage < gen_n; ++stage) {
+    const double yaw_ref = (stage == 0) ? x0[2] : references[stage - 1].yaw;
+    const auto [w_xx, w_yy, w_xy] = position_block(yaw_ref);
+    stage_weight_matrix[0] = unscale * w_xx;
+    stage_weight_matrix[gen_ny + 1] = unscale * w_yy;
+    stage_weight_matrix[1] = unscale * w_xy;
+    stage_weight_matrix[gen_ny] = unscale * w_xy;
+    ocp_nlp_cost_model_set(
+      impl_->config, impl_->dims, impl_->in, static_cast<int>(stage), "W",
+      stage_weight_matrix.data());
+  }
+  const double terminal_scale = impl_->params.terminal_weight_scale / unscale;
+  std::array<double, gen_nyn * gen_nyn> terminal_weight_matrix{};
+  const auto [we_xx, we_yy, we_xy] = position_block(references[gen_n - 1].yaw);
+  terminal_weight_matrix[0] = terminal_scale * we_xx;
+  terminal_weight_matrix[gen_nyn + 1] = terminal_scale * we_yy;
+  terminal_weight_matrix[1] = terminal_scale * we_xy;
+  terminal_weight_matrix[gen_nyn] = terminal_scale * we_xy;
+  terminal_weight_matrix[2 * gen_nyn + 2] = terminal_scale * impl_->params.weight_yaw;
+  ocp_nlp_cost_model_set(
+    impl_->config, impl_->dims, impl_->in, static_cast<int>(gen_n), "W",
+    terminal_weight_matrix.data());
+
+  // References: stage 0 tracks the (fixed) initial state so it contributes no cost,
+  // stages 1..N-1 track the input trajectory, stage N is the terminal reference.
+  std::array<double, gen_ny> yref{};
+  std::copy(x0.begin(), x0.end(), yref.begin());
+  ocp_nlp_cost_model_set(impl_->config, impl_->dims, impl_->in, 0, "yref", yref.data());
+  for (size_t stage = 1; stage < gen_n; ++stage) {
+    const auto & ref = references[stage - 1];
+    yref = {ref.x, ref.y, ref.yaw, 0.0, 0.0, 0.0, 0.0};
+    ocp_nlp_cost_model_set(
+      impl_->config, impl_->dims, impl_->in, static_cast<int>(stage), "yref", yref.data());
+  }
+  const auto & terminal_ref = references[gen_n - 1];
+  std::array<double, gen_nyn> yref_e{terminal_ref.x, terminal_ref.y, terminal_ref.yaw, 0.0, 0.0};
+  ocp_nlp_cost_model_set(
+    impl_->config, impl_->dims, impl_->in, static_cast<int>(gen_n), "yref", yref_e.data());
+
+  // Initial guess: previous solution shifted by one stage, or the initial state.
+  for (size_t stage = 0; stage <= gen_n; ++stage) {
+    std::array<double, gen_nx> x_guess = x0;
+    if (warm_start != nullptr) {
+      x_guess = warm_start->states[std::min(stage + 1, gen_n)];
+    }
+    ocp_nlp_out_set(
+      impl_->config, impl_->dims, impl_->out, impl_->in, static_cast<int>(stage), "x",
+      x_guess.data());
+    if (stage < gen_n) {
+      std::array<double, gen_nu> u_guess{};
+      if (warm_start != nullptr) {
+        u_guess = warm_start->inputs[std::min(stage + 1, gen_n - 1)];
+      }
+      ocp_nlp_out_set(
+        impl_->config, impl_->dims, impl_->out, impl_->in, static_cast<int>(stage), "u",
+        u_guess.data());
+    }
+  }
+
+  SolverSolution solution;
+  solution.status = diffusion_planner_optimizer_acados_solve(impl_->capsule);
+  ocp_nlp_get(impl_->solver, "time_tot", &solution.solve_time_s);
+  ocp_nlp_get(impl_->solver, "sqp_iter", &solution.sqp_iterations);
+
+  for (size_t stage = 0; stage <= gen_n; ++stage) {
+    ocp_nlp_out_get(
+      impl_->config, impl_->dims, impl_->out, static_cast<int>(stage), "x",
+      solution.states[stage].data());
+    if (stage < gen_n) {
+      ocp_nlp_out_get(
+        impl_->config, impl_->dims, impl_->out, static_cast<int>(stage), "u",
+        solution.inputs[stage].data());
+    }
+  }
+
+  return solution;
+}
+
+}  // namespace autoware::diffusion_planner::optimization

--- a/planning/autoware_diffusion_planner/src/optimization/trajectory_optimizer.cpp
+++ b/planning/autoware_diffusion_planner/src/optimization/trajectory_optimizer.cpp
@@ -1,0 +1,170 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/optimization/trajectory_optimizer.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/normalization.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace autoware::diffusion_planner::optimization
+{
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+namespace
+{
+// Warm starts older than this are discarded (stale after a planner hiccup).
+constexpr double max_warm_start_age_s = 0.5;
+// Minimum speed used when estimating the steering angle from the yaw rate.
+constexpr double min_speed_for_steering_estimation_mps = 0.5;
+
+double yaw_from_quaternion(const geometry_msgs::msg::Quaternion & q)
+{
+  return std::atan2(2.0 * (q.w * q.z + q.x * q.y), 1.0 - 2.0 * (q.y * q.y + q.z * q.z));
+}
+}  // namespace
+
+TrajectoryOptimizer::TrajectoryOptimizer(
+  const TrajectoryOptimizationParams & params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const size_t batch_size)
+: params_(params),
+  wheelbase_m_(vehicle_info.wheel_base_m),
+  max_steering_angle_rad_(vehicle_info.max_steer_angle_rad),
+  solver_(
+    std::make_unique<AcadosSolverWrapper>(params, wheelbase_m_, vehicle_info.max_steer_angle_rad)),
+  previous_solutions_(batch_size)
+{
+}
+
+OptimizationResult TrajectoryOptimizer::optimize(
+  const Trajectory & raw_trajectory, const Odometry & ego_odometry,
+  const std::optional<double> & current_steering_angle_rad, const size_t batch_index)
+{
+  OptimizationResult result;
+  result.trajectory = raw_trajectory;
+
+  if (raw_trajectory.points.size() < opt_horizon || batch_index >= previous_solutions_.size()) {
+    return result;
+  }
+
+  // Initial state at base_link. Positions are solved in a local frame centered on the ego
+  // position for numerical conditioning.
+  const auto & ego_pose = ego_odometry.pose.pose;
+  const double base_x = ego_pose.position.x;
+  const double base_y = ego_pose.position.y;
+  const double yaw0 = yaw_from_quaternion(ego_pose.orientation);
+  const double v0 = std::clamp(
+    static_cast<double>(ego_odometry.twist.twist.linear.x), params_.min_velocity_mps,
+    params_.max_velocity_mps);
+
+  double delta0 = 0.0;
+  if (current_steering_angle_rad.has_value()) {
+    delta0 = *current_steering_angle_rad;
+  } else {
+    const double yaw_rate = ego_odometry.twist.twist.angular.z;
+    const double speed = std::max(std::abs(v0), min_speed_for_steering_estimation_mps);
+    delta0 = std::atan(wheelbase_m_ * yaw_rate / speed);
+  }
+  delta0 = std::clamp(delta0, -max_steering_angle_rad_, max_steering_angle_rad_);
+
+  const std::array<double, opt_nx> initial_state{0.0, 0.0, yaw0, v0, delta0};
+
+  // References for stages 1..N from the raw 80-point sequence (t = k * 0.1 s).
+  // Yaw is unwrapped so the reference stays continuous across the +-pi boundary.
+  std::array<StageReference, opt_horizon> references;
+  double previous_yaw = yaw0;
+  for (size_t k = 0; k < opt_horizon; ++k) {
+    const auto & point = raw_trajectory.points[k];
+    StageReference & ref = references[k];
+    ref.x = point.pose.position.x - base_x;
+    ref.y = point.pose.position.y - base_y;
+    const double raw_yaw = yaw_from_quaternion(point.pose.orientation);
+    ref.yaw = previous_yaw + autoware_utils::normalize_radian(raw_yaw - previous_yaw);
+    previous_yaw = ref.yaw;
+  }
+
+  // Warm start from the previous solution of this candidate, re-centered on the current
+  // ego position. Discarded when stale.
+  const rclcpp::Time stamp(raw_trajectory.header.stamp);
+  SolverSolution warm_start;
+  const SolverSolution * warm_start_ptr = nullptr;
+  auto & previous = previous_solutions_[batch_index];
+  if (previous.has_value()) {
+    const double age_s = (stamp - previous->stamp).seconds();
+    if (age_s >= 0.0 && age_s <= max_warm_start_age_s) {
+      warm_start = previous->solution;
+      for (auto & state : warm_start.states) {
+        state[0] -= base_x;
+        state[1] -= base_y;
+      }
+      warm_start_ptr = &warm_start;
+    } else {
+      previous.reset();
+    }
+  }
+
+  SolverSolution solution = solver_->solve(initial_state, references, warm_start_ptr);
+  result.solver_status = solution.status;
+  result.solve_time_ms = solution.solve_time_s * 1e3;
+
+  if (!solution.success()) {
+    previous.reset();
+    return result;
+  }
+
+  // Build the output trajectory from stages 1..N (t = 0.1..8.0 s, same timing convention
+  // as the raw model output). Stage 0 is the base_link initial state and is not published,
+  // but the whole solution is dynamically consistent with it.
+  Trajectory optimized;
+  optimized.header = raw_trajectory.header;
+  optimized.points.reserve(opt_horizon);
+  for (size_t i = 1; i <= opt_horizon; ++i) {
+    const auto & state = solution.states[i];
+    TrajectoryPoint point;
+    const double time_s = opt_dt_s * static_cast<double>(i);
+    point.time_from_start.sec = static_cast<int32_t>(time_s);
+    point.time_from_start.nanosec =
+      static_cast<uint32_t>((time_s - point.time_from_start.sec) * 1e9);
+    point.pose.position.x = state[0] + base_x;
+    point.pose.position.y = state[1] + base_y;
+    point.pose.position.z = raw_trajectory.points[i - 1].pose.position.z;
+    point.pose.orientation =
+      autoware_utils::create_quaternion_from_yaw(autoware_utils::normalize_radian(state[2]));
+    point.longitudinal_velocity_mps = static_cast<float>(state[3]);
+    point.front_wheel_angle_rad = static_cast<float>(state[4]);
+    point.acceleration_mps2 = (i < opt_horizon) ? static_cast<float>(solution.inputs[i][0]) : 0.0F;
+    point.heading_rate_rps = static_cast<float>(state[3] * std::tan(state[4]) / wheelbase_m_);
+    optimized.points.push_back(point);
+  }
+  result.trajectory = std::move(optimized);
+  result.optimized = true;
+
+  // Store the solution in map frame for the next cycle's warm start.
+  for (auto & state : solution.states) {
+    state[0] += base_x;
+    state[1] += base_y;
+  }
+  previous = PreviousSolution{solution, stamp};
+
+  return result;
+}
+
+}  // namespace autoware::diffusion_planner::optimization

--- a/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
+++ b/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
@@ -322,6 +322,44 @@ Trajectory create_ego_trajectory(
     stopping_threshold);
 }
 
+Trajectory create_ego_pose_trajectory(
+  const std::vector<std::vector<std::vector<Eigen::Matrix4d>>> & agent_poses,
+  const rclcpp::Time & stamp, const int64_t batch_index)
+{
+  const int64_t ego_index = 0;
+
+  if (batch_index < 0 || batch_index >= static_cast<int64_t>(agent_poses.size())) {
+    throw std::out_of_range(
+      "Invalid batch_index: " + std::to_string(batch_index) +
+      ", batch_size=" + std::to_string(agent_poses.size()));
+  }
+
+  const auto & poses = agent_poses[batch_index][ego_index];
+  Trajectory trajectory;
+  trajectory.header.stamp = stamp;
+  trajectory.header.frame_id = "map";
+  constexpr double dt = 0.1;
+
+  for (size_t i = 0; i < poses.size(); ++i) {
+    const double curr_time = dt * static_cast<double>(i + 1);
+    TrajectoryPoint p;
+    p.time_from_start.sec = static_cast<int>(curr_time);
+    p.time_from_start.nanosec = static_cast<uint32_t>((curr_time - p.time_from_start.sec) * 1e9);
+    p.pose.position.x = poses[i](0, 3);
+    p.pose.position.y = poses[i](1, 3);
+    p.pose.position.z = poses[i](2, 3);
+    const Eigen::Matrix3d rotation_matrix = poses[i].block<3, 3>(0, 0);
+    const Eigen::Quaterniond quaternion(rotation_matrix);
+    p.pose.orientation.x = quaternion.x();
+    p.pose.orientation.y = quaternion.y();
+    p.pose.orientation.z = quaternion.z();
+    p.pose.orientation.w = quaternion.w();
+    trajectory.points.push_back(p);
+  }
+
+  return trajectory;
+}
+
 int64_t count_valid_elements(
   const std::vector<float> & data, int64_t len, int64_t dim2, int64_t dim3, int64_t batch_idx)
 {

--- a/planning/autoware_diffusion_planner/src/postprocessing/road_border_avoidance.cpp
+++ b/planning/autoware_diffusion_planner/src/postprocessing/road_border_avoidance.cpp
@@ -1,0 +1,214 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/postprocessing/road_border_avoidance.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::diffusion_planner::postprocess
+{
+namespace bg = boost::geometry;
+using autoware_utils_geometry::LinearRing2d;
+using autoware_utils_geometry::LineString2d;
+using autoware_utils_geometry::Point2d;
+
+namespace
+{
+double yaw_from_quaternion(const geometry_msgs::msg::Quaternion & q)
+{
+  return std::atan2(2.0 * (q.w * q.z + q.x * q.y), 1.0 - 2.0 * (q.y * q.y + q.z * q.z));
+}
+
+LinearRing2d place_footprint(
+  const LinearRing2d & base_footprint, const double x, const double y, const double yaw)
+{
+  const double c = std::cos(yaw);
+  const double s = std::sin(yaw);
+  LinearRing2d placed;
+  placed.reserve(base_footprint.size());
+  for (const auto & p : base_footprint) {
+    placed.emplace_back(c * p.x() - s * p.y() + x, s * p.x() + c * p.y() + y);
+  }
+  return placed;
+}
+
+Point2d nearest_point_on_linestring(const LineString2d & line, const Point2d & point)
+{
+  Point2d nearest = line.front();
+  double min_sq_dist = std::numeric_limits<double>::max();
+  for (size_t i = 0; i + 1 < line.size(); ++i) {
+    const Eigen::Vector2d & a = line[i];
+    const Eigen::Vector2d & b = line[i + 1];
+    const Eigen::Vector2d ab = b - a;
+    const double ab_sq = ab.squaredNorm();
+    const double t = (ab_sq > 0.0) ? std::clamp((point - a).dot(ab) / ab_sq, 0.0, 1.0) : 0.0;
+    const Eigen::Vector2d candidate = a + t * ab;
+    const double sq_dist = (point - candidate).squaredNorm();
+    if (sq_dist < min_sq_dist) {
+      min_sq_dist = sq_dist;
+      nearest = Point2d(candidate.x(), candidate.y());
+    }
+  }
+  return nearest;
+}
+
+const LineString2d * find_nearest_overlapping_border(
+  const std::vector<const LineString2d *> & borders, const LinearRing2d & footprint,
+  const Point2d & position)
+{
+  const LineString2d * nearest_border = nullptr;
+  double min_sq_dist = std::numeric_limits<double>::max();
+  for (const LineString2d * border : borders) {
+    if (!bg::intersects(footprint, *border)) {
+      continue;
+    }
+    const double sq_dist = bg::comparable_distance(position, *border);
+    if (sq_dist < min_sq_dist) {
+      min_sq_dist = sq_dist;
+      nearest_border = border;
+    }
+  }
+  return nearest_border;
+}
+}  // namespace
+
+RoadBorderAvoidance::RoadBorderAvoidance(
+  const RoadBorderAvoidanceParams & params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+: params_(params), base_footprint_(vehicle_info.createFootprint(params.footprint_margin_m))
+{
+}
+
+void RoadBorderAvoidance::set_map(const lanelet::LaneletMap & lanelet_map)
+{
+  std::vector<LineString2d> road_borders;
+  for (const auto & line_string : lanelet_map.lineStringLayer) {
+    const std::string line_string_type = line_string.attributeOr("type", "");
+    if (line_string_type != "road_border" || line_string.size() < 2) {
+      continue;
+    }
+    LineString2d border;
+    border.reserve(line_string.size());
+    for (const auto & point : line_string) {
+      border.emplace_back(point.x(), point.y());
+    }
+    road_borders.push_back(std::move(border));
+  }
+  set_road_borders(std::move(road_borders));
+}
+
+void RoadBorderAvoidance::set_road_borders(std::vector<LineString2d> road_borders)
+{
+  road_borders_ = std::move(road_borders);
+}
+
+RoadBorderAvoidanceResult RoadBorderAvoidance::adjust(
+  const Trajectory & raw_trajectory, const geometry_msgs::msg::Pose & ego_pose) const
+{
+  RoadBorderAvoidanceResult result;
+  result.trajectory = raw_trajectory;
+  if (road_borders_.empty() || raw_trajectory.points.empty()) {
+    return result;
+  }
+
+  // Pre-filter borders reachable within the horizon.
+  const Point2d ego_point(ego_pose.position.x, ego_pose.position.y);
+  std::vector<const LineString2d *> nearby_borders;
+  for (const auto & border : road_borders_) {
+    if (bg::distance(ego_point, border) <= params_.search_radius_m) {
+      nearby_borders.push_back(&border);
+    }
+  }
+  if (nearby_borders.empty()) {
+    return result;
+  }
+
+  const auto intersects_any = [&nearby_borders](const LinearRing2d & footprint) {
+    return std::any_of(
+      nearby_borders.begin(), nearby_borders.end(),
+      [&footprint](const LineString2d * border) { return bg::intersects(footprint, *border); });
+  };
+
+  // Signed lateral offset from the raw position (positive = left of the heading). With
+  // propagate_shift it is carried over to subsequent points along their own lateral
+  // direction; otherwise every point starts from the raw position again.
+  double carried_offset_m = 0.0;
+
+  for (auto & point : result.trajectory.points) {
+    const double raw_x = point.pose.position.x;
+    const double raw_y = point.pose.position.y;
+    const double yaw = yaw_from_quaternion(point.pose.orientation);
+    const Eigen::Vector2d heading(std::cos(yaw), std::sin(yaw));
+    const Eigen::Vector2d lateral_left(-heading.y(), heading.x());
+
+    double offset = params_.propagate_shift ? carried_offset_m : 0.0;
+    const auto footprint_at = [&](const double off) {
+      return place_footprint(
+        base_footprint_, raw_x + lateral_left.x() * off, raw_y + lateral_left.y() * off, yaw);
+    };
+    const auto apply_offset = [&](const double off) {
+      point.pose.position.x = raw_x + lateral_left.x() * off;
+      point.pose.position.y = raw_y + lateral_left.y() * off;
+    };
+
+    const LinearRing2d footprint = footprint_at(offset);
+    const Point2d position(raw_x + lateral_left.x() * offset, raw_y + lateral_left.y() * offset);
+
+    // The nearest overlapping border (if any) decides the shift direction.
+    const LineString2d * offending_border =
+      find_nearest_overlapping_border(nearby_borders, footprint, position);
+    if (offending_border == nullptr) {
+      if (offset != 0.0) {
+        apply_offset(offset);
+        ++result.num_shifted_points;
+      }
+      continue;
+    }
+
+    // Step the offset perpendicular to the heading, away from the border side.
+    const Point2d border_point = nearest_point_on_linestring(*offending_border, position);
+    const Eigen::Vector2d to_border = border_point - position;
+    const double cross = heading.x() * to_border.y() - heading.y() * to_border.x();
+    const double step = (cross > 0.0) ? -params_.shift_step_m : params_.shift_step_m;
+
+    bool resolved = false;
+    while (std::abs(offset + step) <= params_.max_lateral_shift_m + 1e-9) {
+      offset += step;
+      if (!intersects_any(footprint_at(offset))) {
+        resolved = true;
+        break;
+      }
+    }
+
+    // Apply the (possibly capped) offset; moving away is better than staying overlapped.
+    apply_offset(offset);
+    carried_offset_m = offset;
+    if (resolved) {
+      ++result.num_shifted_points;
+    } else {
+      ++result.num_unresolved_points;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace autoware::diffusion_planner::postprocess

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
@@ -58,6 +58,11 @@ TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
     agent_poses, stamp, base_position, 0, velocity_smoothing_window, enable_force_stop,
     stopping_threshold);
   ASSERT_EQ(traj.points.size(), expected_points);
+
+  const auto pose_traj = postprocess::create_ego_pose_trajectory(agent_poses, stamp, 0);
+  ASSERT_EQ(pose_traj.points.size(), expected_points);
+  EXPECT_FLOAT_EQ(pose_traj.points.front().longitudinal_velocity_mps, 0.0f);
+  EXPECT_FLOAT_EQ(pose_traj.points.front().acceleration_mps2, 0.0f);
 }
 
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/road_border_avoidance_test.cpp
+++ b/planning/autoware_diffusion_planner/test/road_border_avoidance_test.cpp
@@ -1,0 +1,188 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/postprocessing/road_border_avoidance.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+namespace autoware::diffusion_planner::test
+{
+using autoware::diffusion_planner::postprocess::RoadBorderAvoidance;
+using autoware::diffusion_planner::postprocess::RoadBorderAvoidanceParams;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils_geometry::LineString2d;
+
+class RoadBorderAvoidanceTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Vehicle width = wheel_tread + left/right overhangs = 1.6 + 0.1 + 0.1 = 1.8 m
+    // -> half width 0.9 m; with footprint_margin_m = 0.2 the required lateral
+    // clearance to a parallel border is 1.1 m.
+    vehicle_info_ = autoware::vehicle_info_utils::createVehicleInfo(
+      0.3, 0.2, 2.75, 1.6, 1.0, 1.0, 0.1, 0.1, 2.0, 0.7);
+    params_.enable = true;
+    params_.footprint_margin_m = 0.2;
+
+    ego_pose_.orientation.w = 1.0;
+  }
+
+  // Straight trajectory along +x at the given y, heading +x.
+  static Trajectory make_straight_trajectory(const double y, const size_t num_points = 20)
+  {
+    Trajectory trajectory;
+    trajectory.header.frame_id = "map";
+    for (size_t i = 1; i <= num_points; ++i) {
+      TrajectoryPoint point;
+      point.pose.position.x = static_cast<double>(i);
+      point.pose.position.y = y;
+      point.pose.orientation = autoware_utils::create_quaternion_from_yaw(0.0);
+      trajectory.points.push_back(point);
+    }
+    return trajectory;
+  }
+
+  // Border parallel to the x axis at the given y.
+  static LineString2d make_parallel_border(const double y)
+  {
+    LineString2d border;
+    border.emplace_back(-10.0, y);
+    border.emplace_back(50.0, y);
+    return border;
+  }
+
+  RoadBorderAvoidanceParams params_;
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  geometry_msgs::msg::Pose ego_pose_;
+};
+
+TEST_F(RoadBorderAvoidanceTest, NoOpWhenClear)
+{
+  RoadBorderAvoidance avoidance(params_, vehicle_info_);
+  avoidance.set_road_borders({make_parallel_border(5.0)});
+
+  const auto raw = make_straight_trajectory(0.0);
+  const auto result = avoidance.adjust(raw, ego_pose_);
+
+  EXPECT_EQ(result.num_shifted_points, 0U);
+  EXPECT_EQ(result.num_unresolved_points, 0U);
+  ASSERT_EQ(result.trajectory.points.size(), raw.points.size());
+  for (size_t i = 0; i < raw.points.size(); ++i) {
+    EXPECT_DOUBLE_EQ(result.trajectory.points[i].pose.position.x, raw.points[i].pose.position.x);
+    EXPECT_DOUBLE_EQ(result.trajectory.points[i].pose.position.y, raw.points[i].pose.position.y);
+  }
+}
+
+TEST_F(RoadBorderAvoidanceTest, ShiftsAwayFromLeftBorder)
+{
+  RoadBorderAvoidance avoidance(params_, vehicle_info_);
+  // Border on the left at y = 1.0 < required clearance 1.1 -> overlap, shift to -y.
+  avoidance.set_road_borders({make_parallel_border(1.0)});
+
+  const auto raw = make_straight_trajectory(0.0);
+  const auto result = avoidance.adjust(raw, ego_pose_);
+
+  EXPECT_GT(result.num_shifted_points, 0U);
+  EXPECT_EQ(result.num_unresolved_points, 0U);
+  for (const auto & point : result.trajectory.points) {
+    EXPECT_LT(point.pose.position.y, 0.0);
+  }
+
+  // The adjusted trajectory must be clear: a second pass is a no-op.
+  const auto second = avoidance.adjust(result.trajectory, ego_pose_);
+  EXPECT_EQ(second.num_shifted_points, 0U);
+  EXPECT_EQ(second.num_unresolved_points, 0U);
+}
+
+TEST_F(RoadBorderAvoidanceTest, ShiftsAwayFromRightBorder)
+{
+  RoadBorderAvoidance avoidance(params_, vehicle_info_);
+  avoidance.set_road_borders({make_parallel_border(-1.0)});
+
+  const auto raw = make_straight_trajectory(0.0);
+  const auto result = avoidance.adjust(raw, ego_pose_);
+
+  EXPECT_GT(result.num_shifted_points, 0U);
+  for (const auto & point : result.trajectory.points) {
+    EXPECT_GT(point.pose.position.y, 0.0);
+  }
+}
+
+TEST_F(RoadBorderAvoidanceTest, CapsShiftAndReportsUnresolved)
+{
+  params_.max_lateral_shift_m = 0.3;  // not enough to clear a deeply overlapping border
+  RoadBorderAvoidance avoidance(params_, vehicle_info_);
+  avoidance.set_road_borders({make_parallel_border(0.0)});  // border through the path
+
+  const auto raw = make_straight_trajectory(0.0);
+  const auto result = avoidance.adjust(raw, ego_pose_);
+
+  EXPECT_EQ(result.num_shifted_points, 0U);
+  EXPECT_GT(result.num_unresolved_points, 0U);
+  // The capped shift is still applied.
+  for (const auto & point : result.trajectory.points) {
+    EXPECT_NEAR(std::abs(point.pose.position.y), 0.3, 1e-9);
+  }
+}
+
+TEST_F(RoadBorderAvoidanceTest, PropagatesShiftToSubsequentPoints)
+{
+  // Border alongside only the first part of the trajectory (ends at x = 5).
+  LineString2d border;
+  border.emplace_back(-10.0, 1.0);
+  border.emplace_back(5.0, 1.0);
+
+  {
+    params_.propagate_shift = true;
+    RoadBorderAvoidance avoidance(params_, vehicle_info_);
+    avoidance.set_road_borders({border});
+    const auto result = avoidance.adjust(make_straight_trajectory(0.0), ego_pose_);
+    EXPECT_GT(result.num_shifted_points, 0U);
+    // The offset is carried to the end of the trajectory.
+    EXPECT_LT(result.trajectory.points.back().pose.position.y, 0.0);
+  }
+  {
+    params_.propagate_shift = false;
+    RoadBorderAvoidance avoidance(params_, vehicle_info_);
+    avoidance.set_road_borders({border});
+    const auto result = avoidance.adjust(make_straight_trajectory(0.0), ego_pose_);
+    EXPECT_GT(result.num_shifted_points, 0U);
+    // Without propagation the tail stays on the raw output.
+    EXPECT_DOUBLE_EQ(result.trajectory.points.back().pose.position.y, 0.0);
+  }
+}
+
+TEST_F(RoadBorderAvoidanceTest, IgnoresBordersOutsideSearchRadius)
+{
+  params_.search_radius_m = 10.0;
+  RoadBorderAvoidance avoidance(params_, vehicle_info_);
+  LineString2d far_border;
+  far_border.emplace_back(100.0, 1.0);
+  far_border.emplace_back(150.0, 1.0);
+  avoidance.set_road_borders({far_border});
+
+  const auto raw = make_straight_trajectory(0.0);
+  const auto result = avoidance.adjust(raw, ego_pose_);
+  EXPECT_EQ(result.num_shifted_points, 0U);
+  EXPECT_EQ(result.num_unresolved_points, 0U);
+}
+
+}  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/trajectory_optimizer_test.cpp
+++ b/planning/autoware_diffusion_planner/test/trajectory_optimizer_test.cpp
@@ -1,0 +1,135 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/optimization/trajectory_optimizer.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <optional>
+#include <random>
+
+namespace autoware::diffusion_planner::test
+{
+using autoware::diffusion_planner::optimization::opt_dt_s;
+using autoware::diffusion_planner::optimization::opt_horizon;
+using autoware::diffusion_planner::optimization::TrajectoryOptimizationParams;
+using autoware::diffusion_planner::optimization::TrajectoryOptimizer;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using nav_msgs::msg::Odometry;
+
+class TrajectoryOptimizerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    vehicle_info_.wheel_base_m = 2.75;
+    vehicle_info_.max_steer_angle_rad = 0.7;
+
+    odometry_.header.frame_id = "map";
+    odometry_.pose.pose.orientation.w = 1.0;
+    odometry_.twist.twist.linear.x = 8.0;
+  }
+
+  // Straight-line constant-speed trajectory with position noise, starting at t = 0.1 s
+  // slightly ahead of base_link (mimicking the raw model output: poses only).
+  static Trajectory make_noisy_trajectory(const double speed, const double noise_std)
+  {
+    std::mt19937 rng(42);
+    std::normal_distribution<double> noise(0.0, noise_std);
+
+    Trajectory trajectory;
+    trajectory.header.frame_id = "map";
+    for (size_t i = 1; i <= opt_horizon; ++i) {
+      TrajectoryPoint point;
+      point.pose.position.x = speed * opt_dt_s * static_cast<double>(i) + noise(rng);
+      point.pose.position.y = noise(rng);
+      point.pose.orientation = autoware_utils::create_quaternion_from_yaw(0.0);
+      trajectory.points.push_back(point);
+    }
+    return trajectory;
+  }
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  Odometry odometry_;
+};
+
+TEST_F(TrajectoryOptimizerTest, OptimizesNoisyTrajectory)
+{
+  TrajectoryOptimizationParams params;
+  params.enable = true;
+  TrajectoryOptimizer optimizer(params, vehicle_info_, 1);
+
+  const auto raw = make_noisy_trajectory(8.0, 0.15);
+  const auto result = optimizer.optimize(raw, odometry_, 0.0, 0);
+
+  ASSERT_TRUE(result.optimized) << "acados status: " << result.solver_status;
+  ASSERT_EQ(result.trajectory.points.size(), opt_horizon);
+
+  // Points are published from t = 0.1 s; the first point follows from the base_link
+  // initial state (x0 at origin, v0 = 8 m/s) through the vehicle dynamics.
+  const auto & first = result.trajectory.points.front();
+  EXPECT_EQ(first.time_from_start.sec, 0);
+  EXPECT_NEAR(first.time_from_start.nanosec * 1e-9, opt_dt_s, 1e-9);
+  const double v0 = odometry_.twist.twist.linear.x;
+  EXPECT_NEAR(first.pose.position.x, v0 * opt_dt_s, 0.3);
+  EXPECT_NEAR(first.pose.position.y, 0.0, 0.3);
+
+  for (const auto & point : result.trajectory.points) {
+    EXPECT_GE(point.longitudinal_velocity_mps, params.min_velocity_mps - 1e-6);
+    EXPECT_LE(std::abs(point.front_wheel_angle_rad), vehicle_info_.max_steer_angle_rad + 1e-6);
+    EXPECT_GE(point.acceleration_mps2, params.min_acceleration_mps2 - 1e-6);
+    EXPECT_LE(point.acceleration_mps2, params.max_acceleration_mps2 + 1e-6);
+  }
+
+  // The solution should stay close to the (noise-free) straight line.
+  for (const auto & point : result.trajectory.points) {
+    EXPECT_LT(std::abs(point.pose.position.y), 0.5);
+  }
+}
+
+TEST_F(TrajectoryOptimizerTest, FallsBackOnShortTrajectory)
+{
+  TrajectoryOptimizationParams params;
+  params.enable = true;
+  TrajectoryOptimizer optimizer(params, vehicle_info_, 1);
+
+  Trajectory short_trajectory;
+  short_trajectory.header.frame_id = "map";
+  short_trajectory.points.resize(3);
+
+  const auto result = optimizer.optimize(short_trajectory, odometry_, std::nullopt, 0);
+  EXPECT_FALSE(result.optimized);
+  EXPECT_EQ(result.trajectory.points.size(), short_trajectory.points.size());
+}
+
+TEST_F(TrajectoryOptimizerTest, WarmStartAcrossCycles)
+{
+  TrajectoryOptimizationParams params;
+  params.enable = true;
+  TrajectoryOptimizer optimizer(params, vehicle_info_, 1);
+
+  const auto raw = make_noisy_trajectory(8.0, 0.15);
+  const auto first = optimizer.optimize(raw, odometry_, 0.0, 0);
+  ASSERT_TRUE(first.optimized);
+
+  // Second solve with warm start must also succeed.
+  const auto second = optimizer.optimize(raw, odometry_, 0.0, 0);
+  ASSERT_TRUE(second.optimized);
+}
+
+}  // namespace autoware::diffusion_planner::test


### PR DESCRIPTION
## Summary
- Add an optional acados OCP after diffusion inference so the published ego trajectory is dynamically consistent with the current vehicle state (pose, odometry velocity, measured steering).
- Keep model decoding, turn-indicator commands, predicted objects, and the rest of the post-network pipeline unchanged. Finite-difference velocity smoothing remains the fallback when optimization is disabled, acados is not built, or a solve fails.
- Document the OCP (kinematic bicycle, lon/lat tracking weights, constraints) in the package README, param YAML, and schema. New debug topics: `~/debug/optimization/raw_trajectory`, `solver_status`, `solve_time_ms`.

The raw network output is pose-only \((x, y, \cos\psi, \sin\psi)\) at \(t = 0.1\ldots 8.0\,\mathrm{s}\). The OCP tracks that sequence with a kinematic bicycle:

- States: \((p_x, p_y, \psi, v, \delta)\); inputs: \((a, \dot\delta)\); \(N=80\), \(\Delta t=0.1\,\mathrm{s}\)
- Position cost is split along the reference heading (longitudinal vs lateral)
- Box bounds on \(v\), \(\delta\), \(a\), \(\dot\delta\); soft \(|v^2\tan\delta/L| \le a_{\mathrm{lat,max}}\)
- Horizon aligned 1:1 with `OUTPUT_T`

Building requires acados at `ACADOS_SOURCE_DIR` (default `/opt/acados`). Without it the package still builds and uses finite-difference kinematics.

This PR only touches `planning/autoware_diffusion_planner` (no hisaki tree).

## Test plan
- [ ] Build `autoware_diffusion_planner` with acados available and confirm `AUTOWARE_DIFFUSION_PLANNER_USE_ACADOS` is set
- [ ] Build without acados and confirm the node warns and falls back to finite-difference smoothing when `trajectory_optimization.enable` is true
- [ ] Run `colcon test --packages-select autoware_diffusion_planner` (includes `TrajectoryOptimizerTest`)
- [ ] With optimization enabled, check `~/output/trajectory` has consistent `longitudinal_velocity_mps`, `acceleration_mps2`, and `front_wheel_angle_rad`
- [ ] Confirm `~/output/turn_indicators` and `~/output/predicted_objects` are unchanged vs the previous decode path
- [ ] Confirm debug topics `~/debug/optimization/{raw_trajectory,solver_status,solve_time_ms}` publish; on solver failure the FD trajectory is still published


Made with [Cursor](https://cursor.com)