### PR TITLE
feat(traffic_light_compliance_checker): improve compliance checker to prevent chattering behavior

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -110,10 +110,16 @@ private:
 
   bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
 
+  void cleanup_violation_distance_history(
+    const std::vector<StopLineInfo> & red_stop_lines,
+    const std::vector<StopLineInfo> & amber_stop_lines, const bool check_red_lights,
+    const bool check_amber_lights) const;
+
   Parameters params_;
   vehicle_info_utils::VehicleInfo vehicle_info_;
   std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
   mutable std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  mutable std::unordered_map<int64_t, double> violation_distance_history_;
   std::optional<double> ego_stopping_distance_;
 };
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -35,6 +35,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -287,16 +288,42 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
     return ComplianceResult{};
   }
 
+  const auto [red_stop_lines, amber_stop_lines] =
+    get_stop_lines(*input.map, input.route, filtered_signals);
+
+  if (
+    (!check_red_lights || red_stop_lines.empty()) &&
+    (!check_amber_lights || amber_stop_lines.empty())) {
+    violation_distance_history_.clear();
+    return ComplianceResult{};
+  }
+
+  // clear violation distance history for tl ids that are no longer in detected stop lines
+  cleanup_violation_distance_history(
+    red_stop_lines, amber_stop_lines, check_red_lights, check_amber_lights);
+
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
+
+  // floor minimum lookahead distance by the previous violation distance to avoid chattering
+  // behavior between cycles
+  const auto max_prev_violation_distance =
+    violation_distance_history_.empty()
+      ? 0.0
+      : std::max_element(
+          violation_distance_history_.begin(), violation_distance_history_.end(),
+          [](const auto & a, const auto & b) { return a.second < b.second; })
+          ->second;
+
+  const auto min_lookahead_distance =
+    std::max(params_.min_lookahead_distance, max_prev_violation_distance);
 
   // Floor by min_lookahead_distance so low ego speed still covers nearby stop lines,
   // while keeping the comfortable-stop cap so far lights are not over-checked
   // (important for traffic_light_filter which rejects trajectories).
   // stop_overshoot_margin extends the scan so a stop just past the line is not truncated.
   const auto max_trajectory_length = std::max(
-    params_.min_lookahead_distance,
-    ego_stopping_distance_.value_or(0.0) + params_.stop_overshoot_margin);
+    min_lookahead_distance, ego_stopping_distance_.value_or(0.0) + params_.stop_overshoot_margin);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -338,9 +365,6 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
     if (stop_point.has_value()) stop_point.value() = offset_point;
   }
 
-  const auto [red_stop_lines, amber_stop_lines] =
-    get_stop_lines(*input.map, input.route, filtered_signals);
-
   ComplianceResult result;
   if (check_red_lights) {
     result.violations =
@@ -352,6 +376,10 @@ ComplianceResult TrafficLightComplianceChecker::check_with_filtered_signals(
       input.current_time, backward_length);
     result.violations.insert(
       result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+  }
+
+  for (const auto & violation : result.violations) {
+    violation_distance_history_[violation.traffic_light_id] = violation.arc_length_to_cross_point;
   }
 
   return result;
@@ -432,4 +460,28 @@ bool TrafficLightComplianceChecker::is_allow_if_cannot_stop(
          distance_from_ego_front < *ego_stopping_distance_ - params_.stop_overshoot_margin;
 }
 
+void TrafficLightComplianceChecker::cleanup_violation_distance_history(
+  const std::vector<StopLineInfo> & red_stop_lines,
+  const std::vector<StopLineInfo> & amber_stop_lines, const bool check_red_lights,
+  const bool check_amber_lights) const
+{
+  std::unordered_set<int64_t> target_tl_ids;
+  if (check_red_lights) {
+    for (const auto & red_stop_line : red_stop_lines) {
+      target_tl_ids.insert(red_stop_line.traffic_light_id);
+    }
+  }
+  if (check_amber_lights) {
+    for (const auto & amber_stop_line : amber_stop_lines) {
+      target_tl_ids.insert(amber_stop_line.traffic_light_id);
+    }
+  }
+  for (auto it = violation_distance_history_.begin(); it != violation_distance_history_.end();) {
+    if (target_tl_ids.count(it->first) == 0) {
+      it = violation_distance_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -73,9 +73,6 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
   const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
   const rclcpp::Time & current_time, const bool is_ego_stopped)
 {
-  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
-  filtered_signals.stamp = signals.stamp;
-
   for (const auto & signal : signals.traffic_light_groups) {
     const auto id = signal.traffic_light_group_id;
     auto history_it = signal_history_.find(id);
@@ -103,15 +100,21 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker:
       }
       history_it->second.stable_state = signal;
     }
-
-    if (is_ego_stopped) {
-      filtered_signals.traffic_light_groups.push_back(signal);
-    } else if (history_it->second.stable_state) {
-      filtered_signals.traffic_light_groups.push_back(*history_it->second.stable_state);
-    }
   }
 
   cleanup_signal_history(current_time);
+
+  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
+  filtered_signals.stamp = signals.stamp;
+  for (const auto & tracked_signal : signal_history_) {
+    const auto & history = tracked_signal.second;
+    const bool seen_this_frame = history.last_seen_time == current_time;
+    if (is_ego_stopped && seen_this_frame) {
+      filtered_signals.traffic_light_groups.push_back(history.current_state);
+    } else if (history.stable_state) {
+      filtered_signals.traffic_light_groups.push_back(*history.stable_state);
+    }
+  }
 
   return filtered_signals;
 }

--- a/planning/autoware_trajectory_processor/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_traffic_light_stop_integration.cpp
@@ -521,8 +521,9 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithAmberLightWhenPrev
   auto crossing_trajectory = create_straight_trajectory(0.0, 10.0, 10.0);
   auto input = make_default_input(10.0);
   const auto result = plugin_->process(crossing_trajectory, input);
-  EXPECT_TRUE(result == autoware::trajectory_processor::plugin::ProcessingResult::Modified) << "Should modify trajectory when a prior stop attempt is detected and "
-                           "reject_if_stop_detected is true";
+  EXPECT_TRUE(result == autoware::trajectory_processor::plugin::ProcessingResult::Modified)
+    << "Should modify trajectory when a prior stop attempt is detected and "
+       "reject_if_stop_detected is true";
   EXPECT_FLOAT_EQ(crossing_trajectory.back().longitudinal_velocity_mps, 0.0F);
 }
 


### PR DESCRIPTION
## Description

The `TrafficLightComplianceChecker` trims the trajectory line-string based on the computed stopping distance (and `min_lookahead_distance` param which defaults to 0.0), this can result in chattering behavior in `traffic_light_filter`:

```
violation detected -> trajectory rejected -> ego brakes -> stopping distance shrinks -> stop line further than lookahead -> no violation
```

This PR improves the robustness of the compliance checker by implementing a latching logic for the scan horizon based on previously detected violations.

### Changes
- refactor TrafficLightStatusTracker::filter_signals to emit all stable statuses in the history, not only the ones in this frame
- keep a history of violation arc lengths per id
- use previous violation arc lengths to floor current frame lookahead distance
- use current frame collected stop lines to cleanup the history of violation arc lengths

## How was this PR tested?
- Scenario Sim

before:

[Screencast from 2026年08月31日 11時35分52秒.webm](https://github.com/user-attachments/assets/a00aa329-11c8-4b5a-8836-53df0e7fb278)

after:

[Screencast from 2026年08月31日 11時31分55秒.webm](https://github.com/user-attachments/assets/af18c751-866e-4ce0-9248-907ed754e293)
