### PR TITLE
feat(diffusion_planner): input as image

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -4,6 +4,7 @@ project(autoware_diffusion_planner)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 find_package(Boost REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(onnxruntime QUIET)
 
 # Options
@@ -77,6 +78,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/conversion/agent.cpp
     src/conversion/agent_history_resampler.cpp
     src/postprocessing/postprocessing_utils.cpp
+    src/preprocessing/bev_image.cpp
     src/preprocessing/lane_segments.cpp
     src/preprocessing/preprocessing_utils.cpp
     src/preprocessing/traffic_signals.cpp
@@ -109,6 +111,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     ${CUDA_INCLUDE_DIRS}
     ${autoware_cuda_utils_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
   )
   if(onnxruntime_FOUND)
     target_include_directories(autoware_diffusion_planner_component PUBLIC
@@ -123,6 +126,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     ${NVONNXPARSER}
     ${CUDA_LIBRARIES}
     ${CUBLAS_LIBRARIES}
+    ${OpenCV_LIBRARIES}
   )
 
   if(onnxruntime_FOUND)
@@ -160,6 +164,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       test/lanelet_test.cpp
       test/lane_segments_test.cpp
       test/pre_processing_utils_test.cpp
+      test/bev_image_test.cpp
       test/postprocessing_utils_test.cpp
       test/utils_test.cpp
       test/marker_utils_test.cpp

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -169,6 +169,49 @@ ros2 launch autoware_launch planning_simulator.launch.xml \
 
 ---
 
+## Scene Representation
+
+The encoder of a checkpoint reads the scene in one of two ways, and the node picks the matching
+path automatically from the `input_type` field of the model's args JSON. A checkpoint that predates
+the image encoder carries no such field and is treated as `vector`.
+
+| `input_type` | Encoder input                                                          | Encoder tokens |
+| ------------ | ---------------------------------------------------------------------- | -------------- |
+| `vector`     | One token per lane segment, route segment, polygon, line string, agent | 501            |
+| `image`      | BEV rasters, plus the ego motion and turn-indicator scalar tokens      | 100            |
+
+In `image` mode the node rasterizes the same vector scene it builds for `vector` mode into a stack
+of binary bird's-eye-view masks - a mirror of `diffusion_planner/utils/render_bev.py` in the
+training repository - and feeds that to the encoder instead of the polylines:
+
+- Two scales share the ego pose as their origin, both 224x224 pixels with the ego heading
+  pointing up. The figure is the full side length of the view, not its reach from the ego:
+
+  | View  | Side  | Around ego | Resolution   |
+  | ----- | ----- | ---------- | ------------ |
+  | near  | 50 m  | +/-25 m    | 0.223 m/pixel |
+  | far   | 200 m | +/-100 m   | 0.893 m/pixel |
+- 17 semantic channels, each its own binary mask so overlapping elements never hide each other:
+  lane boundary, lane centerline, route, four traffic light planes, polygon, line string, static
+  object, goal pose, vehicle, pedestrian, bicycle, ego, neighbor history, ego history.
+- The traffic light state gets one plane per colour - go (green), caution (yellow), stop (red) and
+  unknown (the lane has a light whose colour never arrived) - so none of them is folded into
+  another. A lane with no traffic light at all is silent on all four planes, and that silence is
+  what identifies it.
+- Motion lives in the history channels: an agent's past track is a polyline that ends at its
+  current bounding box.
+
+Rendering happens before normalization, since the rasterizer works in meters. The elements the
+raster cannot carry stay as tensors: the ego velocity and acceleration (from `ego_current_state`)
+and the turn-indicator history. `goal_pose`, `ego_shape` and `ego_agent_past` are not passed at all
+in `image` mode - the encoder does not read them - though the renderer still draws them.
+
+Set `debug_params.publish_debug_bev_image` to `true` to publish a colorized preview of each scale
+on `~/debug/bev_image_50m` and `~/debug/bev_image_200m`. This is the quickest way to confirm the
+node's rasters match what the model was trained on.
+
+---
+
 ## Parameters
 
 {{ json_to_markdown("planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json") }}
@@ -200,6 +243,8 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 | `~/output/debug/traffic_signal` | autoware_perception_msgs/msg/TrafficLightGroup            | First traffic light on route (ego forward) for RViz/ad_api |
 | `~/debug/lane_marker`           | visualization_msgs/msg/MarkerArray                        | Lane debug markers                                         |
 | `~/debug/route_marker`          | visualization_msgs/msg/MarkerArray                        | Route debug markers                                        |
+| `~/debug/bev_image_50m`         | sensor_msgs/msg/Image                                     | BEV raster preview, near view (image-input models only)    |
+| `~/debug/bev_image_200m`        | sensor_msgs/msg/Image                                     | BEV raster preview, far view (image-input models only)     |
 
 ---
 

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -54,3 +54,4 @@
       publish_debug_route: true
       publish_debug_map: false
       publish_debug_linestrings: true
+      publish_debug_bev_image: false   # colorized preview of the BEV rasters; image-input models only

--- a/planning/autoware_diffusion_planner/design/DiffusionPlanner.node.yaml
+++ b/planning/autoware_diffusion_planner/design/DiffusionPlanner.node.yaml
@@ -1,0 +1,89 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: DiffusionPlanner.node
+package:
+  name: autoware_diffusion_planner
+  provider: autoware
+launch:
+  plugin: autoware::diffusion_planner::DiffusionPlanner
+  executable: autoware_diffusion_planner_node
+# interfaces
+subscribers:
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: route
+    message_type: autoware_planning_msgs/msg/LaneletRoute
+  - name: odometry
+    message_type: nav_msgs/msg/Odometry
+  - name: acceleration
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+  - name: tracked_objects
+    message_type: autoware_perception_msgs/msg/TrackedObjects
+  - name: traffic_signals
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+  - name: turn_indicators
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsReport
+publishers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+  - name: trajectories
+    message_type: autoware_internal_planning_msgs/msg/CandidateTrajectories
+  - name: predicted_objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+  - name: turn_indicators
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsCommand
+  - name: traffic_signal
+    message_type: autoware_perception_msgs/msg/TrafficLightGroup
+    remap_target: ~/output/debug/traffic_signal
+  - name: route_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/route_marker
+  - name: lane_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/lane_marker
+  - name: linestring_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/linestring_marker
+  - name: processing_time_detail
+    message_type: autoware_internal_debug_msgs/msg/ProcessingTimeTree
+    remap_target: ~/debug/processing_time_detail_ms
+  - name: processing_time
+    message_type: autoware_internal_debug_msgs/msg/Float64Stamped
+    remap_target: ~/debug/processing_time_ms
+  - name: inference_time
+    message_type: std_msgs/msg/Float64
+    remap_target: ~/debug/inference_time_ms
+  - name: denoising_steps
+    message_type: std_msgs/msg/Float32MultiArray
+    remap_target: ~/debug/denoising_steps
+  - name: guidance_status
+    message_type: autoware_internal_debug_msgs/msg/StringStamped
+    remap_target: ~/debug/guidance_status
+  - name: bev_image_50m
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/bev_image_50m
+  - name: bev_image_200m
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/bev_image_200m
+# parameters
+param_files:
+  - name: diffusion_planner_param
+    default: config/diffusion_planner.param.yaml
+param_values: []
+# processes
+processes:
+  - name: plan_trajectory
+    trigger_conditions:
+      - on_input: route
+    outcomes:
+      - to_output: trajectory
+servers:
+  - name: set_start_guidance_enabled
+    message_type: std_srvs/srv/SetBool
+    remap_target: ~/service/set_start_guidance_enabled
+  - name: set_stop_guidance_enabled
+    message_type: std_srvs/srv/SetBool
+    remap_target: ~/service/set_stop_guidance_enabled
+  - name: set_centerline_guidance_enabled
+    message_type: std_srvs/srv/SetBool
+    remap_target: ~/service/set_centerline_guidance_enabled

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -17,11 +17,13 @@
 
 #include "autoware/diffusion_planner/conversion/agent.hpp"
 #include "autoware/diffusion_planner/conversion/agent_history_resampler.hpp"
+#include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/guidance/centerline_guidance.hpp"
 #include "autoware/diffusion_planner/inference/guidance/start_guidance.hpp"
 #include "autoware/diffusion_planner/inference/guidance/stop_guidance.hpp"
 #include "autoware/diffusion_planner/inference/inference.hpp"
 #include "autoware/diffusion_planner/postprocessing/turn_indicator_manager.hpp"
+#include "autoware/diffusion_planner/preprocessing/bev_image.hpp"
 #include "autoware/diffusion_planner/preprocessing/lane_segments.hpp"
 #include "autoware/diffusion_planner/preprocessing/traffic_signals.hpp"
 #include "autoware/diffusion_planner/utils/arg_reader.hpp"
@@ -44,6 +46,7 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>
@@ -250,6 +253,21 @@ public:
   InputDataMap create_input_data(const FrameContext & frame_context);
 
   /**
+   * @brief Rasterize the BEV stack the loaded model's encoder needs.
+   *
+   * @param input_data_map Un-normalized output of create_input_data. The rasterizer reads
+   *                       meters, so this must be called before normalize_input_data.
+   * @return The rendered stack, or an empty vector when the loaded model takes vector input and
+   *         therefore reads the polylines directly.
+   */
+  std::vector<uint8_t> create_bev_image(const InputDataMap & input_data_map) const;
+
+  /**
+   * @brief Scene representation the loaded model's encoder takes.
+   */
+  ModelInputType get_model_input_type() const { return model_input_type_; }
+
+  /**
    * @brief Set the lanelet map context.
    *
    * @param lanelet_map_ptr Shared pointer to lanelet map
@@ -304,10 +322,12 @@ public:
   /**
    * @brief Run inference on the input data.
    *
-   * @param input_data_map Input data for inference
+   * @param input_data_map Normalized input data for inference
+   * @param bev_image Rendered BEV stack from create_bev_image
    * @return Inference result with predictions, turn indicator logits, and denoising steps
    */
-  InferenceResult run_inference(const InputDataMap & input_data_map);
+  InferenceResult run_inference(
+    const InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image);
 
   /**
    * @brief Create all planner output messages from raw inference outputs.
@@ -358,6 +378,8 @@ private:
 
   ObservationNormalization observation_normalization_;
   StateNormalization state_normalization_;
+  // Declared by the loaded weights, so it is only meaningful once load_model has run.
+  ModelInputType model_input_type_{ModelInputType::VECTOR};
 
   // Inference engine
   std::unique_ptr<Inference> diffusion_planner_inference_{nullptr};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -40,6 +40,7 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_srvs/srv/set_bool.hpp>
@@ -72,6 +73,9 @@ struct DiffusionPlannerDebugParams
   bool publish_debug_route{true};
   bool publish_debug_map{false};
   bool publish_debug_linestrings{true};
+  // Publish the rendered BEV stack the image encoder sees, as one colorized preview per scale.
+  // Only meaningful for a model that takes image input.
+  bool publish_debug_bev_image{false};
 };
 
 struct DiffusionPlannerPlanningFactorParams
@@ -155,6 +159,15 @@ private:
    * @param input_data_map Input data used for inference.
    * @param ego_to_map_transform Transform from ego to map frame for visualization.
    */
+  /**
+   * @brief Publish the rendered BEV stack as a colorized preview, one image per scale.
+   *
+   * @param bev_image Output of DiffusionPlannerCore::create_bev_image; nothing is published when
+   *                  it is empty, i.e. when the loaded model takes vector input.
+   */
+  void publish_debug_bev_image(
+    const std::vector<uint8_t> & bev_image, const rclcpp::Time & timestamp);
+
   void publish_debug_markers(
     const InputDataMap & input_data_map, const Eigen::Matrix4d & ego_to_map_transform,
     const rclcpp::Time & timestamp) const;
@@ -244,6 +257,8 @@ private:
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_denoising_steps_{nullptr};
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
     pub_guidance_status_{nullptr};
+  // One publisher per BEV scale, in BEV_VIEW_EXTENTS_M order.
+  std::vector<rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr> pub_bev_images_;
   rclcpp::Service<SetBool>::SharedPtr set_start_guidance_enabled_service_{nullptr};
   rclcpp::Service<SetBool>::SharedPtr set_stop_guidance_enabled_service_{nullptr};
   rclcpp::Service<SetBool>::SharedPtr set_centerline_guidance_enabled_service_{nullptr};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
@@ -31,7 +31,7 @@ inline constexpr int64_t NUM_STATIC_OBJECTS = 5;
 inline constexpr int64_t MAX_NUM_NEIGHBORS = 320;
 inline constexpr int64_t MAX_NUM_AGENTS = MAX_NUM_NEIGHBORS + 1;  // Including ego
 inline constexpr int64_t HIDDEN_DIM = 256;
-inline constexpr int64_t ENCODING_TOKEN_NUM =
+inline constexpr int64_t VECTOR_ENCODING_TOKEN_NUM =
   MAX_NUM_AGENTS + NUM_STATIC_OBJECTS + NUM_SEGMENTS_IN_LANE + NUM_SEGMENTS_IN_ROUTE +
   NUM_POLYGONS + NUM_LINE_STRINGS + 3;  // goal_pose, ego_shape, turn_indicator
 inline constexpr int64_t POINTS_PER_SEGMENT = 20;
@@ -103,5 +103,47 @@ inline constexpr std::array<int64_t, 2> GOAL_POSE_SHAPE = {1, POSE_DIM};
 inline constexpr std::array<int64_t, 2> EGO_SHAPE_SHAPE = {1, 3};
 inline constexpr std::array<int64_t, 2> TURN_INDICATORS_SHAPE = {1, INPUT_T + 1};
 inline constexpr std::array<int64_t, 2> DELAY_SHAPE = {1, 1};
+
+// ---------------------------------------------------------------------------
+// Scene representation fed to the encoder.
+//
+// VECTOR encodes every polyline and agent state as its own token. IMAGE instead rasterizes the
+// same scene into BEV binary masks (see preprocessing/bev_image.hpp) and encodes those with a
+// ResNet, leaving as tensors only the facts that have no pixel representation. Which one a
+// checkpoint expects is declared by "input_type" in its args JSON.
+// ---------------------------------------------------------------------------
+enum class ModelInputType { VECTOR, IMAGE };
+
+// BEV raster layout; mirrors diffusion_planner/utils/render_bev.py.
+//
+// An extent is the full side length of a view, not its reach from the ego: the 50 m view covers
+// +/-25 m at 50 / 224 = 0.223 m per pixel, and the 200 m view covers +/-100 m at 0.893 m per
+// pixel. Both are square and centred on the ego.
+inline constexpr int64_t BEV_IMAGE_SIZE = 224;
+inline constexpr int64_t BEV_NUM_SCALES = 2;
+inline constexpr int64_t BEV_NUM_CHANNELS = 17;
+inline constexpr double BEV_NEAR_EXTENT_M = 50.0;
+inline constexpr double BEV_FAR_EXTENT_M = 200.0;
+inline constexpr std::array<double, BEV_NUM_SCALES> BEV_VIEW_EXTENTS_M = {
+  BEV_NEAR_EXTENT_M, BEV_FAR_EXTENT_M};
+inline constexpr std::array<int64_t, 5> BEV_IMAGE_SHAPE = {
+  1, BEV_NUM_SCALES, BEV_NUM_CHANNELS, BEV_IMAGE_SIZE, BEV_IMAGE_SIZE};
+
+// resnet18 downsamples by 32 up to layer4, and every cell of the resulting feature map becomes
+// one token. On top of the per-scale cells the image encoder appends the ego-motion and the
+// turn-indicator scalar tokens (see model/module/image_encoder.py).
+inline constexpr int64_t BEV_RESNET_STRIDE = 32;
+inline constexpr int64_t BEV_FEATURE_GRID_SIZE = BEV_IMAGE_SIZE / BEV_RESNET_STRIDE;
+static_assert(
+  BEV_FEATURE_GRID_SIZE * BEV_RESNET_STRIDE == BEV_IMAGE_SIZE,
+  "BEV_IMAGE_SIZE must be a multiple of the ResNet stride");
+inline constexpr int64_t BEV_IMAGE_SCALAR_TOKEN_NUM = 2;  // ego motion, turn indicator
+inline constexpr int64_t IMAGE_ENCODING_TOKEN_NUM =
+  BEV_NUM_SCALES * BEV_FEATURE_GRID_SIZE * BEV_FEATURE_GRID_SIZE + BEV_IMAGE_SCALAR_TOKEN_NUM;
+
+inline constexpr int64_t encoding_token_num(const ModelInputType input_type)
+{
+  return input_type == ModelInputType::IMAGE ? IMAGE_ENCODING_TOKEN_NUM : VECTOR_ENCODING_TOKEN_NUM;
+}
 }  // namespace autoware::diffusion_planner
 #endif  // AUTOWARE__DIFFUSION_PLANNER__DIMENSIONS_HPP_

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/inference.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/inference.hpp
@@ -19,6 +19,7 @@
 
 #include <tl/expected.hpp>
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -44,7 +45,15 @@ class Inference
 public:
   virtual ~Inference() = default;
 
-  virtual InferenceResult infer(const preprocess::InputDataMap & input_data_map) = 0;
+  /**
+   * @brief Run one planning inference.
+   *
+   * @param input_data_map Normalized float inputs.
+   * @param bev_image      Rendered BEV stack (see preprocessing/bev_image.hpp). Read only by
+   *                       models whose encoder takes image input; empty otherwise.
+   */
+  virtual InferenceResult infer(
+    const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image) = 0;
 };
 
 }  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/multi_step_inference.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/multi_step_inference.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__DIFFUSION_PLANNER__INFERENCE__MULTI_STEP_INFERENCE_HPP_
 #define AUTOWARE__DIFFUSION_PLANNER__INFERENCE__MULTI_STEP_INFERENCE_HPP_
 
+#include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/guidance/guidance.hpp"
 #include "autoware/diffusion_planner/inference/inference.hpp"
 #include "autoware/diffusion_planner/inference/solver/dpm_solver.hpp"
@@ -26,6 +27,7 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -42,17 +44,21 @@ public:
   MultiStepInference(
     const std::string & encoder_model_path, const std::string & decoder_model_path,
     const std::string & turn_indicator_model_path, const std::string & plugins_path, int batch_size,
-    const std::string & precision = "fp32", bool use_cuda_graph = false, int dpm_solver_steps = 10,
-    std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances = {});
+    const std::string & precision, bool use_cuda_graph, int dpm_solver_steps,
+    std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances,
+    ModelInputType input_type);
   ~MultiStepInference() override;
 
   void load_engines(
     const std::string & encoder_model_path, const std::string & decoder_model_path,
     const std::string & turn_indicator_model_path);
-  InferenceResult infer(const preprocess::InputDataMap & input_data_map) override;
+  InferenceResult infer(
+    const preprocess::InputDataMap & input_data_map,
+    const std::vector<uint8_t> & bev_image) override;
 
 private:
   int batch_size_{1};
+  ModelInputType input_type_{ModelInputType::VECTOR};
   int dpm_solver_steps_{10};
   std::string plugins_path_;
   std::string precision_{"fp32"};
@@ -69,6 +75,7 @@ private:
   autoware::cuda_utils::CudaUniquePtr<float[]> sampled_trajectories_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> diffusion_time_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> ego_history_d_;
+  autoware::cuda_utils::CudaUniquePtr<float[]> ego_current_state_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> neighbor_agents_past_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> static_objects_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> lanes_d_;
@@ -82,6 +89,9 @@ private:
   autoware::cuda_utils::CudaUniquePtr<float[]> goal_pose_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> ego_shape_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> turn_indicators_d_;
+  // Bound only in ModelInputType::IMAGE; the graph declares it as uint8, straight from the
+  // renderer.
+  autoware::cuda_utils::CudaUniquePtr<uint8_t[]> bev_image_d_;
 
   autoware::cuda_utils::CudaUniquePtr<float[]> encoding_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> model_output_d_;
@@ -98,7 +108,8 @@ private:
   void bind_encoder_buffers();
   void bind_decoder_buffers();
   void bind_turn_indicator_buffers();
-  void transfer_inputs_to_device(const preprocess::InputDataMap & input_data_map);
+  void transfer_inputs_to_device(
+    const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image);
   DpmSolver::SampleResult run_dpm_solver(const preprocess::InputDataMap & input_data_map);
   std::vector<float> evaluate_decoder(const std::vector<float> & x, float t);
   std::vector<float> create_diffusion_time(float t) const;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/onnxruntime_inference.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/onnxruntime_inference.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__DIFFUSION_PLANNER__INFERENCE__ONNXRUNTIME_INFERENCE_HPP_
 #define AUTOWARE__DIFFUSION_PLANNER__INFERENCE__ONNXRUNTIME_INFERENCE_HPP_
 
+#include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/guidance/guidance.hpp"
 #include "autoware/diffusion_planner/inference/inference.hpp"
 #include "autoware/diffusion_planner/inference/solver/dpm_solver.hpp"
@@ -40,18 +41,36 @@ class OrtModel
 public:
   OrtModel(
     const std::string & model_path, OnnxruntimeExecutionProvider execution_provider,
-    const std::string & plugins_path = "");
+    const std::string & plugins_path);
 
+  /**
+   * @brief Feed the named inputs and read the named outputs.
+   *
+   * Shapes and element types come from the graph's own declarations, so a caller only supplies
+   * the payload. Every declared dimension except the leading batch is fixed; the batch is
+   * recovered from the payload size. Byte payloads cover both the BOOL and the UINT8 inputs -
+   * which of the two a name is, is again what the graph declares.
+   */
   std::unordered_map<std::string, std::vector<float>> run(
     const std::unordered_map<std::string, std::vector<float>> & float_inputs,
-    const std::unordered_map<std::string, std::vector<uint8_t>> & bool_inputs,
+    const std::unordered_map<std::string, std::vector<uint8_t>> & byte_inputs,
     const std::vector<std::string> & output_names);
 
 private:
+  struct InputSpec
+  {
+    std::vector<int64_t> shape;  // as declared, with the batch dimension left as -1
+    ONNXTensorElementDataType element_type;
+  };
+
+  const InputSpec & input_spec(const std::string & name) const;
+  std::vector<int64_t> shape_for(const std::string & name, size_t element_count) const;
+
   Ort::Env env_;
   Ort::SessionOptions session_options_;
   Ort::Session session_;
   Ort::MemoryInfo memory_info_;
+  std::unordered_map<std::string, InputSpec> input_specs_;
 };
 
 class OnnxruntimeSingleStepInference : public Inference
@@ -59,11 +78,14 @@ class OnnxruntimeSingleStepInference : public Inference
 public:
   OnnxruntimeSingleStepInference(
     const std::string & model_path, const std::string & execution_provider,
-    const std::string & plugins_path, int batch_size);
+    const std::string & plugins_path, int batch_size, ModelInputType input_type);
 
-  InferenceResult infer(const preprocess::InputDataMap & input_data_map) override;
+  InferenceResult infer(
+    const preprocess::InputDataMap & input_data_map,
+    const std::vector<uint8_t> & bev_image) override;
 
 private:
+  ModelInputType input_type_{ModelInputType::VECTOR};
   OrtModel model_;
 };
 
@@ -73,13 +95,17 @@ public:
   OnnxruntimeMultiStepInference(
     const std::string & encoder_model_path, const std::string & decoder_model_path,
     const std::string & turn_indicator_model_path, const std::string & execution_provider,
-    const std::string & plugins_path, int batch_size, int dpm_solver_steps = 10,
-    std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances = {});
+    const std::string & plugins_path, int batch_size, int dpm_solver_steps,
+    std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances,
+    ModelInputType input_type);
 
-  InferenceResult infer(const preprocess::InputDataMap & input_data_map) override;
+  InferenceResult infer(
+    const preprocess::InputDataMap & input_data_map,
+    const std::vector<uint8_t> & bev_image) override;
 
 private:
   int batch_size_{1};
+  ModelInputType input_type_{ModelInputType::VECTOR};
   int dpm_solver_steps_{10};
   std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances_;
   OrtModel encoder_model_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/single_step_inference.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/single_step_inference.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__DIFFUSION_PLANNER__INFERENCE__SINGLE_STEP_INFERENCE_HPP_
 #define AUTOWARE__DIFFUSION_PLANNER__INFERENCE__SINGLE_STEP_INFERENCE_HPP_
 
+#include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/inference.hpp"
 #include "autoware/diffusion_planner/inference/utils.hpp"
 #include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
@@ -24,6 +25,7 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -45,10 +47,11 @@ public:
    * @param model_path Path to the TensorRT model file.
    * @param plugins_path Path to TensorRT plugin shared libraries.
    * @param batch_size Batch size for inference buffers and shapes.
+   * @param input_type Scene representation the exported graph takes.
    */
   SingleStepInference(
     const std::string & model_path, const std::string & plugins_path, int batch_size,
-    const std::string & precision = "fp32", bool use_cuda_graph = false);
+    const std::string & precision, bool use_cuda_graph, ModelInputType input_type);
   ~SingleStepInference() override;
 
   /**
@@ -56,7 +59,9 @@ public:
    * @param input_data_map Input tensor data keyed by input names.
    * @return InferenceResult containing outputs or error message.
    */
-  InferenceResult infer(const preprocess::InputDataMap & input_data_map) override;
+  InferenceResult infer(
+    const preprocess::InputDataMap & input_data_map,
+    const std::vector<uint8_t> & bev_image) override;
   /**
    * @brief Load or rebuild the TensorRT engine from the given model path.
    * @param model_path Path to the TensorRT model file.
@@ -65,6 +70,7 @@ public:
 
 private:
   int batch_size_{1};
+  ModelInputType input_type_{ModelInputType::VECTOR};
   std::string plugins_path_;
   std::string precision_{"fp32"};
   bool use_cuda_graph_{false};
@@ -90,6 +96,9 @@ private:
   autoware::cuda_utils::CudaUniquePtr<float[]> ego_shape_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> turn_indicators_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> delay_d_;
+  // Bound only in ModelInputType::IMAGE; the graph declares it as uint8, straight from the
+  // renderer.
+  autoware::cuda_utils::CudaUniquePtr<uint8_t[]> bev_image_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> output_d_;
   autoware::cuda_utils::CudaUniquePtr<float[]> turn_indicator_logit_d_;
 
@@ -102,7 +111,8 @@ private:
   cudaStream_t stream_{nullptr};
 
   void bindBuffers();
-  void transferInputsToDevice(const preprocess::InputDataMap & input_data_map);
+  void transferInputsToDevice(
+    const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image);
 };
 
 }  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/inference/utils.hpp
@@ -110,6 +110,15 @@ void transfer_float_input(
 }
 
 template <class DevicePtr>
+void transfer_uint8_input(
+  const std::vector<uint8_t> & host_vec, const DevicePtr & device_ptr, cudaStream_t stream)
+{
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_ptr.get(), host_vec.data(), host_vec.size() * sizeof(uint8_t), cudaMemcpyHostToDevice,
+    stream));
+}
+
+template <class DevicePtr>
 void transfer_speed_mask(
   const std::vector<float> & speed_limit, const DevicePtr & device_ptr, const size_t count,
   cudaStream_t stream)

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/bev_image.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/bev_image.hpp
@@ -1,0 +1,82 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__PREPROCESSING__BEV_IMAGE_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__PREPROCESSING__BEV_IMAGE_HPP_
+
+#include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace autoware::diffusion_planner::preprocess
+{
+
+// Semantic plane each element is drawn onto. Every plane is its own binary mask, so overlapping
+// elements never hide each other. The order is part of the trained weights: the ResNet's first
+// convolution has one input plane per entry, in exactly this order.
+enum BevChannel {
+  BEV_CH_LANE_BOUNDARY = 0,
+  BEV_CH_LANE_CENTERLINE = 1,
+  BEV_CH_ROUTE = 2,
+  BEV_CH_TRAFFIC_LIGHT_GO = 3,       // green
+  BEV_CH_TRAFFIC_LIGHT_CAUTION = 4,  // yellow
+  BEV_CH_TRAFFIC_LIGHT_STOP = 5,     // red
+  BEV_CH_TRAFFIC_LIGHT_UNKNOWN = 6,  // has a light, colour unknown or never received
+  BEV_CH_POLYGON = 7,
+  BEV_CH_LINE_STRING = 8,
+  BEV_CH_STATIC_OBJECT = 9,
+  BEV_CH_GOAL_POSE = 10,
+  BEV_CH_VEHICLE = 11,
+  BEV_CH_PEDESTRIAN = 12,
+  BEV_CH_BICYCLE = 13,
+  BEV_CH_EGO = 14,
+  BEV_CH_NEIGHBOR_HISTORY = 15,
+  BEV_CH_EGO_HISTORY = 16,
+};
+
+/**
+ * @brief Rasterize the vector scene of one frame into the BEV stack the image encoder consumes.
+ *
+ * Mirrors diffusion_planner/utils/render_bev.py: one image per spatial scale
+ * (BEV_VIEW_EXTENTS_M), each a stack of BEV_NUM_CHANNELS binary masks centered on the current ego
+ * pose with the ego heading pointing up. An extent is the full side length of a view, so the
+ * 50 m scale reaches +/-25 m around the ego. Motion is carried by the history channels - an
+ * agent's past track is drawn as a polyline ending at that agent's current bounding box - so no
+ * per-timestep raster is needed.
+ *
+ * @param input_data_map Un-normalized model inputs, i.e. meters, exactly as create_input_data
+ *                       returns them. Every key read here is batch-replicated from the same
+ *                       single frame, so only the first batch entry is rasterized.
+ * @param batch_size     Number of identical copies to emit, matching the other input tensors.
+ * @return Row-major [batch_size, BEV_NUM_SCALES, BEV_NUM_CHANNELS, BEV_IMAGE_SIZE,
+ *         BEV_IMAGE_SIZE] bytes, each either 0 or 255.
+ */
+std::vector<uint8_t> create_bev_image(const InputDataMap & input_data_map, int64_t batch_size);
+
+/**
+ * @brief Composite one scale of a rendered stack into a BGR preview, for debugging only.
+ *
+ * Mirrors render_bev.py::colorize, including the draw order that keeps the agents visible on top
+ * of the map.
+ *
+ * @param bev_image Output of create_bev_image; only its first batch entry is read.
+ * @param scale     Index into BEV_VIEW_EXTENTS_M.
+ * @return Row-major [BEV_IMAGE_SIZE, BEV_IMAGE_SIZE, 3] BGR bytes.
+ */
+std::vector<uint8_t> colorize_bev_image(const std::vector<uint8_t> & bev_image, int64_t scale);
+
+}  // namespace autoware::diffusion_planner::preprocess
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__PREPROCESSING__BEV_IMAGE_HPP_

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/arg_reader.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/arg_reader.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__DIFFUSION_PLANNER__UTILS__ARG_READER_HPP_
 
 #include "autoware/diffusion_planner/constants.hpp"
+#include "autoware/diffusion_planner/dimensions.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -75,6 +76,35 @@ inline void check_weight_version(const std::string & json_path)
     throw std::runtime_error(
       "Unsupported major_version: " + std::to_string(major_version) + ". " + error_msg);
   }
+}
+
+inline ModelInputType load_model_input_type(const std::string & json_path)
+{
+  std::ifstream file(json_path);
+  if (!file) {
+    throw std::runtime_error("Could not open JSON file: " + json_path);
+  }
+
+  json j;
+  file >> j;
+
+  // Checkpoints trained before the image encoder existed carry no "input_type"; they are all
+  // vector runs, and the training code reads the field the same way (see
+  // diffusion_planner/model/diffusion_planner.py::build_encoder).
+  if (!j.contains("input_type")) {
+    return ModelInputType::VECTOR;
+  }
+
+  const std::string input_type = j["input_type"].get<std::string>();
+  if (input_type == "vector") {
+    return ModelInputType::VECTOR;
+  }
+  if (input_type == "image") {
+    return ModelInputType::IMAGE;
+  }
+  throw std::runtime_error(
+    "Unsupported 'input_type' in " + json_path + ": '" + input_type +
+    "'. Expected 'vector' or 'image'.");
 }
 
 inline ObservationNormalization load_observation_normalization(const std::string & json_path)

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -42,10 +42,12 @@
   <depend>lanelet2_routing</depend>
   <depend>lanelet2_traffic_rules</depend>
   <depend>libexpected-dev</depend>
+  <depend>libopencv-dev</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>visualization_msgs</depend>

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -335,9 +335,19 @@
               "type": "boolean",
               "default": true,
               "description": "Publish debug linestring markers"
+            },
+            "publish_debug_bev_image": {
+              "type": "boolean",
+              "default": false,
+              "description": "Publish a colorized preview of the rendered BEV rasters, one image per scale. Only meaningful for a model whose encoder takes image input."
             }
           },
-          "required": ["publish_debug_map", "publish_debug_route", "publish_debug_linestrings"]
+          "required": [
+            "publish_debug_map",
+            "publish_debug_route",
+            "publish_debug_linestrings",
+            "publish_debug_bev_image"
+          ]
         }
       },
       "required": [

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -23,6 +23,7 @@
 #include "autoware/diffusion_planner/inference/multi_step_inference.hpp"
 #include "autoware/diffusion_planner/inference/single_step_inference.hpp"
 #include "autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp"
+#include "autoware/diffusion_planner/preprocessing/bev_image.hpp"
 #include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
@@ -106,6 +107,7 @@ void DiffusionPlannerCore::load_model()
   last_ego_to_map_transform_.reset();
   diffusion_planner_inference_.reset();
   utils::check_weight_version(params_.args_path);
+  model_input_type_ = utils::load_model_input_type(params_.args_path);
   observation_normalization_ = utils::load_observation_normalization(params_.args_path);
   state_normalization_ = utils::load_state_normalization(params_.args_path);
 
@@ -146,22 +148,22 @@ void DiffusionPlannerCore::load_model()
   if (params_.backend == "tensorrt" && params_.model_type == "single_step") {
     diffusion_planner_inference_ = std::make_unique<SingleStepInference>(
       params_.single_step_model_path, params_.plugins_path, params_.batch_size,
-      params_.trt_precision, params_.use_cuda_graph);
+      params_.trt_precision, params_.use_cuda_graph, model_input_type_);
   } else if (params_.backend == "tensorrt" && params_.model_type == "multi_step") {
     diffusion_planner_inference_ = std::make_unique<MultiStepInference>(
       params_.encoder_model_path, params_.decoder_model_path, params_.turn_indicator_model_path,
       params_.plugins_path, params_.batch_size, params_.trt_precision, params_.use_cuda_graph,
-      params_.dpm_solver_steps, std::move(guidances));
+      params_.dpm_solver_steps, std::move(guidances), model_input_type_);
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ONNXRUNTIME
   } else if (is_onnxruntime_backend(params_.backend) && params_.model_type == "single_step") {
     diffusion_planner_inference_ = std::make_unique<OnnxruntimeSingleStepInference>(
       params_.single_step_model_path, onnxruntime_execution_provider_from_backend(params_.backend),
-      params_.plugins_path, params_.batch_size);
+      params_.plugins_path, params_.batch_size, model_input_type_);
   } else if (is_onnxruntime_backend(params_.backend) && params_.model_type == "multi_step") {
     diffusion_planner_inference_ = std::make_unique<OnnxruntimeMultiStepInference>(
       params_.encoder_model_path, params_.decoder_model_path, params_.turn_indicator_model_path,
       onnxruntime_execution_provider_from_backend(params_.backend), params_.plugins_path,
-      params_.batch_size, params_.dpm_solver_steps, std::move(guidances));
+      params_.batch_size, params_.dpm_solver_steps, std::move(guidances), model_input_type_);
 #endif
   } else {
     if (params_.backend != "tensorrt") {
@@ -591,12 +593,23 @@ InputDataMap DiffusionPlannerCore::create_input_data(const FrameContext & frame_
   return input_data_map;
 }
 
-InferenceResult DiffusionPlannerCore::run_inference(const InputDataMap & input_data_map)
+std::vector<uint8_t> DiffusionPlannerCore::create_bev_image(
+  const InputDataMap & input_data_map) const
+{
+  if (model_input_type_ == ModelInputType::VECTOR) {
+    // The vector encoder reads the polylines and agent states directly; no raster is needed.
+    return {};
+  }
+  return preprocess::create_bev_image(input_data_map, params_.batch_size);
+}
+
+InferenceResult DiffusionPlannerCore::run_inference(
+  const InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   if (!diffusion_planner_inference_) {
     return tl::unexpected(std::string{"Model not loaded"});
   }
-  return diffusion_planner_inference_->infer(input_data_map);
+  return diffusion_planner_inference_->infer(input_data_map, bev_image);
 }
 
 PlannerOutput DiffusionPlannerCore::create_planner_output(

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/diffusion_planner/constants.hpp"
 #include "autoware/diffusion_planner/dimensions.hpp"
+#include "autoware/diffusion_planner/preprocessing/bev_image.hpp"
 #include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
 #include "autoware/diffusion_planner/utils/marker_utils.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
@@ -26,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -99,6 +101,11 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     this->create_publisher<std_msgs::msg::Float64>("~/debug/inference_time_ms", 1);
   pub_denoising_steps_ =
     this->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/denoising_steps", 1);
+  for (int64_t scale = 0; scale < BEV_NUM_SCALES; ++scale) {
+    const auto extent_m = static_cast<int64_t>(BEV_VIEW_EXTENTS_M[scale]);
+    pub_bev_images_.push_back(this->create_publisher<sensor_msgs::msg::Image>(
+      "~/debug/bev_image_" + std::to_string(extent_m) + "m", 1));
+  }
   pub_guidance_status_ = this->create_publisher<autoware_internal_debug_msgs::msg::StringStamped>(
     "~/debug/guidance_status", 1);
 
@@ -252,6 +259,8 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<bool>("debug_params.publish_debug_route", true);
   debug_params_.publish_debug_linestrings =
     this->declare_parameter<bool>("debug_params.publish_debug_linestrings", true);
+  debug_params_.publish_debug_bev_image =
+    this->declare_parameter<bool>("debug_params.publish_debug_bev_image", false);
 }
 
 void DiffusionPlanner::load_model()
@@ -441,6 +450,9 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<bool>(
       parameters, "debug_params.publish_debug_linestrings",
       temp_debug_params.publish_debug_linestrings);
+    update_param<bool>(
+      parameters, "debug_params.publish_debug_bev_image",
+      temp_debug_params.publish_debug_bev_image);
     debug_params_ = temp_debug_params;
   }
 
@@ -510,6 +522,27 @@ void DiffusionPlanner::publish_snapped_pose(
   interpolation_time_msg.stamp = timestamp;
   interpolation_time_msg.data = frame_context.snapped_interpolation_time_s.value();
   pub_snap_interpolation_time_->publish(interpolation_time_msg);
+}
+
+void DiffusionPlanner::publish_debug_bev_image(
+  const std::vector<uint8_t> & bev_image, const rclcpp::Time & timestamp)
+{
+  if (!debug_params_.publish_debug_bev_image || bev_image.empty()) {
+    return;
+  }
+
+  for (int64_t scale = 0; scale < BEV_NUM_SCALES; ++scale) {
+    sensor_msgs::msg::Image msg;
+    msg.header.stamp = timestamp;
+    msg.header.frame_id = "base_link";
+    msg.height = static_cast<uint32_t>(BEV_IMAGE_SIZE);
+    msg.width = static_cast<uint32_t>(BEV_IMAGE_SIZE);
+    msg.encoding = "bgr8";
+    msg.is_bigendian = 0U;
+    msg.step = static_cast<uint32_t>(BEV_IMAGE_SIZE * 3);
+    msg.data = preprocess::colorize_bev_image(bev_image, scale);
+    pub_bev_images_[static_cast<size_t>(scale)]->publish(msg);
+  }
 }
 
 void DiffusionPlanner::publish_debug_markers(
@@ -609,8 +642,11 @@ void DiffusionPlanner::on_timer()
 
   const rclcpp::Time frame_time(frame_context->frame_time);
   InputDataMap input_data_map = core_->create_input_data(*frame_context);
+  // The rasterizer reads meters, so it has to run before the normalization below.
+  const std::vector<uint8_t> bev_image = core_->create_bev_image(input_data_map);
 
   publish_debug_markers(input_data_map, frame_context->ego_to_map_transform, frame_time);
+  publish_debug_bev_image(bev_image, frame_time);
 
   publish_first_traffic_light_on_route(*frame_context);
 
@@ -641,7 +677,7 @@ void DiffusionPlanner::on_timer()
   }
 
   // Run inference using core
-  auto inference_result = core_->run_inference(input_data_map);
+  auto inference_result = core_->run_inference(input_data_map, bev_image);
 
   if (!inference_result) {
     RCLCPP_WARN_STREAM_THROTTLE(

--- a/planning/autoware_diffusion_planner/src/inference/multi_step_inference.cpp
+++ b/planning/autoware_diffusion_planner/src/inference/multi_step_inference.cpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -37,15 +38,17 @@ MultiStepInference::MultiStepInference(
   const std::string & encoder_model_path, const std::string & decoder_model_path,
   const std::string & turn_indicator_model_path, const std::string & plugins_path, int batch_size,
   const std::string & precision, bool use_cuda_graph, int dpm_solver_steps,
-  std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances)
+  std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances, ModelInputType input_type)
 : batch_size_(batch_size),
+  input_type_(input_type),
   dpm_solver_steps_(dpm_solver_steps),
   plugins_path_(plugins_path),
   precision_(precision),
   use_cuda_graph_(use_cuda_graph),
   guidances_(std::move(guidances))
 {
-  const std::vector<int64_t> encoding_shape = {batch_size_, ENCODING_TOKEN_NUM, HIDDEN_DIM};
+  const std::vector<int64_t> encoding_shape = {
+    batch_size_, encoding_token_num(input_type_), HIDDEN_DIM};
   const std::vector<int64_t> diffusion_time_shape = {batch_size_, MAX_NUM_AGENTS, OUTPUT_T + 1, 1};
   const std::vector<int64_t> model_output_shape = {
     batch_size_, MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM};
@@ -56,6 +59,8 @@ MultiStepInference::MultiStepInference(
     autoware::cuda_utils::make_unique<float[]>(num_elements(diffusion_time_shape));
   ego_history_d_ = autoware::cuda_utils::make_unique<float[]>(
     batch_size_ * num_elements_without_batch(EGO_HISTORY_SHAPE));
+  ego_current_state_d_ = autoware::cuda_utils::make_unique<float[]>(
+    batch_size_ * num_elements_without_batch(EGO_CURRENT_STATE_SHAPE));
   neighbor_agents_past_d_ = autoware::cuda_utils::make_unique<float[]>(
     batch_size_ * num_elements_without_batch(NEIGHBOR_SHAPE));
   static_objects_d_ = autoware::cuda_utils::make_unique<float[]>(
@@ -82,6 +87,10 @@ MultiStepInference::MultiStepInference(
     batch_size_ * num_elements_without_batch(EGO_SHAPE_SHAPE));
   turn_indicators_d_ = autoware::cuda_utils::make_unique<float[]>(
     batch_size_ * num_elements_without_batch(TURN_INDICATORS_SHAPE));
+  // Every buffer above is allocated in both modes - together they are a few MB - so only the
+  // engine bindings below actually differ per input type.
+  bev_image_d_ = autoware::cuda_utils::make_unique<uint8_t[]>(
+    batch_size_ * num_elements_without_batch(BEV_IMAGE_SHAPE));
 
   encoding_num_elements_ = num_elements(encoding_shape);
   model_output_num_elements_ = num_elements(model_output_shape);
@@ -109,7 +118,7 @@ void MultiStepInference::load_engines(
   const std::string & encoder_model_path, const std::string & decoder_model_path,
   const std::string & turn_indicator_model_path)
 {
-  const std::vector<int64_t> encoding_shape = {1, ENCODING_TOKEN_NUM, HIDDEN_DIM};
+  const std::vector<int64_t> encoding_shape = {1, encoding_token_num(input_type_), HIDDEN_DIM};
   const std::vector<int64_t> diffusion_time_shape = {1, MAX_NUM_AGENTS, OUTPUT_T + 1, 1};
   const std::vector<int64_t> model_output_shape = {1, MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM};
 
@@ -120,20 +129,28 @@ void MultiStepInference::load_engines(
     encoder_profile_dims.emplace_back(make_profile_dims(name, dims, batch_size_));
     encoder_network_io.emplace_back(name, dims);
   };
-  add_encoder_tensor("ego_agent_past", EGO_HISTORY_SHAPE);
-  add_encoder_tensor("neighbor_agents_past", NEIGHBOR_SHAPE);
-  add_encoder_tensor("static_objects", STATIC_OBJECTS_SHAPE);
-  add_encoder_tensor("lanes", LANES_SHAPE);
-  add_encoder_tensor("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE);
-  add_encoder_tensor("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE);
-  add_encoder_tensor("route_lanes", ROUTE_LANES_SHAPE);
-  add_encoder_tensor("route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE);
-  add_encoder_tensor("route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE);
-  add_encoder_tensor("polygons", POLYGONS_SHAPE);
-  add_encoder_tensor("line_strings", LINE_STRINGS_SHAPE);
-  add_encoder_tensor("goal_pose", GOAL_POSE_SHAPE);
-  add_encoder_tensor("ego_shape", EGO_SHAPE_SHAPE);
   add_encoder_tensor("turn_indicators", TURN_INDICATORS_SHAPE);
+  if (input_type_ == ModelInputType::IMAGE) {
+    // The raster replaces every drawable element; what is left are the scene facts with no pixel
+    // representation, i.e. the ego motion inside ego_current_state and the turn indicators (see
+    // image_encoder.py).
+    add_encoder_tensor("bev_image", BEV_IMAGE_SHAPE);
+    add_encoder_tensor("ego_current_state", EGO_CURRENT_STATE_SHAPE);
+  } else {
+    add_encoder_tensor("ego_agent_past", EGO_HISTORY_SHAPE);
+    add_encoder_tensor("neighbor_agents_past", NEIGHBOR_SHAPE);
+    add_encoder_tensor("static_objects", STATIC_OBJECTS_SHAPE);
+    add_encoder_tensor("lanes", LANES_SHAPE);
+    add_encoder_tensor("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE);
+    add_encoder_tensor("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE);
+    add_encoder_tensor("route_lanes", ROUTE_LANES_SHAPE);
+    add_encoder_tensor("route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE);
+    add_encoder_tensor("route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE);
+    add_encoder_tensor("polygons", POLYGONS_SHAPE);
+    add_encoder_tensor("line_strings", LINE_STRINGS_SHAPE);
+    add_encoder_tensor("goal_pose", GOAL_POSE_SHAPE);
+    add_encoder_tensor("ego_shape", EGO_SHAPE_SHAPE);
+  }
   encoder_network_io.emplace_back("encoding", to_dynamic_dims(encoding_shape, batch_size_));
 
   encoder_trt_ptr_ = setup_engine(
@@ -180,53 +197,46 @@ void MultiStepInference::load_engines(
 
 void MultiStepInference::bind_encoder_buffers()
 {
-  encoder_trt_ptr_->setInputShape(
-    "ego_agent_past", to_dims_with_batch(EGO_HISTORY_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "neighbor_agents_past", to_dims_with_batch(NEIGHBOR_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "static_objects", to_dims_with_batch(STATIC_OBJECTS_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape("lanes", to_dims_with_batch(LANES_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "lanes_speed_limit", to_dims_with_batch(LANES_SPEED_LIMIT_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "lanes_has_speed_limit", to_dims_with_batch(LANES_HAS_SPEED_LIMIT_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "route_lanes", to_dims_with_batch(ROUTE_LANES_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "route_lanes_speed_limit", to_dims_with_batch(ROUTE_LANES_SPEED_LIMIT_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "route_lanes_has_speed_limit",
-    to_dims_with_batch(ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape("polygons", to_dims_with_batch(POLYGONS_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "line_strings", to_dims_with_batch(LINE_STRINGS_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape("goal_pose", to_dims_with_batch(GOAL_POSE_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape("ego_shape", to_dims_with_batch(EGO_SHAPE_SHAPE, batch_size_));
-  encoder_trt_ptr_->setInputShape(
-    "turn_indicators", to_dims_with_batch(TURN_INDICATORS_SHAPE, batch_size_));
+  const auto bind_float = [this](const char * name, const auto & shape, float * buffer) {
+    encoder_trt_ptr_->setInputShape(name, to_dims_with_batch(shape, batch_size_));
+    encoder_trt_ptr_->setTensorAddress(name, buffer);
+  };
+  const auto bind_bool = [this](const char * name, const auto & shape, bool * buffer) {
+    encoder_trt_ptr_->setInputShape(name, to_dims_with_batch(shape, batch_size_));
+    encoder_trt_ptr_->setTensorAddress(name, buffer);
+  };
 
-  encoder_trt_ptr_->setTensorAddress("ego_agent_past", ego_history_d_.get());
-  encoder_trt_ptr_->setTensorAddress("neighbor_agents_past", neighbor_agents_past_d_.get());
-  encoder_trt_ptr_->setTensorAddress("static_objects", static_objects_d_.get());
-  encoder_trt_ptr_->setTensorAddress("lanes", lanes_d_.get());
-  encoder_trt_ptr_->setTensorAddress("lanes_speed_limit", lanes_speed_limit_d_.get());
-  encoder_trt_ptr_->setTensorAddress("lanes_has_speed_limit", lanes_has_speed_limit_d_.get());
-  encoder_trt_ptr_->setTensorAddress("route_lanes", route_lanes_d_.get());
-  encoder_trt_ptr_->setTensorAddress("route_lanes_speed_limit", route_lanes_speed_limit_d_.get());
-  encoder_trt_ptr_->setTensorAddress(
-    "route_lanes_has_speed_limit", route_lanes_has_speed_limit_d_.get());
-  encoder_trt_ptr_->setTensorAddress("polygons", polygons_d_.get());
-  encoder_trt_ptr_->setTensorAddress("line_strings", line_strings_d_.get());
-  encoder_trt_ptr_->setTensorAddress("goal_pose", goal_pose_d_.get());
-  encoder_trt_ptr_->setTensorAddress("ego_shape", ego_shape_d_.get());
-  encoder_trt_ptr_->setTensorAddress("turn_indicators", turn_indicators_d_.get());
+  bind_float("turn_indicators", TURN_INDICATORS_SHAPE, turn_indicators_d_.get());
+
+  if (input_type_ == ModelInputType::IMAGE) {
+    encoder_trt_ptr_->setInputShape("bev_image", to_dims_with_batch(BEV_IMAGE_SHAPE, batch_size_));
+    encoder_trt_ptr_->setTensorAddress("bev_image", bev_image_d_.get());
+    bind_float("ego_current_state", EGO_CURRENT_STATE_SHAPE, ego_current_state_d_.get());
+  } else {
+    bind_float("ego_agent_past", EGO_HISTORY_SHAPE, ego_history_d_.get());
+    bind_float("neighbor_agents_past", NEIGHBOR_SHAPE, neighbor_agents_past_d_.get());
+    bind_float("static_objects", STATIC_OBJECTS_SHAPE, static_objects_d_.get());
+    bind_float("lanes", LANES_SHAPE, lanes_d_.get());
+    bind_float("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE, lanes_speed_limit_d_.get());
+    bind_bool("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE, lanes_has_speed_limit_d_.get());
+    bind_float("route_lanes", ROUTE_LANES_SHAPE, route_lanes_d_.get());
+    bind_float(
+      "route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE, route_lanes_speed_limit_d_.get());
+    bind_bool(
+      "route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE,
+      route_lanes_has_speed_limit_d_.get());
+    bind_float("polygons", POLYGONS_SHAPE, polygons_d_.get());
+    bind_float("line_strings", LINE_STRINGS_SHAPE, line_strings_d_.get());
+    bind_float("goal_pose", GOAL_POSE_SHAPE, goal_pose_d_.get());
+    bind_float("ego_shape", EGO_SHAPE_SHAPE, ego_shape_d_.get());
+  }
+
   encoder_trt_ptr_->setTensorAddress("encoding", encoding_d_.get());
 }
 
 void MultiStepInference::bind_decoder_buffers()
 {
-  const std::vector<int64_t> encoding_shape = {1, ENCODING_TOKEN_NUM, HIDDEN_DIM};
+  const std::vector<int64_t> encoding_shape = {1, encoding_token_num(input_type_), HIDDEN_DIM};
   const std::vector<int64_t> diffusion_time_shape = {1, MAX_NUM_AGENTS, OUTPUT_T + 1, 1};
 
   decoder_trt_ptr_->setInputShape("encoding", to_dims_with_batch(encoding_shape, batch_size_));
@@ -246,7 +256,7 @@ void MultiStepInference::bind_decoder_buffers()
 
 void MultiStepInference::bind_turn_indicator_buffers()
 {
-  const std::vector<int64_t> encoding_shape = {1, ENCODING_TOKEN_NUM, HIDDEN_DIM};
+  const std::vector<int64_t> encoding_shape = {1, encoding_token_num(input_type_), HIDDEN_DIM};
   const std::vector<int64_t> final_x0_shape = {1, MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM};
 
   turn_indicator_trt_ptr_->setInputShape(
@@ -259,11 +269,29 @@ void MultiStepInference::bind_turn_indicator_buffers()
   turn_indicator_trt_ptr_->setTensorAddress("turn_indicator_logit", turn_indicator_logit_d_.get());
 }
 
-void MultiStepInference::transfer_inputs_to_device(const preprocess::InputDataMap & input_data_map)
+void MultiStepInference::transfer_inputs_to_device(
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   transfer_float_input(input_data_map.at("sampled_trajectories"), sampled_trajectories_d_, stream_);
-  transfer_float_input(input_data_map.at("ego_agent_past"), ego_history_d_, stream_);
+  // The decoder reads neighbor_agents_past in both modes.
   transfer_float_input(input_data_map.at("neighbor_agents_past"), neighbor_agents_past_d_, stream_);
+  transfer_float_input(input_data_map.at("turn_indicators"), turn_indicators_d_, stream_);
+
+  const auto diffusion_time_it = input_data_map.find("diffusion_time");
+  if (diffusion_time_it != input_data_map.end()) {
+    transfer_float_input(diffusion_time_it->second, diffusion_time_d_, stream_);
+  } else {
+    const std::vector<float> diffusion_time(batch_size_ * MAX_NUM_AGENTS * (OUTPUT_T + 1), 1.0f);
+    transfer_float_input(diffusion_time, diffusion_time_d_, stream_);
+  }
+
+  if (input_type_ == ModelInputType::IMAGE) {
+    transfer_uint8_input(bev_image, bev_image_d_, stream_);
+    transfer_float_input(input_data_map.at("ego_current_state"), ego_current_state_d_, stream_);
+    return;
+  }
+
+  transfer_float_input(input_data_map.at("ego_agent_past"), ego_history_d_, stream_);
   transfer_float_input(input_data_map.at("static_objects"), static_objects_d_, stream_);
   transfer_float_input(input_data_map.at("lanes"), lanes_d_, stream_);
   transfer_float_input(input_data_map.at("lanes_speed_limit"), lanes_speed_limit_d_, stream_);
@@ -274,15 +302,6 @@ void MultiStepInference::transfer_inputs_to_device(const preprocess::InputDataMa
   transfer_float_input(input_data_map.at("line_strings"), line_strings_d_, stream_);
   transfer_float_input(input_data_map.at("goal_pose"), goal_pose_d_, stream_);
   transfer_float_input(input_data_map.at("ego_shape"), ego_shape_d_, stream_);
-  transfer_float_input(input_data_map.at("turn_indicators"), turn_indicators_d_, stream_);
-
-  const auto diffusion_time_it = input_data_map.find("diffusion_time");
-  if (diffusion_time_it != input_data_map.end()) {
-    transfer_float_input(diffusion_time_it->second, diffusion_time_d_, stream_);
-  } else {
-    const std::vector<float> diffusion_time(batch_size_ * MAX_NUM_AGENTS * (OUTPUT_T + 1), 1.0f);
-    transfer_float_input(diffusion_time, diffusion_time_d_, stream_);
-  }
 
   transfer_speed_mask(
     input_data_map.at("lanes_speed_limit"), lanes_has_speed_limit_d_,
@@ -381,11 +400,11 @@ DpmSolver::SampleResult MultiStepInference::run_dpm_solver(
 }
 
 MultiStepInference::InferenceResult MultiStepInference::infer(
-  const preprocess::InputDataMap & input_data_map)
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   auto start = std::chrono::steady_clock::now();
 
-  transfer_inputs_to_device(input_data_map);
+  transfer_inputs_to_device(input_data_map, bev_image);
 
   bool status = enqueue_trt(*encoder_trt_ptr_, encoder_cuda_graph_, stream_, use_cuda_graph_);
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));

--- a/planning/autoware_diffusion_planner/src/inference/onnxruntime_inference.cpp
+++ b/planning/autoware_diffusion_planner/src/inference/onnxruntime_inference.cpp
@@ -33,11 +33,6 @@ namespace autoware::diffusion_planner
 {
 namespace
 {
-size_t num_elements_from_shape(const std::vector<int64_t> & shape)
-{
-  return std::accumulate(shape.begin(), shape.end(), size_t{1}, std::multiplies<>());
-}
-
 std::vector<uint8_t> make_speed_mask(const std::vector<float> & speed_limit)
 {
   std::vector<uint8_t> mask(speed_limit.size(), 0);
@@ -89,28 +84,16 @@ void append_tensorrt_provider(
   Ort::GetApi().ReleaseTensorRTProviderOptions(trt_options);
 }
 
-std::vector<FloatInput> single_step_float_inputs(const preprocess::InputDataMap & input_data_map)
+std::vector<FloatInput> encoder_float_inputs(
+  const preprocess::InputDataMap & input_data_map, const ModelInputType input_type)
 {
-  return {
-    {"sampled_trajectories", &input_data_map.at("sampled_trajectories")},
-    {"ego_agent_past", &input_data_map.at("ego_agent_past")},
-    {"ego_current_state", &input_data_map.at("ego_current_state")},
-    {"neighbor_agents_past", &input_data_map.at("neighbor_agents_past")},
-    {"static_objects", &input_data_map.at("static_objects")},
-    {"lanes", &input_data_map.at("lanes")},
-    {"lanes_speed_limit", &input_data_map.at("lanes_speed_limit")},
-    {"route_lanes", &input_data_map.at("route_lanes")},
-    {"route_lanes_speed_limit", &input_data_map.at("route_lanes_speed_limit")},
-    {"polygons", &input_data_map.at("polygons")},
-    {"line_strings", &input_data_map.at("line_strings")},
-    {"goal_pose", &input_data_map.at("goal_pose")},
-    {"ego_shape", &input_data_map.at("ego_shape")},
-    {"turn_indicators", &input_data_map.at("turn_indicators")},
-    {"delay", &input_data_map.at("delay")}};
-}
-
-std::vector<FloatInput> encoder_float_inputs(const preprocess::InputDataMap & input_data_map)
-{
+  if (input_type == ModelInputType::IMAGE) {
+    // Everything drawable is in the raster; only the scene facts with no pixel representation
+    // stay as tensors (see image_encoder.py).
+    return {
+      {"ego_current_state", &input_data_map.at("ego_current_state")},
+      {"turn_indicators", &input_data_map.at("turn_indicators")}};
+  }
   return {
     {"ego_agent_past", &input_data_map.at("ego_agent_past")},
     {"neighbor_agents_past", &input_data_map.at("neighbor_agents_past")},
@@ -126,12 +109,39 @@ std::vector<FloatInput> encoder_float_inputs(const preprocess::InputDataMap & in
     {"turn_indicators", &input_data_map.at("turn_indicators")}};
 }
 
+// The full graph takes the sampled trajectories and the control delay on top of whatever its
+// encoder reads.
+std::vector<FloatInput> single_step_float_inputs(
+  const preprocess::InputDataMap & input_data_map, const ModelInputType input_type)
+{
+  std::vector<FloatInput> inputs = encoder_float_inputs(input_data_map, input_type);
+  inputs.push_back({"sampled_trajectories", &input_data_map.at("sampled_trajectories")});
+  inputs.push_back({"delay", &input_data_map.at("delay")});
+  if (input_type == ModelInputType::IMAGE) {
+    // The decoder reads the neighbor histories even though the image encoder does not.
+    inputs.push_back({"neighbor_agents_past", &input_data_map.at("neighbor_agents_past")});
+  }
+  return inputs;
+}
+
 std::unordered_map<std::string, std::vector<uint8_t>> speed_limit_bool_inputs(
   const preprocess::InputDataMap & input_data_map)
 {
   return {
     {"lanes_has_speed_limit", make_speed_mask(input_data_map.at("lanes_speed_limit"))},
     {"route_lanes_has_speed_limit", make_speed_mask(input_data_map.at("route_lanes_speed_limit"))}};
+}
+
+// Encoder-side byte inputs: the speed-limit flags for the vector encoder, the raster for the
+// image encoder.
+std::unordered_map<std::string, std::vector<uint8_t>> encoder_byte_inputs(
+  const preprocess::InputDataMap & input_data_map, const ModelInputType input_type,
+  const std::vector<uint8_t> & bev_image)
+{
+  if (input_type == ModelInputType::IMAGE) {
+    return {{"bev_image", bev_image}};
+  }
+  return speed_limit_bool_inputs(input_data_map);
 }
 
 std::unordered_map<std::string, std::vector<float>> to_float_input_map(
@@ -181,142 +191,99 @@ OrtModel::OrtModel(
   }
 
   session_ = Ort::Session(env_, model_path.c_str(), session_options_);
+
+  // Cache what the graph declares about each input, so callers only ever supply payloads. Every
+  // dimension but the leading batch is fixed in these exports, and the declared element type is
+  // what decides whether a byte payload becomes a BOOL or a UINT8 tensor.
+  Ort::AllocatorWithDefaultOptions allocator;
+  const size_t input_count = session_.GetInputCount();
+  for (size_t i = 0; i < input_count; ++i) {
+    const Ort::AllocatedStringPtr name = session_.GetInputNameAllocated(i, allocator);
+    // GetTensorTypeAndShapeInfo hands back a non-owning view, so the TypeInfo has to outlive it.
+    const Ort::TypeInfo type_info = session_.GetInputTypeInfo(i);
+    const auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+    input_specs_.emplace(
+      std::string{name.get()}, InputSpec{tensor_info.GetShape(), tensor_info.GetElementType()});
+  }
+}
+
+const OrtModel::InputSpec & OrtModel::input_spec(const std::string & name) const
+{
+  const auto it = input_specs_.find(name);
+  if (it == input_specs_.end()) {
+    throw std::runtime_error("The ONNX graph declares no input named " + name);
+  }
+  return it->second;
+}
+
+std::vector<int64_t> OrtModel::shape_for(const std::string & name, const size_t element_count) const
+{
+  std::vector<int64_t> shape = input_spec(name).shape;
+  if (shape.empty()) {
+    throw std::runtime_error("Input " + name + " is declared as a scalar");
+  }
+
+  const size_t elements_per_batch = std::accumulate(
+    shape.begin() + 1, shape.end(), size_t{1}, [&name](const size_t product, const int64_t dim) {
+      if (dim <= 0) {
+        throw std::runtime_error("Input " + name + " has a non-batch dynamic dimension");
+      }
+      return product * static_cast<size_t>(dim);
+    });
+  if (element_count % elements_per_batch != 0) {
+    throw std::runtime_error("Input size mismatch for " + name);
+  }
+  shape[0] = static_cast<int64_t>(element_count / elements_per_batch);
+  return shape;
 }
 
 std::unordered_map<std::string, std::vector<float>> OrtModel::run(
   const std::unordered_map<std::string, std::vector<float>> & float_inputs,
-  const std::unordered_map<std::string, std::vector<uint8_t>> & bool_inputs,
+  const std::unordered_map<std::string, std::vector<uint8_t>> & byte_inputs,
   const std::vector<std::string> & output_names)
 {
   std::vector<std::string> input_names;
   std::vector<const char *> input_name_ptrs;
   std::vector<Ort::Value> input_tensors;
-  const auto input_count = float_inputs.size() + bool_inputs.size();
+  std::vector<std::vector<int64_t>> input_shapes;
+  const auto input_count = float_inputs.size() + byte_inputs.size();
   input_names.reserve(input_count);
   input_name_ptrs.reserve(input_count);
   input_tensors.reserve(input_count);
+  input_shapes.reserve(input_count);
 
-  const auto add_float_tensor = [&](
-                                  const std::string & name, const std::vector<float> & data,
-                                  const std::vector<int64_t> & shape) {
-    if (data.size() != num_elements_from_shape(shape)) {
-      throw std::runtime_error("Input size mismatch for " + name);
-    }
+  const auto push_name = [&](const std::string & name) {
     input_names.push_back(name);
     input_name_ptrs.push_back(input_names.back().c_str());
-    input_tensors.push_back(
-      Ort::Value::CreateTensor<float>(
-        memory_info_, const_cast<float *>(data.data()), data.size(), shape.data(), shape.size()));
-  };
-
-  const auto add_bool_tensor = [&](
-                                 const std::string & name, const std::vector<uint8_t> & data,
-                                 const std::vector<int64_t> & shape) {
-    if (data.size() != num_elements_from_shape(shape)) {
-      throw std::runtime_error("Input size mismatch for " + name);
-    }
-    input_names.push_back(name);
-    input_name_ptrs.push_back(input_names.back().c_str());
-    input_tensors.push_back(
-      Ort::Value::CreateTensor(
-        memory_info_, const_cast<uint8_t *>(data.data()), data.size() * sizeof(uint8_t),
-        shape.data(), shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL));
   };
 
   for (const auto & [name, data] : float_inputs) {
-    if (name == "sampled_trajectories") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (MAX_NUM_AGENTS * (OUTPUT_T + 1) * POSE_DIM)),
-         MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM});
-    } else if (name == "ego_agent_past") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / ((INPUT_T + 1) * POSE_DIM)), INPUT_T + 1, POSE_DIM});
-    } else if (name == "ego_current_state") {
-      add_float_tensor(name, data, {static_cast<int64_t>(data.size() / 10), 10});
-    } else if (name == "neighbor_agents_past") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (MAX_NUM_NEIGHBORS * (INPUT_T + 1) * 11)),
-         MAX_NUM_NEIGHBORS, INPUT_T + 1, 11});
-    } else if (name == "static_objects") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (NUM_STATIC_OBJECTS * 10)), NUM_STATIC_OBJECTS, 10});
-    } else if (name == "lanes") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(
-           data.size() / (NUM_SEGMENTS_IN_LANE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM)),
-         NUM_SEGMENTS_IN_LANE, POINTS_PER_SEGMENT, SEGMENT_POINT_DIM});
-    } else if (name == "lanes_speed_limit") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / NUM_SEGMENTS_IN_LANE), NUM_SEGMENTS_IN_LANE, 1});
-    } else if (name == "route_lanes") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(
-           data.size() / (NUM_SEGMENTS_IN_ROUTE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM)),
-         NUM_SEGMENTS_IN_ROUTE, POINTS_PER_SEGMENT, SEGMENT_POINT_DIM});
-    } else if (name == "route_lanes_speed_limit") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / NUM_SEGMENTS_IN_ROUTE), NUM_SEGMENTS_IN_ROUTE, 1});
-    } else if (name == "polygons") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(
-           data.size() / (NUM_POLYGONS * POINTS_PER_POLYGON * (2 + POLYGON_TYPE_NUM))),
-         NUM_POLYGONS, POINTS_PER_POLYGON, 2 + POLYGON_TYPE_NUM});
-    } else if (name == "line_strings") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(
-           data.size() / (NUM_LINE_STRINGS * POINTS_PER_LINE_STRING * (2 + LINE_STRING_TYPE_NUM))),
-         NUM_LINE_STRINGS, POINTS_PER_LINE_STRING, 2 + LINE_STRING_TYPE_NUM});
-    } else if (name == "goal_pose") {
-      add_float_tensor(name, data, {static_cast<int64_t>(data.size() / POSE_DIM), POSE_DIM});
-    } else if (name == "ego_shape") {
-      add_float_tensor(name, data, {static_cast<int64_t>(data.size() / 3), 3});
-    } else if (name == "turn_indicators") {
-      add_float_tensor(
-        name, data, {static_cast<int64_t>(data.size() / (INPUT_T + 1)), INPUT_T + 1});
-    } else if (name == "delay") {
-      add_float_tensor(name, data, {static_cast<int64_t>(data.size()), 1});
-    } else if (name == "encoding") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (ENCODING_TOKEN_NUM * HIDDEN_DIM)), ENCODING_TOKEN_NUM,
-         HIDDEN_DIM});
-    } else if (name == "diffusion_time") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (MAX_NUM_AGENTS * (OUTPUT_T + 1))), MAX_NUM_AGENTS,
-         OUTPUT_T + 1, 1});
-    } else if (name == "final_x0" || name == "model_output") {
-      add_float_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / (MAX_NUM_AGENTS * (OUTPUT_T + 1) * POSE_DIM)),
-         MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM});
-    } else {
-      throw std::runtime_error("Unsupported ONNX Runtime input: " + name);
+    if (input_spec(name).element_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+      throw std::runtime_error("Input " + name + " is not declared as float by the ONNX graph");
     }
+    input_shapes.push_back(shape_for(name, data.size()));
+    const std::vector<int64_t> & shape = input_shapes.back();
+    push_name(name);
+    input_tensors.push_back(
+      Ort::Value::CreateTensor<float>(
+        memory_info_, const_cast<float *>(data.data()), data.size(), shape.data(), shape.size()));
   }
 
-  for (const auto & [name, data] : bool_inputs) {
-    if (name == "lanes_has_speed_limit") {
-      add_bool_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / NUM_SEGMENTS_IN_LANE), NUM_SEGMENTS_IN_LANE, 1});
-    } else if (name == "route_lanes_has_speed_limit") {
-      add_bool_tensor(
-        name, data,
-        {static_cast<int64_t>(data.size() / NUM_SEGMENTS_IN_ROUTE), NUM_SEGMENTS_IN_ROUTE, 1});
-    } else {
-      throw std::runtime_error("Unsupported ONNX Runtime bool input: " + name);
+  for (const auto & [name, data] : byte_inputs) {
+    const ONNXTensorElementDataType element_type = input_spec(name).element_type;
+    if (
+      element_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL &&
+      element_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8) {
+      throw std::runtime_error(
+        "Input " + name + " is not declared as bool or uint8 by the ONNX graph");
     }
+    input_shapes.push_back(shape_for(name, data.size()));
+    const std::vector<int64_t> & shape = input_shapes.back();
+    push_name(name);
+    input_tensors.push_back(
+      Ort::Value::CreateTensor(
+        memory_info_, const_cast<uint8_t *>(data.data()), data.size() * sizeof(uint8_t),
+        shape.data(), shape.size(), element_type));
   }
 
   std::vector<const char *> output_name_ptrs;
@@ -341,19 +308,21 @@ std::unordered_map<std::string, std::vector<float>> OrtModel::run(
 
 OnnxruntimeSingleStepInference::OnnxruntimeSingleStepInference(
   const std::string & model_path, const std::string & execution_provider,
-  const std::string & plugins_path, const int)
-: model_(model_path, parse_execution_provider(execution_provider), plugins_path)
+  const std::string & plugins_path, const int, const ModelInputType input_type)
+: input_type_(input_type),
+  model_(model_path, parse_execution_provider(execution_provider), plugins_path)
 {
 }
 
 InferenceResult OnnxruntimeSingleStepInference::infer(
-  const preprocess::InputDataMap & input_data_map)
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   auto start = std::chrono::steady_clock::now();
   try {
     const auto outputs = model_.run(
-      to_float_input_map(single_step_float_inputs(input_data_map)),
-      speed_limit_bool_inputs(input_data_map), {"prediction", "turn_indicator_logit"});
+      to_float_input_map(single_step_float_inputs(input_data_map, input_type_)),
+      encoder_byte_inputs(input_data_map, input_type_, bev_image),
+      {"prediction", "turn_indicator_logit"});
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> elapsed = end - start;
@@ -372,8 +341,10 @@ OnnxruntimeMultiStepInference::OnnxruntimeMultiStepInference(
   const std::string & encoder_model_path, const std::string & decoder_model_path,
   const std::string & turn_indicator_model_path, const std::string & execution_provider,
   const std::string & plugins_path, const int batch_size, const int dpm_solver_steps,
-  std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances)
+  std::unordered_map<std::string, std::shared_ptr<Guidance>> guidances,
+  const ModelInputType input_type)
 : batch_size_(batch_size),
+  input_type_(input_type),
   dpm_solver_steps_(dpm_solver_steps),
   guidances_(std::move(guidances)),
   encoder_model_(encoder_model_path, parse_execution_provider(execution_provider), plugins_path),
@@ -460,13 +431,13 @@ DpmSolver::SampleResult OnnxruntimeMultiStepInference::run_dpm_solver(
 }
 
 InferenceResult OnnxruntimeMultiStepInference::infer(
-  const preprocess::InputDataMap & input_data_map)
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   auto start = std::chrono::steady_clock::now();
   try {
     const auto encoder_outputs = encoder_model_.run(
-      to_float_input_map(encoder_float_inputs(input_data_map)),
-      speed_limit_bool_inputs(input_data_map), {"encoding"});
+      to_float_input_map(encoder_float_inputs(input_data_map, input_type_)),
+      encoder_byte_inputs(input_data_map, input_type_, bev_image), {"encoding"});
     encoding_ = encoder_outputs.at("encoding");
 
     auto solver_result = run_dpm_solver(input_data_map);

--- a/planning/autoware_diffusion_planner/src/inference/single_step_inference.cpp
+++ b/planning/autoware_diffusion_planner/src/inference/single_step_inference.cpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,8 +32,9 @@ using autoware::tensorrt_common::ProfileDims;
 
 SingleStepInference::SingleStepInference(
   const std::string & model_path, const std::string & plugins_path, int batch_size,
-  const std::string & precision, bool use_cuda_graph)
+  const std::string & precision, bool use_cuda_graph, ModelInputType input_type)
 : batch_size_(batch_size),
+  input_type_(input_type),
   plugins_path_(plugins_path),
   precision_(precision),
   use_cuda_graph_(use_cuda_graph)
@@ -84,6 +86,10 @@ SingleStepInference::SingleStepInference(
   ego_shape_d_ = autoware::cuda_utils::make_unique<float[]>(ego_shape_size);
   turn_indicators_d_ = autoware::cuda_utils::make_unique<float[]>(turn_indicators_size);
   delay_d_ = autoware::cuda_utils::make_unique<float[]>(delay_size);
+  // Every buffer above is allocated in both modes - together they are a few MB - so only the
+  // engine bindings below actually differ per input type.
+  bev_image_d_ = autoware::cuda_utils::make_unique<uint8_t[]>(
+    batch_size_ * num_elements_without_batch(BEV_IMAGE_SHAPE));
 
   output_d_ = autoware::cuda_utils::make_unique<float[]>(output_size);
   turn_indicator_logit_d_ = autoware::cuda_utils::make_unique<float[]>(turn_indicator_logit_size);
@@ -119,22 +125,28 @@ void SingleStepInference::load_engine(const std::string & model_path)
   };
 
   add_input_tensor("sampled_trajectories", SAMPLED_TRAJECTORIES_SHAPE);
-  add_input_tensor("ego_agent_past", EGO_HISTORY_SHAPE);
-  add_input_tensor("ego_current_state", EGO_CURRENT_STATE_SHAPE);
   add_input_tensor("neighbor_agents_past", NEIGHBOR_SHAPE);
-  add_input_tensor("static_objects", STATIC_OBJECTS_SHAPE);
-  add_input_tensor("lanes", LANES_SHAPE);
-  add_input_tensor("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE);
-  add_input_tensor("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE);
-  add_input_tensor("route_lanes", ROUTE_LANES_SHAPE);
-  add_input_tensor("polygons", POLYGONS_SHAPE);
-  add_input_tensor("line_strings", LINE_STRINGS_SHAPE);
-  add_input_tensor("route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE);
-  add_input_tensor("route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE);
-  add_input_tensor("goal_pose", GOAL_POSE_SHAPE);
-  add_input_tensor("ego_shape", EGO_SHAPE_SHAPE);
+  add_input_tensor("ego_current_state", EGO_CURRENT_STATE_SHAPE);
   add_input_tensor("turn_indicators", TURN_INDICATORS_SHAPE);
   add_input_tensor("delay", DELAY_SHAPE);
+  if (input_type_ == ModelInputType::IMAGE) {
+    // The raster replaces every drawable element; ego_agent_past, goal_pose and ego_shape are
+    // gone with them because the image encoder reads none of them (see image_encoder.py).
+    add_input_tensor("bev_image", BEV_IMAGE_SHAPE);
+  } else {
+    add_input_tensor("ego_agent_past", EGO_HISTORY_SHAPE);
+    add_input_tensor("static_objects", STATIC_OBJECTS_SHAPE);
+    add_input_tensor("lanes", LANES_SHAPE);
+    add_input_tensor("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE);
+    add_input_tensor("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE);
+    add_input_tensor("route_lanes", ROUTE_LANES_SHAPE);
+    add_input_tensor("polygons", POLYGONS_SHAPE);
+    add_input_tensor("line_strings", LINE_STRINGS_SHAPE);
+    add_input_tensor("route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE);
+    add_input_tensor("route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE);
+    add_input_tensor("goal_pose", GOAL_POSE_SHAPE);
+    add_input_tensor("ego_shape", EGO_SHAPE_SHAPE);
+  }
 
   network_io.emplace_back("prediction", to_dynamic_dims(OUTPUT_SHAPE, batch_size_));
   network_io.emplace_back(
@@ -148,67 +160,62 @@ void SingleStepInference::load_engine(const std::string & model_path)
 
 void SingleStepInference::bindBuffers()
 {
-  // Set input shapes once (fixed batch_size)
-  network_trt_ptr_->setInputShape(
-    "sampled_trajectories", to_dims_with_batch(SAMPLED_TRAJECTORIES_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "ego_agent_past", to_dims_with_batch(EGO_HISTORY_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "ego_current_state", to_dims_with_batch(EGO_CURRENT_STATE_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "neighbor_agents_past", to_dims_with_batch(NEIGHBOR_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "static_objects", to_dims_with_batch(STATIC_OBJECTS_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape("lanes", to_dims_with_batch(LANES_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "lanes_has_speed_limit", to_dims_with_batch(LANES_HAS_SPEED_LIMIT_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "lanes_speed_limit", to_dims_with_batch(LANES_SPEED_LIMIT_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "route_lanes", to_dims_with_batch(ROUTE_LANES_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape("polygons", to_dims_with_batch(POLYGONS_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "line_strings", to_dims_with_batch(LINE_STRINGS_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "route_lanes_speed_limit", to_dims_with_batch(ROUTE_LANES_SPEED_LIMIT_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "route_lanes_has_speed_limit",
-    to_dims_with_batch(ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape("goal_pose", to_dims_with_batch(GOAL_POSE_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape("ego_shape", to_dims_with_batch(EGO_SHAPE_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape(
-    "turn_indicators", to_dims_with_batch(TURN_INDICATORS_SHAPE, batch_size_));
-  network_trt_ptr_->setInputShape("delay", to_dims_with_batch(DELAY_SHAPE, batch_size_));
+  // Set input shapes and bind addresses once: batch_size is fixed and the GPU buffers are stable.
+  const auto bind_float = [this](const char * name, const auto & shape, float * buffer) {
+    network_trt_ptr_->setInputShape(name, to_dims_with_batch(shape, batch_size_));
+    network_trt_ptr_->setTensorAddress(name, buffer);
+  };
+  const auto bind_bool = [this](const char * name, const auto & shape, bool * buffer) {
+    network_trt_ptr_->setInputShape(name, to_dims_with_batch(shape, batch_size_));
+    network_trt_ptr_->setTensorAddress(name, buffer);
+  };
 
-  // Bind tensor addresses once (GPU buffers are pre-allocated and stable)
-  network_trt_ptr_->setTensorAddress("sampled_trajectories", sampled_trajectories_d_.get());
-  network_trt_ptr_->setTensorAddress("ego_agent_past", ego_history_d_.get());
-  network_trt_ptr_->setTensorAddress("ego_current_state", ego_current_state_d_.get());
-  network_trt_ptr_->setTensorAddress("neighbor_agents_past", neighbor_agents_past_d_.get());
-  network_trt_ptr_->setTensorAddress("static_objects", static_objects_d_.get());
-  network_trt_ptr_->setTensorAddress("lanes", lanes_d_.get());
-  network_trt_ptr_->setTensorAddress("lanes_has_speed_limit", lanes_has_speed_limit_d_.get());
-  network_trt_ptr_->setTensorAddress("lanes_speed_limit", lanes_speed_limit_d_.get());
-  network_trt_ptr_->setTensorAddress("route_lanes", route_lanes_d_.get());
-  network_trt_ptr_->setTensorAddress("route_lanes_speed_limit", route_lanes_speed_limit_d_.get());
-  network_trt_ptr_->setTensorAddress(
-    "route_lanes_has_speed_limit", route_lanes_has_speed_limit_d_.get());
-  network_trt_ptr_->setTensorAddress("polygons", polygons_d_.get());
-  network_trt_ptr_->setTensorAddress("line_strings", line_strings_d_.get());
-  network_trt_ptr_->setTensorAddress("goal_pose", goal_pose_d_.get());
-  network_trt_ptr_->setTensorAddress("ego_shape", ego_shape_d_.get());
-  network_trt_ptr_->setTensorAddress("turn_indicators", turn_indicators_d_.get());
-  network_trt_ptr_->setTensorAddress("delay", delay_d_.get());
+  bind_float("sampled_trajectories", SAMPLED_TRAJECTORIES_SHAPE, sampled_trajectories_d_.get());
+  bind_float("neighbor_agents_past", NEIGHBOR_SHAPE, neighbor_agents_past_d_.get());
+  bind_float("ego_current_state", EGO_CURRENT_STATE_SHAPE, ego_current_state_d_.get());
+  bind_float("turn_indicators", TURN_INDICATORS_SHAPE, turn_indicators_d_.get());
+  bind_float("delay", DELAY_SHAPE, delay_d_.get());
+
+  if (input_type_ == ModelInputType::IMAGE) {
+    network_trt_ptr_->setInputShape("bev_image", to_dims_with_batch(BEV_IMAGE_SHAPE, batch_size_));
+    network_trt_ptr_->setTensorAddress("bev_image", bev_image_d_.get());
+  } else {
+    bind_float("ego_agent_past", EGO_HISTORY_SHAPE, ego_history_d_.get());
+    bind_float("static_objects", STATIC_OBJECTS_SHAPE, static_objects_d_.get());
+    bind_float("lanes", LANES_SHAPE, lanes_d_.get());
+    bind_float("lanes_speed_limit", LANES_SPEED_LIMIT_SHAPE, lanes_speed_limit_d_.get());
+    bind_bool("lanes_has_speed_limit", LANES_HAS_SPEED_LIMIT_SHAPE, lanes_has_speed_limit_d_.get());
+    bind_float("route_lanes", ROUTE_LANES_SHAPE, route_lanes_d_.get());
+    bind_float(
+      "route_lanes_speed_limit", ROUTE_LANES_SPEED_LIMIT_SHAPE, route_lanes_speed_limit_d_.get());
+    bind_bool(
+      "route_lanes_has_speed_limit", ROUTE_LANES_HAS_SPEED_LIMIT_SHAPE,
+      route_lanes_has_speed_limit_d_.get());
+    bind_float("polygons", POLYGONS_SHAPE, polygons_d_.get());
+    bind_float("line_strings", LINE_STRINGS_SHAPE, line_strings_d_.get());
+    bind_float("goal_pose", GOAL_POSE_SHAPE, goal_pose_d_.get());
+    bind_float("ego_shape", EGO_SHAPE_SHAPE, ego_shape_d_.get());
+  }
+
   network_trt_ptr_->setTensorAddress("prediction", output_d_.get());
   network_trt_ptr_->setTensorAddress("turn_indicator_logit", turn_indicator_logit_d_.get());
 }
 
-void SingleStepInference::transferInputsToDevice(const preprocess::InputDataMap & input_data_map)
+void SingleStepInference::transferInputsToDevice(
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   transfer_float_input(input_data_map.at("sampled_trajectories"), sampled_trajectories_d_, stream_);
-  transfer_float_input(input_data_map.at("ego_agent_past"), ego_history_d_, stream_);
-  transfer_float_input(input_data_map.at("ego_current_state"), ego_current_state_d_, stream_);
   transfer_float_input(input_data_map.at("neighbor_agents_past"), neighbor_agents_past_d_, stream_);
+  transfer_float_input(input_data_map.at("ego_current_state"), ego_current_state_d_, stream_);
+  transfer_float_input(input_data_map.at("turn_indicators"), turn_indicators_d_, stream_);
+  transfer_float_input(input_data_map.at("delay"), delay_d_, stream_);
+
+  if (input_type_ == ModelInputType::IMAGE) {
+    transfer_uint8_input(bev_image, bev_image_d_, stream_);
+    return;
+  }
+
+  transfer_float_input(input_data_map.at("ego_agent_past"), ego_history_d_, stream_);
   transfer_float_input(input_data_map.at("static_objects"), static_objects_d_, stream_);
   transfer_float_input(input_data_map.at("lanes"), lanes_d_, stream_);
   transfer_float_input(input_data_map.at("lanes_speed_limit"), lanes_speed_limit_d_, stream_);
@@ -219,8 +226,6 @@ void SingleStepInference::transferInputsToDevice(const preprocess::InputDataMap 
   transfer_float_input(input_data_map.at("line_strings"), line_strings_d_, stream_);
   transfer_float_input(input_data_map.at("goal_pose"), goal_pose_d_, stream_);
   transfer_float_input(input_data_map.at("ego_shape"), ego_shape_d_, stream_);
-  transfer_float_input(input_data_map.at("turn_indicators"), turn_indicators_d_, stream_);
-  transfer_float_input(input_data_map.at("delay"), delay_d_, stream_);
 
   transfer_speed_mask(
     input_data_map.at("lanes_speed_limit"), lanes_has_speed_limit_d_,
@@ -231,11 +236,11 @@ void SingleStepInference::transferInputsToDevice(const preprocess::InputDataMap 
 }
 
 SingleStepInference::InferenceResult SingleStepInference::infer(
-  const preprocess::InputDataMap & input_data_map)
+  const preprocess::InputDataMap & input_data_map, const std::vector<uint8_t> & bev_image)
 {
   auto start = std::chrono::steady_clock::now();
 
-  transferInputsToDevice(input_data_map);
+  transferInputsToDevice(input_data_map, bev_image);
 
   const bool status = enqueue_trt(*network_trt_ptr_, network_cuda_graph_, stream_, use_cuda_graph_);
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));

--- a/planning/autoware_diffusion_planner/src/preprocessing/bev_image.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/bev_image.cpp
@@ -1,0 +1,616 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/preprocessing/bev_image.hpp"
+
+#include "autoware/diffusion_planner/conversion/agent.hpp"
+#include "autoware/diffusion_planner/dimensions.hpp"
+
+#include <Eigen/Core>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::diffusion_planner::preprocess
+{
+namespace
+{
+// Line thicknesses and marker sizes, all from render_bev.py.
+constexpr int LANE_BOUNDARY_THICKNESS = 1;
+constexpr int LANE_CENTERLINE_THICKNESS = 1;
+constexpr int TRAFFIC_LIGHT_THICKNESS = 2;
+constexpr int ROUTE_THICKNESS = 3;
+constexpr int LINE_STRING_THICKNESS = 1;
+constexpr int HISTORY_THICKNESS = 2;
+constexpr int GOAL_MARKER_THICKNESS = 2;
+constexpr double GOAL_MARKER_LENGTH_M = 5.0;
+constexpr int GOAL_MARKER_RADIUS_PX = 3;
+
+// Binary masks: hard edges, so cv::LINE_8 rather than an anti-aliased line type that would emit
+// intermediate values.
+//
+// Rendered against render_bev.py on real dataset frames, this file reproduces it exactly for
+// every polyline channel. The filled channels (polygon, agent boxes) can differ by a handful of
+// pixels on a shape that runs off the canvas, because OpenCV changed how fillPoly clips between
+// the version the training environment uses and the one Autoware builds against.
+constexpr int LINE_TYPE = cv::LINE_8;
+constexpr int FOREGROUND = 255;
+
+constexpr double VALID_EPS = 1e-6;
+constexpr double MIN_BOX_SIZE_M = 0.1;
+
+// Neighbor state layout inside neighbor_agents_past (see AgentState::as_array).
+constexpr int64_t NEIGHBOR_STATE_DIM = static_cast<int64_t>(AGENT_STATE_DIM);
+constexpr int64_t NEIGHBOR_IDX_COS = 2;
+constexpr int64_t NEIGHBOR_IDX_SIN = 3;
+constexpr int64_t NEIGHBOR_IDX_WIDTH = 6;
+constexpr int64_t NEIGHBOR_IDX_LENGTH = 7;
+constexpr int64_t NEIGHBOR_IDX_TYPE_START = 8;
+constexpr int64_t NEIGHBOR_TYPE_NUM = 3;
+
+// Static object state layout inside static_objects.
+constexpr int64_t STATIC_IDX_COS = 2;
+constexpr int64_t STATIC_IDX_SIN = 3;
+constexpr int64_t STATIC_IDX_WIDTH = 4;
+constexpr int64_t STATIC_IDX_LENGTH = 5;
+
+// Guard against undefined behavior when casting a pixel coordinate to int. Anything this far
+// off-canvas is clipped away by the drawing calls regardless of its exact value.
+constexpr double MAX_PIXEL_COORDINATE = 1.0e7;
+
+// Later entries win where channels overlap, so agents stay visible on top of the map. Lanes
+// cross at an intersection, so the light planes are ordered by how much they demand
+// attention: an unknown light loses to a green one, which loses to yellow, which loses to red.
+constexpr std::array<BevChannel, BEV_NUM_CHANNELS> DRAW_ORDER = {
+  BEV_CH_POLYGON,
+  BEV_CH_LANE_CENTERLINE,
+  BEV_CH_LANE_BOUNDARY,
+  BEV_CH_LINE_STRING,
+  BEV_CH_ROUTE,
+  BEV_CH_TRAFFIC_LIGHT_UNKNOWN,
+  BEV_CH_TRAFFIC_LIGHT_GO,
+  BEV_CH_TRAFFIC_LIGHT_CAUTION,
+  BEV_CH_TRAFFIC_LIGHT_STOP,
+  BEV_CH_GOAL_POSE,
+  BEV_CH_NEIGHBOR_HISTORY,
+  BEV_CH_EGO_HISTORY,
+  BEV_CH_STATIC_OBJECT,
+  BEV_CH_VEHICLE,
+  BEV_CH_PEDESTRIAN,
+  BEV_CH_BICYCLE,
+  BEV_CH_EGO};
+constexpr std::array<std::array<uint8_t, 3>, BEV_NUM_CHANNELS> COLOR_BGR_OF_CHANNEL = {{
+  {160, 160, 160},  // BEV_CH_LANE_BOUNDARY
+  {90, 90, 90},     // BEV_CH_LANE_CENTERLINE
+  {255, 0, 255},    // BEV_CH_ROUTE
+  {0, 200, 0},      // BEV_CH_TRAFFIC_LIGHT_GO
+  {0, 255, 255},    // BEV_CH_TRAFFIC_LIGHT_CAUTION
+  {0, 0, 255},      // BEV_CH_TRAFFIC_LIGHT_STOP
+  {128, 0, 128},    // BEV_CH_TRAFFIC_LIGHT_UNKNOWN
+  {60, 110, 60},    // BEV_CH_POLYGON
+  {0, 140, 255},    // BEV_CH_LINE_STRING
+  {0, 200, 200},    // BEV_CH_STATIC_OBJECT
+  {255, 128, 0},    // BEV_CH_GOAL_POSE
+  {255, 60, 60},    // BEV_CH_VEHICLE
+  {60, 255, 60},    // BEV_CH_PEDESTRIAN
+  {255, 0, 128},    // BEV_CH_BICYCLE
+  {255, 255, 255},  // BEV_CH_EGO
+  {128, 64, 0},     // BEV_CH_NEIGHBOR_HISTORY
+  {0, 165, 255},    // BEV_CH_EGO_HISTORY
+}};
+// A channel missing from the draw order would silently vanish from every preview, which is
+// exactly how a folded-together traffic light state went unnoticed before.
+static_assert(
+  [] {
+    std::array<bool, BEV_NUM_CHANNELS> seen{};
+    for (const BevChannel channel : DRAW_ORDER) {
+      seen[static_cast<size_t>(channel)] = true;
+    }
+    for (const bool value : seen) {
+      if (!value) {
+        return false;
+      }
+    }
+    return true;
+  }(),
+  "every BevChannel must appear in the preview draw order");
+
+using Canvas = std::array<cv::Mat, BEV_NUM_CHANNELS>;
+
+/// Pixel mapping of one scale: ego at the image center, ego heading pointing up.
+struct BevView
+{
+  double pixels_per_meter;
+  double half;
+};
+
+BevView make_view(const double extent_m)
+{
+  return BevView{
+    static_cast<double>(BEV_IMAGE_SIZE) / extent_m, static_cast<double>(BEV_IMAGE_SIZE) / 2.0};
+}
+
+/// Map ego-relative meters to integer (col, row) pixels.
+cv::Point to_pixel(const BevView & view, const Eigen::Vector2d & point_rel)
+{
+  const double col = view.half - point_rel.y() * view.pixels_per_meter;
+  const double row = view.half - point_rel.x() * view.pixels_per_meter;
+  // std::nearbyint rounds half to even under the default rounding mode, matching numpy's round.
+  const auto to_int = [](const double value) {
+    return static_cast<int>(
+      std::nearbyint(std::clamp(value, -MAX_PIXEL_COORDINATE, MAX_PIXEL_COORDINATE)));
+  };
+  return cv::Point{to_int(col), to_int(row)};
+}
+
+double yaw_from_cos_sin(const double cos_value, const double sin_value)
+{
+  return std::atan2(sin_value, cos_value);
+}
+
+Eigen::Matrix2d rotation_matrix(const double yaw)
+{
+  Eigen::Matrix2d rotation;
+  rotation << std::cos(yaw), -std::sin(yaw), std::sin(yaw), std::cos(yaw);
+  return rotation;
+}
+
+/// Maps points into the ego-centered, ego-aligned frame. The tensors handed to the node are
+/// already ego-relative, which makes this the identity; it is kept so the renderer stays a
+/// faithful port and also works on frames whose ego pose is not the origin.
+class BevTransform
+{
+public:
+  BevTransform(const double ego_x, const double ego_y, const double ego_yaw)
+  : rotation_(rotation_matrix(-ego_yaw)), origin_(ego_x, ego_y)
+  {
+  }
+
+  Eigen::Vector2d operator()(const double x, const double y) const
+  {
+    return rotation_ * (Eigen::Vector2d(x, y) - origin_);
+  }
+
+private:
+  Eigen::Matrix2d rotation_;
+  Eigen::Vector2d origin_;
+};
+
+/// Row-major view over the first batch entry of one input tensor.
+class TensorView
+{
+public:
+  TensorView(const InputDataMap & input_data_map, const std::string & key, const int64_t row_stride)
+  : data_(input_data_map.at(key).data()), row_stride_(row_stride)
+  {
+    assert(input_data_map.at(key).size() % static_cast<size_t>(row_stride) == 0);
+  }
+
+  const float * row(const int64_t index) const { return data_ + index * row_stride_; }
+
+private:
+  const float * data_;
+  int64_t row_stride_;
+};
+
+/// Number of leading points of a polyline before its zero padding.
+int64_t valid_prefix_length(const float * points, const int64_t num_points, const int64_t point_dim)
+{
+  for (int64_t i = 0; i < num_points; ++i) {
+    const float * point = points + i * point_dim;
+    if (std::abs(point[X]) + std::abs(point[Y]) < VALID_EPS) {
+      return i;
+    }
+  }
+  return num_points;
+}
+
+// The single-contour overloads are taken explicitly: the InputArrayOfArrays forms would have to
+// guess whether a vector<cv::Point> is one contour or a list of them.
+void draw_pixel_polyline(
+  cv::Mat & canvas, const std::vector<cv::Point> & pixels, const int thickness)
+{
+  const cv::Point * contour = pixels.data();
+  const int num_points = static_cast<int>(pixels.size());
+  cv::polylines(
+    canvas, &contour, &num_points, 1, false, cv::Scalar(FOREGROUND), thickness, LINE_TYPE);
+}
+
+void fill_pixel_polygon(cv::Mat & canvas, const std::vector<cv::Point> & pixels)
+{
+  const cv::Point * contour = pixels.data();
+  const int num_points = static_cast<int>(pixels.size());
+  cv::fillPoly(canvas, &contour, &num_points, 1, cv::Scalar(FOREGROUND), LINE_TYPE);
+}
+
+void draw_polyline(
+  cv::Mat & canvas, const BevView & view, const std::vector<Eigen::Vector2d> & points_rel,
+  const int thickness)
+{
+  if (points_rel.size() < 2) {
+    return;
+  }
+  std::vector<cv::Point> pixels;
+  pixels.reserve(points_rel.size());
+  for (const auto & point_rel : points_rel) {
+    pixels.push_back(to_pixel(view, point_rel));
+  }
+  draw_pixel_polyline(canvas, pixels, thickness);
+}
+
+/// Fill an oriented bounding box; `length` runs along `yaw_rel`.
+void draw_box(
+  cv::Mat & canvas, const BevView & view, const Eigen::Vector2d & center_rel, const double length,
+  const double width, const double yaw_rel)
+{
+  const double half_length = std::max(length, MIN_BOX_SIZE_M) / 2.0;
+  const double half_width = std::max(width, MIN_BOX_SIZE_M) / 2.0;
+  const std::array<Eigen::Vector2d, 4> local = {
+    Eigen::Vector2d{half_length, half_width}, Eigen::Vector2d{half_length, -half_width},
+    Eigen::Vector2d{-half_length, -half_width}, Eigen::Vector2d{-half_length, half_width}};
+
+  const Eigen::Matrix2d rotation = rotation_matrix(yaw_rel);
+  std::vector<cv::Point> corners;
+  corners.reserve(local.size());
+  for (const auto & corner : local) {
+    corners.push_back(to_pixel(view, rotation * corner + center_rel));
+  }
+  fill_pixel_polygon(canvas, corners);
+}
+
+/// Mark a pose as a dot with a short segment pointing along the yaw.
+void draw_pose_marker(
+  cv::Mat & canvas, const BevView & view, const Eigen::Vector2d & center_rel, const double yaw_rel)
+{
+  const Eigen::Vector2d tip =
+    center_rel + Eigen::Vector2d(std::cos(yaw_rel), std::sin(yaw_rel)) * GOAL_MARKER_LENGTH_M;
+  draw_polyline(canvas, view, {center_rel, tip}, GOAL_MARKER_THICKNESS);
+  cv::circle(
+    canvas, to_pixel(view, center_rel), GOAL_MARKER_RADIUS_PX, cv::Scalar(FOREGROUND), cv::FILLED,
+    LINE_TYPE);
+}
+
+// Plane each traffic light state is drawn onto; mirrors
+// render_bev.py::TRAFFIC_LIGHT_CHANNEL_OF_STATE. Every state gets its own plane instead of being
+// folded into one "stop" plane, so the encoder can tell a yellow light from a red one, and a
+// light whose state never arrived from a lane that has no light at all. TRAFFIC_LIGHT_WHITE is
+// the slot the observation writes when the lane has a light but its colour is unknown or was
+// never received.
+//
+// TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT deliberately has no plane: such a lane is already drawn on the
+// centerline channel, and its silence across all four light planes is what identifies it.
+constexpr std::array<std::pair<int64_t, BevChannel>, 4> TRAFFIC_LIGHT_CHANNEL_OF_STATE = {{
+  {TRAFFIC_LIGHT_GREEN, BEV_CH_TRAFFIC_LIGHT_GO},
+  {TRAFFIC_LIGHT_YELLOW, BEV_CH_TRAFFIC_LIGHT_CAUTION},
+  {TRAFFIC_LIGHT_RED, BEV_CH_TRAFFIC_LIGHT_STOP},
+  {TRAFFIC_LIGHT_WHITE, BEV_CH_TRAFFIC_LIGHT_UNKNOWN},
+}};
+
+/// Plane the lane's traffic light belongs on; empty when the lane has no light at all.
+std::optional<BevChannel> traffic_light_channel(const float * state)
+{
+  for (const auto & [index, channel] : TRAFFIC_LIGHT_CHANNEL_OF_STATE) {
+    if (state[index] == 1.0f) {
+      return channel;
+    }
+  }
+  return std::nullopt;
+}
+
+BevChannel neighbor_channel(const float * state)
+{
+  constexpr std::array<BevChannel, NEIGHBOR_TYPE_NUM> CHANNEL_OF_TYPE = {
+    BEV_CH_VEHICLE, BEV_CH_PEDESTRIAN, BEV_CH_BICYCLE};
+  int64_t best = 0;
+  for (int64_t i = 1; i < NEIGHBOR_TYPE_NUM; ++i) {
+    if (state[NEIGHBOR_IDX_TYPE_START + i] > state[NEIGHBOR_IDX_TYPE_START + best]) {
+      best = i;
+    }
+  }
+  return CHANNEL_OF_TYPE[best];
+}
+
+void draw_lanes(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map)
+{
+  const TensorView lanes(input_data_map, "lanes", POINTS_PER_SEGMENT * SEGMENT_POINT_DIM);
+
+  for (int64_t i = 0; i < NUM_SEGMENTS_IN_LANE; ++i) {
+    const float * segment = lanes.row(i);
+    const int64_t num_points = valid_prefix_length(segment, POINTS_PER_SEGMENT, SEGMENT_POINT_DIM);
+    if (num_points < 2) {
+      continue;
+    }
+
+    std::vector<Eigen::Vector2d> center;
+    std::vector<Eigen::Vector2d> left;
+    std::vector<Eigen::Vector2d> right;
+    center.reserve(num_points);
+    left.reserve(num_points);
+    right.reserve(num_points);
+    for (int64_t p = 0; p < num_points; ++p) {
+      const float * point = segment + p * SEGMENT_POINT_DIM;
+      center.push_back(transform(point[X], point[Y]));
+      // The boundaries are stored as offsets from the centerline point.
+      left.push_back(transform(point[X] + point[LB_X], point[Y] + point[LB_Y]));
+      right.push_back(transform(point[X] + point[RB_X], point[Y] + point[RB_Y]));
+    }
+
+    draw_polyline(canvas[BEV_CH_LANE_CENTERLINE], view, center, LANE_CENTERLINE_THICKNESS);
+    draw_polyline(canvas[BEV_CH_LANE_BOUNDARY], view, left, LANE_BOUNDARY_THICKNESS);
+    draw_polyline(canvas[BEV_CH_LANE_BOUNDARY], view, right, LANE_BOUNDARY_THICKNESS);
+
+    // The state one-hot is replicated across the segment, so the first point carries it.
+    const std::optional<BevChannel> light_channel = traffic_light_channel(segment);
+    if (light_channel.has_value()) {
+      draw_polyline(canvas[light_channel.value()], view, center, TRAFFIC_LIGHT_THICKNESS);
+    }
+  }
+}
+
+void draw_route(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map)
+{
+  const TensorView route_lanes(
+    input_data_map, "route_lanes", POINTS_PER_SEGMENT * SEGMENT_POINT_DIM);
+
+  for (int64_t i = 0; i < NUM_SEGMENTS_IN_ROUTE; ++i) {
+    const float * segment = route_lanes.row(i);
+    const int64_t num_points = valid_prefix_length(segment, POINTS_PER_SEGMENT, SEGMENT_POINT_DIM);
+    if (num_points < 2) {
+      continue;
+    }
+
+    std::vector<Eigen::Vector2d> center;
+    center.reserve(num_points);
+    for (int64_t p = 0; p < num_points; ++p) {
+      const float * point = segment + p * SEGMENT_POINT_DIM;
+      center.push_back(transform(point[X], point[Y]));
+    }
+    draw_polyline(canvas[BEV_CH_ROUTE], view, center, ROUTE_THICKNESS);
+  }
+}
+
+void draw_polygons(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map)
+{
+  constexpr int64_t POLYGON_POINT_DIM = 2 + POLYGON_TYPE_NUM;
+  const TensorView polygons(input_data_map, "polygons", POINTS_PER_POLYGON * POLYGON_POINT_DIM);
+
+  for (int64_t i = 0; i < NUM_POLYGONS; ++i) {
+    const float * polygon = polygons.row(i);
+    const int64_t num_points = valid_prefix_length(polygon, POINTS_PER_POLYGON, POLYGON_POINT_DIM);
+    if (num_points < 3) {
+      continue;
+    }
+
+    std::vector<cv::Point> contour;
+    contour.reserve(num_points);
+    for (int64_t p = 0; p < num_points; ++p) {
+      const float * point = polygon + p * POLYGON_POINT_DIM;
+      contour.push_back(to_pixel(view, transform(point[X], point[Y])));
+    }
+    fill_pixel_polygon(canvas[BEV_CH_POLYGON], contour);
+  }
+}
+
+void draw_line_strings(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map)
+{
+  constexpr int64_t LINE_STRING_POINT_DIM = 2 + LINE_STRING_TYPE_NUM;
+  const TensorView line_strings(
+    input_data_map, "line_strings", POINTS_PER_LINE_STRING * LINE_STRING_POINT_DIM);
+
+  for (int64_t i = 0; i < NUM_LINE_STRINGS; ++i) {
+    const float * line_string = line_strings.row(i);
+    const int64_t num_points =
+      valid_prefix_length(line_string, POINTS_PER_LINE_STRING, LINE_STRING_POINT_DIM);
+    if (num_points < 2) {
+      continue;
+    }
+
+    std::vector<Eigen::Vector2d> points;
+    points.reserve(num_points);
+    for (int64_t p = 0; p < num_points; ++p) {
+      const float * point = line_string + p * LINE_STRING_POINT_DIM;
+      points.push_back(transform(point[X], point[Y]));
+    }
+    draw_polyline(canvas[BEV_CH_LINE_STRING], view, points, LINE_STRING_THICKNESS);
+  }
+}
+
+void draw_static_objects(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map, const double ego_yaw)
+{
+  const int64_t static_object_dim = STATIC_OBJECTS_SHAPE[2];
+  const TensorView static_objects(input_data_map, "static_objects", static_object_dim);
+
+  for (int64_t i = 0; i < NUM_STATIC_OBJECTS; ++i) {
+    const float * object = static_objects.row(i);
+    const double pose_magnitude =
+      std::abs(object[0]) + std::abs(object[1]) + std::abs(object[2]) + std::abs(object[3]);
+    if (pose_magnitude < VALID_EPS) {
+      continue;
+    }
+    draw_box(
+      canvas[BEV_CH_STATIC_OBJECT], view, transform(object[X], object[Y]),
+      object[STATIC_IDX_LENGTH], object[STATIC_IDX_WIDTH],
+      yaw_from_cos_sin(object[STATIC_IDX_COS], object[STATIC_IDX_SIN]) - ego_yaw);
+  }
+}
+
+/// Draw each neighbor's past track plus its current box.
+void draw_neighbors(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map, const double ego_yaw)
+{
+  const TensorView neighbors(
+    input_data_map, "neighbor_agents_past", INPUT_T_WITH_CURRENT * NEIGHBOR_STATE_DIM);
+
+  for (int64_t i = 0; i < MAX_NUM_NEIGHBORS; ++i) {
+    const float * history = neighbors.row(i);
+    const float * state = history + INPUT_T * NEIGHBOR_STATE_DIM;
+    const double pose_magnitude =
+      std::abs(state[0]) + std::abs(state[1]) + std::abs(state[2]) + std::abs(state[3]);
+    if (pose_magnitude < VALID_EPS) {
+      continue;
+    }
+
+    std::vector<Eigen::Vector2d> track;
+    track.reserve(INPUT_T_WITH_CURRENT);
+    for (int64_t t = 0; t < INPUT_T_WITH_CURRENT; ++t) {
+      const float * step = history + t * NEIGHBOR_STATE_DIM;
+      if (std::abs(step[X]) + std::abs(step[Y]) <= VALID_EPS) {
+        continue;
+      }
+      track.push_back(transform(step[X], step[Y]));
+    }
+    draw_polyline(canvas[BEV_CH_NEIGHBOR_HISTORY], view, track, HISTORY_THICKNESS);
+
+    draw_box(
+      canvas[neighbor_channel(state)], view, transform(state[X], state[Y]),
+      state[NEIGHBOR_IDX_LENGTH], state[NEIGHBOR_IDX_WIDTH],
+      yaw_from_cos_sin(state[NEIGHBOR_IDX_COS], state[NEIGHBOR_IDX_SIN]) - ego_yaw);
+  }
+}
+
+void draw_ego(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map, const double ego_yaw)
+{
+  const TensorView ego_agent_past(input_data_map, "ego_agent_past", POSE_DIM);
+  std::vector<Eigen::Vector2d> track;
+  track.reserve(INPUT_T_WITH_CURRENT);
+  for (int64_t t = 0; t < INPUT_T_WITH_CURRENT; ++t) {
+    const float * step = ego_agent_past.row(t);
+    track.push_back(transform(step[EGO_AGENT_PAST_IDX_X], step[EGO_AGENT_PAST_IDX_Y]));
+  }
+  draw_polyline(canvas[BEV_CH_EGO_HISTORY], view, track, HISTORY_THICKNESS);
+
+  const std::vector<float> & ego_current_state = input_data_map.at("ego_current_state");
+  const std::vector<float> & ego_shape = input_data_map.at("ego_shape");
+  draw_box(
+    canvas[BEV_CH_EGO], view, transform(ego_current_state[X], ego_current_state[Y]),
+    ego_shape[1] /* length */, ego_shape[2] /* width */,
+    yaw_from_cos_sin(ego_current_state[2], ego_current_state[3]) - ego_yaw);
+}
+
+void draw_goal_pose(
+  Canvas & canvas, const BevView & view, const BevTransform & transform,
+  const InputDataMap & input_data_map, const double ego_yaw)
+{
+  const std::vector<float> & goal_pose = input_data_map.at("goal_pose");
+  if (std::abs(goal_pose[X]) + std::abs(goal_pose[Y]) < VALID_EPS) {
+    return;
+  }
+  const double goal_yaw = yaw_from_cos_sin(goal_pose[2], goal_pose[3]);
+  draw_pose_marker(
+    canvas[BEV_CH_GOAL_POSE], view, transform(goal_pose[X], goal_pose[Y]), goal_yaw - ego_yaw);
+}
+
+/// Rasterize one scale in place, over planes wrapping `image` at `plane_offset`.
+void render_view(
+  std::vector<uint8_t> & image, const size_t plane_offset, const double extent_m,
+  const InputDataMap & input_data_map, const BevTransform & transform, const double ego_yaw)
+{
+  constexpr size_t PLANE_SIZE = static_cast<size_t>(BEV_IMAGE_SIZE) * BEV_IMAGE_SIZE;
+  Canvas canvas;
+  for (int64_t channel = 0; channel < BEV_NUM_CHANNELS; ++channel) {
+    canvas[channel] = cv::Mat(
+      static_cast<int>(BEV_IMAGE_SIZE), static_cast<int>(BEV_IMAGE_SIZE), CV_8UC1,
+      image.data() + plane_offset + static_cast<size_t>(channel) * PLANE_SIZE);
+  }
+
+  const BevView view = make_view(extent_m);
+  draw_lanes(canvas, view, transform, input_data_map);
+  draw_route(canvas, view, transform, input_data_map);
+  draw_polygons(canvas, view, transform, input_data_map);
+  draw_line_strings(canvas, view, transform, input_data_map);
+  draw_static_objects(canvas, view, transform, input_data_map, ego_yaw);
+  draw_goal_pose(canvas, view, transform, input_data_map, ego_yaw);
+  draw_neighbors(canvas, view, transform, input_data_map, ego_yaw);
+  draw_ego(canvas, view, transform, input_data_map, ego_yaw);
+}
+
+}  // namespace
+
+std::vector<uint8_t> create_bev_image(const InputDataMap & input_data_map, const int64_t batch_size)
+{
+  assert(batch_size >= 1);
+
+  constexpr size_t SAMPLE_SIZE =
+    static_cast<size_t>(BEV_NUM_SCALES) * BEV_NUM_CHANNELS * BEV_IMAGE_SIZE * BEV_IMAGE_SIZE;
+  constexpr size_t SCALE_SIZE = SAMPLE_SIZE / BEV_NUM_SCALES;
+
+  std::vector<uint8_t> image(SAMPLE_SIZE * static_cast<size_t>(batch_size), 0U);
+
+  const std::vector<float> & ego_current_state = input_data_map.at("ego_current_state");
+  const double ego_yaw = yaw_from_cos_sin(ego_current_state[2], ego_current_state[3]);
+  const BevTransform transform(ego_current_state[X], ego_current_state[Y], ego_yaw);
+
+  for (int64_t scale = 0; scale < BEV_NUM_SCALES; ++scale) {
+    render_view(
+      image, static_cast<size_t>(scale) * SCALE_SIZE, BEV_VIEW_EXTENTS_M[scale], input_data_map,
+      transform, ego_yaw);
+  }
+
+  // Every scene tensor the renderer reads is batch-replicated from the same frame, so the whole
+  // batch shares one raster.
+  for (int64_t b = 1; b < batch_size; ++b) {
+    std::copy(
+      image.begin(), image.begin() + static_cast<std::ptrdiff_t>(SAMPLE_SIZE),
+      image.begin() + static_cast<std::ptrdiff_t>(static_cast<size_t>(b) * SAMPLE_SIZE));
+  }
+  return image;
+}
+
+std::vector<uint8_t> colorize_bev_image(const std::vector<uint8_t> & bev_image, const int64_t scale)
+{
+  constexpr size_t PLANE_SIZE = static_cast<size_t>(BEV_IMAGE_SIZE) * BEV_IMAGE_SIZE;
+  assert(scale >= 0 && scale < BEV_NUM_SCALES);
+  assert(bev_image.size() >= (static_cast<size_t>(scale) + 1) * BEV_NUM_CHANNELS * PLANE_SIZE);
+
+  std::vector<uint8_t> preview(PLANE_SIZE * 3, 0U);
+  for (const BevChannel channel : DRAW_ORDER) {
+    const uint8_t * plane =
+      bev_image.data() +
+      (static_cast<size_t>(scale) * BEV_NUM_CHANNELS + static_cast<size_t>(channel)) * PLANE_SIZE;
+    const auto & color = COLOR_BGR_OF_CHANNEL[channel];
+    for (size_t pixel = 0; pixel < PLANE_SIZE; ++pixel) {
+      if (plane[pixel] == 0U) {
+        continue;
+      }
+      preview[pixel * 3 + 0] = color[0];
+      preview[pixel * 3 + 1] = color[1];
+      preview[pixel * 3 + 2] = color[2];
+    }
+  }
+  return preview;
+}
+
+}  // namespace autoware::diffusion_planner::preprocess

--- a/planning/autoware_diffusion_planner/test/bev_image_test.cpp
+++ b/planning/autoware_diffusion_planner/test/bev_image_test.cpp
@@ -1,0 +1,377 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/preprocessing/bev_image.hpp"
+
+#include "autoware/diffusion_planner/conversion/agent.hpp"
+#include "autoware/diffusion_planner/dimensions.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace autoware::diffusion_planner::test
+{
+namespace
+{
+constexpr int64_t NEAR_SCALE = 0;
+constexpr int64_t FAR_SCALE = 1;
+constexpr int64_t CENTER_PIXEL = BEV_IMAGE_SIZE / 2;
+
+constexpr size_t PLANE_SIZE = static_cast<size_t>(BEV_IMAGE_SIZE) * BEV_IMAGE_SIZE;
+constexpr size_t SAMPLE_SIZE = static_cast<size_t>(BEV_NUM_SCALES) * BEV_NUM_CHANNELS * PLANE_SIZE;
+
+/// An all-zero input map: every polyline is pure padding and no agent is present, so a render of
+/// it draws nothing except the ego box and the ego history sitting at the origin.
+preprocess::InputDataMap make_empty_input_data(const int64_t batch_size)
+{
+  const auto zeros = [batch_size](const int64_t elements_per_batch) {
+    return std::vector<float>(static_cast<size_t>(batch_size * elements_per_batch), 0.0f);
+  };
+
+  preprocess::InputDataMap input_data_map;
+  input_data_map["lanes"] = zeros(NUM_SEGMENTS_IN_LANE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM);
+  input_data_map["route_lanes"] =
+    zeros(NUM_SEGMENTS_IN_ROUTE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM);
+  input_data_map["polygons"] = zeros(NUM_POLYGONS * POINTS_PER_POLYGON * (2 + POLYGON_TYPE_NUM));
+  input_data_map["line_strings"] =
+    zeros(NUM_LINE_STRINGS * POINTS_PER_LINE_STRING * (2 + LINE_STRING_TYPE_NUM));
+  input_data_map["static_objects"] = zeros(NUM_STATIC_OBJECTS * STATIC_OBJECTS_SHAPE[2]);
+  input_data_map["neighbor_agents_past"] =
+    zeros(MAX_NUM_NEIGHBORS * INPUT_T_WITH_CURRENT * static_cast<int64_t>(AGENT_STATE_DIM));
+  input_data_map["ego_agent_past"] = zeros(INPUT_T_WITH_CURRENT * POSE_DIM);
+  input_data_map["goal_pose"] = zeros(POSE_DIM);
+
+  // Ego sits at the origin facing along +x, and is 5 m long by 2 m wide.
+  input_data_map["ego_current_state"] = zeros(EGO_CURRENT_STATE_SHAPE[1]);
+  input_data_map["ego_shape"] = zeros(EGO_SHAPE_SHAPE[1]);
+  for (int64_t b = 0; b < batch_size; ++b) {
+    input_data_map["ego_current_state"][static_cast<size_t>(b * EGO_CURRENT_STATE_SHAPE[1]) + 2] =
+      1.0f;
+    const size_t shape_base = static_cast<size_t>(b * EGO_SHAPE_SHAPE[1]);
+    input_data_map["ego_shape"][shape_base + 0] = 2.7f;  // wheel base, unused by the renderer
+    input_data_map["ego_shape"][shape_base + 1] = 5.0f;  // length
+    input_data_map["ego_shape"][shape_base + 2] = 2.0f;  // width
+  }
+  return input_data_map;
+}
+
+uint8_t pixel_at(
+  const std::vector<uint8_t> & image, const int64_t scale, const int64_t channel, const int64_t row,
+  const int64_t col)
+{
+  const size_t plane = (static_cast<size_t>(scale) * BEV_NUM_CHANNELS + channel) * PLANE_SIZE;
+  return image[plane + static_cast<size_t>(row * BEV_IMAGE_SIZE + col)];
+}
+
+int64_t count_set(const std::vector<uint8_t> & image, const int64_t scale, const int64_t channel)
+{
+  const size_t plane = (static_cast<size_t>(scale) * BEV_NUM_CHANNELS + channel) * PLANE_SIZE;
+  int64_t count = 0;
+  for (size_t pixel = 0; pixel < PLANE_SIZE; ++pixel) {
+    count += image[plane + pixel] != 0U ? 1 : 0;
+  }
+  return count;
+}
+
+/// Pixel a point lands on, recomputed independently of the renderer.
+int64_t to_row(const double x_rel, const double extent_m)
+{
+  return CENTER_PIXEL - static_cast<int64_t>(std::lround(x_rel * BEV_IMAGE_SIZE / extent_m));
+}
+
+int64_t to_col(const double y_rel, const double extent_m)
+{
+  return CENTER_PIXEL - static_cast<int64_t>(std::lround(y_rel * BEV_IMAGE_SIZE / extent_m));
+}
+
+/// Write a straight lane segment running from x = 1 m to x = 20 m along y = 0, with boundaries
+/// 1.75 m to either side. Points at the exact origin would read as padding, so the first sample
+/// starts one meter ahead.
+void fill_straight_lane(
+  std::vector<float> & lanes, const int64_t traffic_light_state, const int64_t num_points)
+{
+  for (int64_t p = 0; p < num_points; ++p) {
+    float * point = lanes.data() + p * SEGMENT_POINT_DIM;
+    point[X] = static_cast<float>(p + 1);
+    point[Y] = 0.0f;
+    point[LB_X] = 0.0f;
+    point[LB_Y] = 1.75f;
+    point[RB_X] = 0.0f;
+    point[RB_Y] = -1.75f;
+    if (traffic_light_state >= 0) {
+      point[traffic_light_state] = 1.0f;
+    }
+  }
+}
+}  // namespace
+
+TEST(BevImageTest, ShapeAndBinaryValues)
+{
+  const std::vector<uint8_t> image = preprocess::create_bev_image(make_empty_input_data(1), 1);
+
+  ASSERT_EQ(image.size(), SAMPLE_SIZE);
+  for (const uint8_t value : image) {
+    EXPECT_TRUE(value == 0U || value == 255U);
+  }
+}
+
+TEST(BevImageTest, EgoBoxIsCenteredAndOnItsOwnChannel)
+{
+  const std::vector<uint8_t> image = preprocess::create_bev_image(make_empty_input_data(1), 1);
+
+  for (const int64_t scale : {NEAR_SCALE, FAR_SCALE}) {
+    EXPECT_EQ(pixel_at(image, scale, preprocess::BEV_CH_EGO, CENTER_PIXEL, CENTER_PIXEL), 255U);
+    // A 5 m x 2 m box, so the near view (0.223 m per pixel) covers far more pixels than the far
+    // one (0.893 m per pixel).
+    EXPECT_GT(count_set(image, scale, preprocess::BEV_CH_EGO), 0);
+  }
+  EXPECT_GT(
+    count_set(image, NEAR_SCALE, preprocess::BEV_CH_EGO),
+    count_set(image, FAR_SCALE, preprocess::BEV_CH_EGO));
+
+  // Nothing else is present in an empty scene, and the ego history collapses onto the origin.
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_VEHICLE), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_GOAL_POSE), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_GO), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_CAUTION), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_STOP), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_UNKNOWN), 0);
+}
+
+TEST(BevImageTest, LaneCenterlineAndBoundariesLandOnTheirOwnChannels)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  fill_straight_lane(input_data_map["lanes"], -1, POINTS_PER_SEGMENT);
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  const int64_t row = to_row(10.0, BEV_NEAR_EXTENT_M);
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, row, to_col(0.0, BEV_NEAR_EXTENT_M)),
+    255U);
+  // Ego-left maps to image-left, so the left boundary sits at the smaller column.
+  const int64_t left_col = to_col(1.75, BEV_NEAR_EXTENT_M);
+  const int64_t right_col = to_col(-1.75, BEV_NEAR_EXTENT_M);
+  EXPECT_LT(left_col, right_col);
+  EXPECT_EQ(pixel_at(image, NEAR_SCALE, preprocess::BEV_CH_LANE_BOUNDARY, row, left_col), 255U);
+  EXPECT_EQ(pixel_at(image, NEAR_SCALE, preprocess::BEV_CH_LANE_BOUNDARY, row, right_col), 255U);
+  // The boundaries never bleed into the centerline channel and vice versa.
+  EXPECT_EQ(pixel_at(image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, row, left_col), 0U);
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_LANE_BOUNDARY, row, to_col(0.0, BEV_NEAR_EXTENT_M)),
+    0U);
+
+  // fill_straight_lane left every state slot zero, so no light plane is touched.
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_GO), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_CAUTION), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_STOP), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_TRAFFIC_LIGHT_UNKNOWN), 0);
+}
+
+TEST(BevImageTest, PolylineStopsAtThePadding)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  // Only the first five samples are real; the rest of the segment is zero padding.
+  fill_straight_lane(input_data_map["lanes"], -1, 5);
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, to_row(5.0, BEV_NEAR_EXTENT_M),
+      to_col(0.0, BEV_NEAR_EXTENT_M)),
+    255U);
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, to_row(10.0, BEV_NEAR_EXTENT_M),
+      to_col(0.0, BEV_NEAR_EXTENT_M)),
+    0U);
+}
+
+TEST(BevImageTest, EveryTrafficLightStateGetsItsOwnChannel)
+{
+  // A lane with no light at all is drawn on none of the four planes; that silence is what
+  // distinguishes it from a lane whose light state never arrived.
+  const std::vector<std::pair<int64_t, int64_t>> channel_of_state = {
+    {TRAFFIC_LIGHT_GREEN, preprocess::BEV_CH_TRAFFIC_LIGHT_GO},
+    {TRAFFIC_LIGHT_YELLOW, preprocess::BEV_CH_TRAFFIC_LIGHT_CAUTION},
+    {TRAFFIC_LIGHT_RED, preprocess::BEV_CH_TRAFFIC_LIGHT_STOP},
+    {TRAFFIC_LIGHT_WHITE, preprocess::BEV_CH_TRAFFIC_LIGHT_UNKNOWN},
+    {TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT, -1},
+  };
+
+  for (const auto & [light_index, expected_channel] : channel_of_state) {
+    preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+    fill_straight_lane(input_data_map["lanes"], light_index, POINTS_PER_SEGMENT);
+
+    const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+    for (const auto & [other_state, channel] : channel_of_state) {
+      if (channel < 0) {
+        continue;
+      }
+      const int64_t drawn = count_set(image, NEAR_SCALE, channel);
+      if (channel == expected_channel) {
+        EXPECT_GT(drawn, 0) << "state " << light_index << " should light channel " << channel;
+      } else {
+        EXPECT_EQ(drawn, 0) << "state " << light_index << " must not touch channel " << channel
+                            << " (belonging to state " << other_state << ")";
+      }
+    }
+  }
+}
+
+TEST(BevImageTest, YellowIsNotInterchangeableWithRed)
+{
+  preprocess::InputDataMap yellow = make_empty_input_data(1);
+  fill_straight_lane(yellow["lanes"], TRAFFIC_LIGHT_YELLOW, POINTS_PER_SEGMENT);
+  preprocess::InputDataMap red = make_empty_input_data(1);
+  fill_straight_lane(red["lanes"], TRAFFIC_LIGHT_RED, POINTS_PER_SEGMENT);
+
+  EXPECT_NE(preprocess::create_bev_image(yellow, 1), preprocess::create_bev_image(red, 1));
+}
+
+TEST(BevImageTest, NeighborBoxAndTrackUseTheClassChannel)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  std::vector<float> & neighbors = input_data_map["neighbor_agents_past"];
+  constexpr int64_t STATE_DIM = static_cast<int64_t>(AGENT_STATE_DIM);
+
+  // One bicycle driving from 5 m to 10 m ahead, 4 m to the left of ego.
+  for (int64_t t = 0; t < INPUT_T_WITH_CURRENT; ++t) {
+    float * state = neighbors.data() + t * STATE_DIM;
+    state[X] = 5.0f + static_cast<float>(t) * (5.0f / static_cast<float>(INPUT_T));
+    state[Y] = 4.0f;
+    state[2] = 1.0f;   // cos yaw
+    state[3] = 0.0f;   // sin yaw
+    state[6] = 0.6f;   // width
+    state[7] = 1.8f;   // length
+    state[10] = 1.0f;  // bicycle one-hot
+  }
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_BICYCLE, to_row(10.0, BEV_NEAR_EXTENT_M),
+      to_col(4.0, BEV_NEAR_EXTENT_M)),
+    255U);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_VEHICLE), 0);
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_PEDESTRIAN), 0);
+  // The track runs from 5 m to 10 m, so it is drawn well behind the current box.
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_NEIGHBOR_HISTORY, to_row(5.0, BEV_NEAR_EXTENT_M),
+      to_col(4.0, BEV_NEAR_EXTENT_M)),
+    255U);
+}
+
+TEST(BevImageTest, ScaleChangesTheMetersPerPixel)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  fill_straight_lane(input_data_map["lanes"], -1, POINTS_PER_SEGMENT);
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  // 20 m ahead is inside both views, but four times closer to the center in the far one.
+  EXPECT_EQ(
+    pixel_at(
+      image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, to_row(20.0, BEV_NEAR_EXTENT_M),
+      to_col(0.0, BEV_NEAR_EXTENT_M)),
+    255U);
+  EXPECT_EQ(
+    pixel_at(
+      image, FAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE, to_row(20.0, BEV_FAR_EXTENT_M),
+      to_col(0.0, BEV_FAR_EXTENT_M)),
+    255U);
+  EXPECT_GT(
+    count_set(image, NEAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE),
+    count_set(image, FAR_SCALE, preprocess::BEV_CH_LANE_CENTERLINE));
+}
+
+TEST(BevImageTest, GoalPoseBeyondTheFarViewDrawsNothing)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  std::vector<float> & goal_pose = input_data_map["goal_pose"];
+  goal_pose[X] = 5000.0f;
+  goal_pose[Y] = 0.0f;
+  goal_pose[2] = 1.0f;
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_GOAL_POSE), 0);
+  EXPECT_EQ(count_set(image, FAR_SCALE, preprocess::BEV_CH_GOAL_POSE), 0);
+}
+
+TEST(BevImageTest, GoalPoseInsideTheFarViewIsMarked)
+{
+  preprocess::InputDataMap input_data_map = make_empty_input_data(1);
+  std::vector<float> & goal_pose = input_data_map["goal_pose"];
+  goal_pose[X] = 80.0f;
+  goal_pose[Y] = 0.0f;
+  goal_pose[2] = 1.0f;
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, 1);
+
+  // 80 m ahead is outside the 50 m view but inside the 200 m one.
+  EXPECT_EQ(count_set(image, NEAR_SCALE, preprocess::BEV_CH_GOAL_POSE), 0);
+  EXPECT_EQ(
+    pixel_at(
+      image, FAR_SCALE, preprocess::BEV_CH_GOAL_POSE, to_row(80.0, BEV_FAR_EXTENT_M),
+      to_col(0.0, BEV_FAR_EXTENT_M)),
+    255U);
+}
+
+TEST(BevImageTest, EveryBatchEntryCarriesTheSameRaster)
+{
+  constexpr int64_t BATCH_SIZE = 3;
+  preprocess::InputDataMap input_data_map = make_empty_input_data(BATCH_SIZE);
+  fill_straight_lane(input_data_map["lanes"], -1, POINTS_PER_SEGMENT);
+
+  const std::vector<uint8_t> image = preprocess::create_bev_image(input_data_map, BATCH_SIZE);
+
+  ASSERT_EQ(image.size(), SAMPLE_SIZE * BATCH_SIZE);
+  for (int64_t b = 1; b < BATCH_SIZE; ++b) {
+    EXPECT_TRUE(
+      std::equal(
+        image.begin(), image.begin() + static_cast<std::ptrdiff_t>(SAMPLE_SIZE),
+        image.begin() + static_cast<std::ptrdiff_t>(static_cast<size_t>(b) * SAMPLE_SIZE)))
+      << "batch entry " << b << " differs";
+  }
+}
+
+TEST(BevImageTest, ColorizeMarksTheEgoInWhite)
+{
+  const std::vector<uint8_t> image = preprocess::create_bev_image(make_empty_input_data(1), 1);
+  const std::vector<uint8_t> preview = preprocess::colorize_bev_image(image, NEAR_SCALE);
+
+  ASSERT_EQ(preview.size(), PLANE_SIZE * 3);
+  const size_t center = static_cast<size_t>(CENTER_PIXEL * BEV_IMAGE_SIZE + CENTER_PIXEL) * 3;
+  EXPECT_EQ(preview[center + 0], 255U);
+  EXPECT_EQ(preview[center + 1], 255U);
+  EXPECT_EQ(preview[center + 2], 255U);
+  // A corner of an otherwise empty scene stays background.
+  EXPECT_EQ(preview[0], 0U);
+}
+
+}  // namespace autoware::diffusion_planner::test


### PR DESCRIPTION
## Description

Enable Diffusion Planner models whose encoder takes BEV image input: render lane/agent/ego tensors into multi-scale BEV rasters, pass them through ONNX inference, and optionally publish a colorized debug preview.

Cherry-picked from Sakoda's work (`b3960ed`) and **rebased onto current `tier4:feat/v0.64/e2e`** with DCO sign-off. This replaces the earlier fork-only PR that targeted `Owen-Liuyuxuan:feat/v0.64/e2e` (that PR also contained an extra merge commit).

## Related links

**Parent Issue:**

- N/A

- Original cherry-pick PR (Owen fork, do not merge): https://github.com/Owen-Liuyuxuan/autoware.universe/pull/21
- Source commit: `b3960ed8bdeeb14a958d93fb2f60c902193535ff`

## How was this PR tested?

- [ ] Not run on this rebase — see original PR / CI
- [ ] `bev_image_test` (new unit tests)

## Notes for reviewers

Single commit on top of `feat/v0.64/e2e` (no merge commit). Author remains Shintaro Sakoda; committer sign-off added for DCO.

## Interface changes

Added debug image pubs and a debug parameter:

| Change type | Topic Type | Topic Name | Message Type | Description |
|:------------|:-----------|:-----------|:-------------|:------------|
| Added | Pub | `~/debug/bev_image_<extent>m` | `sensor_msgs/Image` | Colorized preview of rendered BEV rasters (one image per scale); image-input models only |

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `debug_params.publish_debug_bev_image` | `bool` | `false` | Publish the colorized BEV preview |

## Effects on system behavior

Vector-input models keep the previous path. Image-input models now receive rendered BEV rasters. Debug BEV publish is off by default.


Made with [Cursor](https://cursor.com)