### PR TITLE
fix(autoware_cuda_pointcloud_preprocessor): stop over-allocating the concatenated cloud by the lidar count (#13287)

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -81,8 +81,8 @@ void CombineCloudHandler<CudaPointCloud2Traits>::allocate_pointclouds()
   }
 
   concatenated_cloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
-  concatenated_cloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
-    max_concat_pointcloud_size_ * input_topics_.size());
+  concatenated_cloud_ptr_->data =
+    cuda_blackboard::make_unique<std::uint8_t[]>(max_concat_pointcloud_size_);
 }
 
 ConcatenatedCloudResult<CudaPointCloud2Traits>
@@ -131,8 +131,8 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   if (total_data_size > max_concat_pointcloud_size_ || !concatenated_cloud_ptr_) {
     max_concat_pointcloud_size_ = CHUNK_SIZE * (1 + total_data_size / CHUNK_SIZE);
     concatenated_cloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
-    concatenated_cloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
-      max_concat_pointcloud_size_ * input_topics_.size());
+    concatenated_cloud_ptr_->data =
+      cuda_blackboard::make_unique<std::uint8_t[]>(max_concat_pointcloud_size_);
   }
 
   concatenate_cloud_result.concatenate_cloud_ptr = std::move(concatenated_cloud_ptr_);


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware_universe/pull/13287

Cherry-pick of b149610239175fb777ec0d47f4d95eaf9b318029.
Fixes 8x over-allocation of concat GPU memory.