### PR TITLE
feat(minimum_rule_based_planner): fix backup planner obstacle stop collision tracking

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -157,7 +157,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
   const auto target_stop_point_arc_length = clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - stop_margin,
     debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
-    data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
+    data.acceleration_ptr->accel.accel.linear.x, params_.maximum_stopping_decel,
     params_.stopping_jerk);
 
   if (
@@ -271,7 +271,7 @@ void ObstacleStop::update_collision_points_buffer(
   std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
   const std::optional<CollisionPoint> & collision_point)
 {
-  constexpr double close_distance_threshold = 0.5;
+  constexpr double close_distance_threshold = 1.0;
 
   const auto now = get_clock()->now();
 
@@ -291,10 +291,10 @@ void ObstacleStop::update_collision_points_buffer(
   auto nearest_collision_point_it = collision_points_buffer.end();
   auto nearest_distance_diff = std::numeric_limits<double>::max();
   for (auto it = collision_points_buffer.begin(); it != collision_points_buffer.end(); ++it) {
-    const auto estimated_shift = it->obstacle_speed * (now - it->last_seen).seconds();
+    const auto estimated_shift = std::abs(it->obstacle_lon_vel) * (now - it->last_seen).seconds();
     it->arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, it->point);
-    const auto raw_distance_diff = collision_point->arc_length - it->arc_length;
-    const auto distance_diff = raw_distance_diff - estimated_shift;
+    const auto expected_arc_length = it->arc_length + estimated_shift;
+    const auto distance_diff = collision_point->arc_length - expected_arc_length;
     if (
       std::abs(distance_diff) > close_distance_threshold ||
       std::abs(distance_diff) > std::abs(nearest_distance_diff))
@@ -314,12 +314,10 @@ void ObstacleStop::update_collision_points_buffer(
   }
 
   nearest_collision_point_it->last_seen = now;
-  nearest_collision_point_it->obstacle_speed = collision_point->obstacle_speed;
+  nearest_collision_point_it->obstacle_lon_vel = collision_point->obstacle_lon_vel;
   nearest_collision_point_it->is_dynamic = collision_point->is_dynamic;
-  if (nearest_distance_diff < 0.0 || collision_point->is_dynamic) {
-    nearest_collision_point_it->point = collision_point->point;
-    nearest_collision_point_it->arc_length = collision_point->arc_length;
-  }
+  nearest_collision_point_it->point = collision_point->point;
+  nearest_collision_point_it->arc_length = collision_point->arc_length;
 }
 
 std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -270,7 +270,7 @@ void ObstacleStop::update_collision_points_buffer(
   std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
   const std::optional<CollisionPoint> & collision_point)
 {
-  constexpr double close_distance_threshold = 1.0;
+  constexpr double close_distance_threshold = 0.5;
 
   const auto now = get_clock()->now();
 
@@ -279,25 +279,27 @@ void ObstacleStop::update_collision_points_buffer(
     std::remove_if(
       collision_points_buffer.begin(), collision_points_buffer.end(),
       [&](CollisionPoint & cp) {
-        if (cp.is_active && (now - cp.start_time).seconds() > params_.off_time_buffer) return true;
+        if (cp.is_active && (now - cp.last_seen).seconds() > params_.off_time_buffer) return true;
 
         if (!collision_point && !cp.is_active) return true;
+
+        const auto distance_th =
+          cp.obstacle_speed * (now - cp.last_seen).seconds() + close_distance_threshold;
 
         cp.arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, cp.point);
         const auto distance_diff = collision_point ? collision_point->arc_length - cp.arc_length
                                                    : std::numeric_limits<double>::max();
-        const bool is_close = abs(distance_diff) < close_distance_threshold;
+        const bool is_close = std::abs(distance_diff) < distance_th;
 
         if (!cp.is_active && !is_close) return true;
 
-        if (!cp.is_active && (now - cp.start_time).seconds() > params_.on_time_buffer) {
+        if (!cp.is_active && (now - cp.first_seen).seconds() > params_.on_time_buffer) {
           cp.is_active = true;
-          cp.start_time = now;
         }
 
         if (
           is_close &&
-          (!closest_distance_diff || abs(distance_diff) < abs(*closest_distance_diff))) {
+          (!closest_distance_diff || std::abs(distance_diff) < std::abs(*closest_distance_diff))) {
           closest_distance_diff = distance_diff;
         }
 
@@ -309,24 +311,24 @@ void ObstacleStop::update_collision_points_buffer(
 
   constexpr double eps = 1e-3;
   if (collision_points_buffer.empty() || !closest_distance_diff) {
-    collision_points_buffer.emplace_back(*collision_point, now, params_.on_time_buffer < eps);
+    collision_points_buffer.emplace_back(*collision_point, now, now, params_.on_time_buffer < eps);
     return;
   }
 
   auto nearest_collision_point_it = std::find_if(
     collision_points_buffer.begin(), collision_points_buffer.end(), [&](const CollisionPoint & cp) {
-      return abs(cp.arc_length - collision_point->arc_length) < abs(*closest_distance_diff) + eps;
+      return std::abs(cp.arc_length - collision_point->arc_length) <
+             std::abs(*closest_distance_diff) + eps;
     });
 
   if (nearest_collision_point_it == collision_points_buffer.end()) return;
 
-  if (*closest_distance_diff < 0.0) {
+  nearest_collision_point_it->last_seen = now;
+  nearest_collision_point_it->obstacle_speed = collision_point->obstacle_speed;
+  nearest_collision_point_it->is_dynamic = collision_point->is_dynamic;
+  if (*closest_distance_diff < 0.0 || collision_point->is_dynamic) {
     nearest_collision_point_it->point = collision_point->point;
     nearest_collision_point_it->arc_length = collision_point->arc_length;
-  }
-
-  if (nearest_collision_point_it->is_active) {
-    nearest_collision_point_it->start_time = now;
   }
 }
 
@@ -338,7 +340,7 @@ std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
 
   auto minimum_arc_length = std::numeric_limits<double>::max();
   for (const auto & cp : collision_points_buffer) {
-    if (cp.is_active > minimum_arc_length || !cp.is_active) continue;
+    if (cp.arc_length > minimum_arc_length || !cp.is_active) continue;
     nearest_collision_point = cp;
     minimum_arc_length = cp.arc_length;
   }

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -22,6 +22,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <memory>
@@ -274,59 +275,48 @@ void ObstacleStop::update_collision_points_buffer(
 
   const auto now = get_clock()->now();
 
-  std::optional<double> closest_distance_diff = std::nullopt;
+  // prune obsolete collision points
   collision_points_buffer.erase(
     std::remove_if(
       collision_points_buffer.begin(), collision_points_buffer.end(),
       [&](CollisionPoint & cp) {
-        if (cp.is_active && (now - cp.last_seen).seconds() > params_.off_time_buffer) return true;
-
-        if (!collision_point && !cp.is_active) return true;
-
-        const auto distance_th =
-          cp.obstacle_speed * (now - cp.last_seen).seconds() + close_distance_threshold;
-
-        cp.arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, cp.point);
-        const auto distance_diff = collision_point ? collision_point->arc_length - cp.arc_length
-                                                   : std::numeric_limits<double>::max();
-        const bool is_close = std::abs(distance_diff) < distance_th;
-
-        if (!cp.is_active && !is_close) return true;
-
-        if (!cp.is_active && (now - cp.first_seen).seconds() > params_.on_time_buffer) {
-          cp.is_active = true;
-        }
-
-        if (
-          is_close &&
-          (!closest_distance_diff || std::abs(distance_diff) < std::abs(*closest_distance_diff))) {
-          closest_distance_diff = distance_diff;
-        }
-
-        return false;
+        if (cp.is_active) return (now - cp.last_seen).seconds() > params_.off_time_buffer;
+        return !collision_point;
       }),
     collision_points_buffer.end());
 
   if (!collision_point) return;
 
+  // find nearest tracked collision
+  auto nearest_collision_point_it = collision_points_buffer.end();
+  auto nearest_distance_diff = std::numeric_limits<double>::max();
+  for (auto it = collision_points_buffer.begin(); it != collision_points_buffer.end(); ++it) {
+    const auto estimated_shift = it->obstacle_speed * (now - it->last_seen).seconds();
+    it->arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, it->point);
+    const auto raw_distance_diff = collision_point->arc_length - it->arc_length;
+    const auto distance_diff = raw_distance_diff - estimated_shift;
+    if (
+      std::abs(distance_diff) > close_distance_threshold ||
+      std::abs(distance_diff) > std::abs(nearest_distance_diff))
+      continue;
+    nearest_collision_point_it = it;
+    nearest_distance_diff = distance_diff;
+  }
+
   constexpr double eps = 1e-3;
-  if (collision_points_buffer.empty() || !closest_distance_diff) {
+  if (nearest_collision_point_it == collision_points_buffer.end()) {
     collision_points_buffer.emplace_back(*collision_point, now, now, params_.on_time_buffer < eps);
     return;
   }
 
-  auto nearest_collision_point_it = std::find_if(
-    collision_points_buffer.begin(), collision_points_buffer.end(), [&](const CollisionPoint & cp) {
-      return std::abs(cp.arc_length - collision_point->arc_length) <
-             std::abs(*closest_distance_diff) + eps;
-    });
-
-  if (nearest_collision_point_it == collision_points_buffer.end()) return;
+  if ((now - nearest_collision_point_it->first_seen).seconds() > params_.on_time_buffer) {
+    nearest_collision_point_it->is_active = true;
+  }
 
   nearest_collision_point_it->last_seen = now;
   nearest_collision_point_it->obstacle_speed = collision_point->obstacle_speed;
   nearest_collision_point_it->is_dynamic = collision_point->is_dynamic;
-  if (*closest_distance_diff < 0.0 || collision_point->is_dynamic) {
+  if (nearest_distance_diff < 0.0 || collision_point->is_dynamic) {
     nearest_collision_point_it->point = collision_point->point;
     nearest_collision_point_it->arc_length = collision_point->arc_length;
   }

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -121,7 +121,7 @@ struct CollisionPoint
 {
   geometry_msgs::msg::Point point;
   double arc_length;
-  double obstacle_speed;
+  double obstacle_lon_vel;
   bool is_active{false};
   bool is_dynamic{false};
   rclcpp::Time first_seen;
@@ -134,9 +134,9 @@ struct CollisionPoint
    * @param is_dynamic Whether this collision is dynamic.
    */
   CollisionPoint(
-    const geometry_msgs::msg::Point & point, const double arc_length, const double obstacle_speed,
+    const geometry_msgs::msg::Point & point, const double arc_length, const double obstacle_lon_vel,
     const bool is_dynamic = false)
-  : point(point), arc_length(arc_length), obstacle_speed(obstacle_speed), is_dynamic(is_dynamic)
+  : point(point), arc_length(arc_length), obstacle_lon_vel(obstacle_lon_vel), is_dynamic(is_dynamic)
   {
   }
 
@@ -152,7 +152,7 @@ struct CollisionPoint
     const rclcpp::Time & last_seen, const bool active)
   : point(collision_point.point),
     arc_length(collision_point.arc_length),
-    obstacle_speed(collision_point.obstacle_speed),
+    obstacle_lon_vel(collision_point.obstacle_lon_vel),
     is_active(active),
     is_dynamic(collision_point.is_dynamic),
     first_seen(first_seen),

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -121,9 +121,11 @@ struct CollisionPoint
 {
   geometry_msgs::msg::Point point;
   double arc_length;
-  rclcpp::Time start_time;
+  double obstacle_speed;
   bool is_active{false};
   bool is_dynamic{false};
+  rclcpp::Time first_seen;
+  rclcpp::Time last_seen;
 
   /**
    * @brief Construct a collision sample from a point and its arc length along the reference path.
@@ -132,8 +134,9 @@ struct CollisionPoint
    * @param is_dynamic Whether this collision is dynamic.
    */
   CollisionPoint(
-    const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
-  : point(point), arc_length(arc_length), is_dynamic(is_dynamic)
+    const geometry_msgs::msg::Point & point, const double arc_length, const double obstacle_speed,
+    const bool is_dynamic = false)
+  : point(point), arc_length(arc_length), obstacle_speed(obstacle_speed), is_dynamic(is_dynamic)
   {
   }
 
@@ -144,12 +147,15 @@ struct CollisionPoint
    * @param active Whether this collision is currently considered active.
    */
   CollisionPoint(
-    const CollisionPoint & collision_point, const rclcpp::Time & start_time, const bool active)
+    const CollisionPoint & collision_point, const rclcpp::Time & first_seen,
+    const rclcpp::Time & last_seen, const bool active)
   : point(collision_point.point),
     arc_length(collision_point.arc_length),
-    start_time(start_time),
+    obstacle_speed(collision_point.obstacle_speed),
     is_active(active),
-    is_dynamic(collision_point.is_dynamic)
+    is_dynamic(collision_point.is_dynamic),
+    first_seen(first_seen),
+    last_seen(last_seen)
   {
   }
 };

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -143,7 +143,8 @@ struct CollisionPoint
   /**
    * @brief Copy a collision point and attach timing / activation state (e.g. for hysteresis).
    * @param collision_point Source geometry and arc length.
-   * @param start_time Time associated with this collision state.
+   * @param first_seen Time associated with first detection of this collision state.
+   * @param last_seen Time associated with last detection of this collision state.
    * @param active Whether this collision is currently considered active.
    */
   CollisionPoint(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -323,7 +323,7 @@ ObjectState get_object_state_at_time(
     const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
-    return std::max(0.0, obj_vel_vector.dot(traj_dir));
+    return obj_vel_vector.dot(traj_dir);
   }();
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
@@ -364,8 +364,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  double obstacle_speed = 0.0;
-  bool is_dynamic_collision = false;
+  double obstacle_lon_vel = 0.0;
   for (const auto & object : target_objects.objects) {
     const auto obj_state = get_object_state_at_time(trajectory_points, object, 0.0);
     found_collision = true;
@@ -373,14 +372,14 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       min_arc_length = obj_state.arc_length;
       nearest_collision_point = obj_state.nearest_point;
       colliding_object = object;
-      obstacle_speed = std::abs(obj_state.lon_vel);
-      is_dynamic_collision = obj_state.lon_vel > stopped_vel_th;
+      obstacle_lon_vel = obj_state.lon_vel;
     }
   }
 
   if (!found_collision) return std::nullopt;
   return CollisionPoint(
-    nearest_collision_point, min_arc_length, obstacle_speed, is_dynamic_collision);
+    nearest_collision_point, min_arc_length, obstacle_lon_vel,
+    std::abs(obstacle_lon_vel) > stopped_vel_th);
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
@@ -430,8 +429,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto min_collision_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  bool is_dynamic_collision = false;
-  double obstacle_speed = 0.0;
+  double obstacle_lon_vel = 0.0;
 
   for (const auto & object : target_objects.objects) {
     auto last_p = trajectory_points.front().pose.position;
@@ -456,8 +454,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
           trajectory_points, obj_state.nearest_point, obj_stopping_distance);
         nearest_collision_point =
           collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
-        is_dynamic_collision = obj_state.lon_vel > stopped_vel_th;
-        obstacle_speed = std::abs(obj_state.lon_vel);
+        obstacle_lon_vel = obj_state.lon_vel;
       }
       break;
     }
@@ -465,7 +462,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   if (!found_collision) return std::nullopt;
   return CollisionPoint(
-    nearest_collision_point, min_collision_arc_length, obstacle_speed, is_dynamic_collision);
+    nearest_collision_point, min_collision_arc_length, obstacle_lon_vel,
+    std::abs(obstacle_lon_vel) > stopped_vel_th);
 }
 
 void PointCloudFilter::filter_pointcloud(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -259,35 +259,7 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
     target_pcd_points.emplace_back(p);
   }
 
-  return CollisionPoint(nearest_collision_point, min_arc_length);
-}
-
-std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
-  PredictedObject & colliding_object)
-{
-  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
-
-  auto min_arc_length = std::numeric_limits<double>::max();
-  geometry_msgs::msg::Point nearest_collision_point;
-  bool found_collision = false;
-  for (const auto & object : target_objects.objects) {
-    const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-    const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    found_collision = true;
-    for (const auto & point : object_polygon.outer()) {
-      geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
-      auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
-      if (arc_length < min_arc_length) {
-        min_arc_length = arc_length;
-        nearest_collision_point = p;
-        colliding_object = object;
-      }
-    }
-  }
-
-  if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_arc_length);
+  return CollisionPoint(nearest_collision_point, min_arc_length, 0.0);
 }
 
 geometry_msgs::msg::Pose extrapolate_object_pose_from_kinematics(
@@ -384,6 +356,34 @@ double get_safe_distance(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
+  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
+  PredictedObject & colliding_object, const double stopped_vel_th)
+{
+  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+
+  auto min_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_collision_point;
+  bool found_collision = false;
+  double obstacle_speed = 0.0;
+  bool is_dynamic_collision = false;
+  for (const auto & object : target_objects.objects) {
+    const auto obj_state = get_object_state_at_time(trajectory_points, object, 0.0);
+    found_collision = true;
+    if (obj_state.arc_length < min_arc_length) {
+      min_arc_length = obj_state.arc_length;
+      nearest_collision_point = obj_state.nearest_point;
+      colliding_object = object;
+      obstacle_speed = std::abs(obj_state.lon_vel);
+      is_dynamic_collision = obj_state.lon_vel > stopped_vel_th;
+    }
+  }
+
+  if (!found_collision) return std::nullopt;
+  return CollisionPoint(
+    nearest_collision_point, min_arc_length, obstacle_speed, is_dynamic_collision);
+}
+
+std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
@@ -395,7 +395,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   // If RSS check is disabled, get the nearest object collision by pure geometric overlap.
   if (!use_rss_check) {
-    return get_nearest_object_collision(trajectory_points, target_objects, colliding_object);
+    return get_nearest_object_collision(
+      trajectory_points, target_objects, colliding_object, stopped_vel_th);
   }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
@@ -417,19 +418,20 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const double obj_arc_length, const double obj_stopping_distance,
-                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
-    if (obj_stopping_distance <= eps) return {false, false};
+                   const double ego_arc_length, const double ego_vel) -> bool {
+    if (obj_stopping_distance <= eps) return false;
     const auto safe_dist =
       get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    return {relative_arc_length - safe_dist > 1e-3, true};
+    return relative_arc_length - safe_dist > 1e-3;
   };
 
   auto min_collision_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   bool is_dynamic_collision = false;
+  double obstacle_speed = 0.0;
 
   for (const auto & object : target_objects.objects) {
     auto last_p = trajectory_points.front().pose.position;
@@ -442,7 +444,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
       const auto obj_stopping_distance = get_object_stopping_distance(object, obj_state.lon_vel);
-      const auto [safe, dynamic] =
+      const auto safe =
         is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
       if (safe) continue;
       found_collision = true;
@@ -454,14 +456,16 @@ std::optional<CollisionPoint> get_nearest_object_collision(
           trajectory_points, obj_state.nearest_point, obj_stopping_distance);
         nearest_collision_point =
           collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
-        is_dynamic_collision = dynamic;
+        is_dynamic_collision = obj_state.lon_vel > stopped_vel_th;
+        obstacle_speed = std::abs(obj_state.lon_vel);
       }
       break;
     }
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_collision_arc_length, is_dynamic_collision);
+  return CollisionPoint(
+    nearest_collision_point, min_collision_arc_length, obstacle_speed, is_dynamic_collision);
 }
 
 void PointCloudFilter::filter_pointcloud(


### PR DESCRIPTION
## Description

Improves obstacle-stop collision tracking in the backup planner so moving (including oncoming) obstacles stay correctly associated across frames.
Collision points now carry path-projected longitudinal speed and first/last-seen timestamps, and buffer association uses a speed-aware expected arc-length gate instead of a fixed distance check.

### Changes

- Replace `CollisionPoint::start_time` with `first_seen` / `last_seen`, and store path-projected `obstacle_lon_vel` on each collision
- Modify geometric collision check to utilize `get_object_state_at_time` at `t=0`
- Preserve signed longitudinal velocity so oncoming obstacles associate and track correctly
- Refactor `update_collision_points_buffer()`: prune by `last_seen` / presence, associate with `estimated_shift = |vel| * dt`, activate after `on_time_buffer`, and always refresh pose / velocity / dynamic flag on match
- Use `maximum_stopping_decel` when clamping the stop-point arc length

## How was this PR tested?
### PSIM

**Static obstacle:**
before:

[Screencast from 2026年09月01日 10時14分33秒.webm](https://github.com/user-attachments/assets/963f4c63-d398-44c3-9f7f-c0a43fd2c5e8)

after:

[Screencast from 2026年09月01日 09時54分50秒.webm](https://github.com/user-attachments/assets/1e786082-8b7b-4075-b2d6-2949f7eb2f66)

---
**Moving Obstacle:**
before:

[Screencast from 2026年09月01日 10時16分08秒.webm](https://github.com/user-attachments/assets/013368df-6bf9-4f44-878a-def03870b53e)

after:

[Screencast from 2026年09月01日 09時57分58秒.webm](https://github.com/user-attachments/assets/811280ab-8c51-4817-a44b-1e67b43e3888)

---
**Oncoming Obstacle:**
before:

[Screencast from 2026年09月01日 10時17分18秒.webm](https://github.com/user-attachments/assets/f04cf9bc-cef5-414c-b739-f098817fe1a1)

after:

[Screencast from 2026年09月01日 10時00分27秒.webm](https://github.com/user-attachments/assets/d47c1776-c090-48f7-9d7a-85d284d29135)