### PR TITLE
fix(trajectory_validator): replace is_feasible boolean to risk level …

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -174,7 +174,7 @@ void VelocityValidator::validate(
       if (is_stopped || std::abs(v_vel) < params_.rolling_back_velocity) {
         return false;
       }
-  
+
       if (std::abs(t_vel) < stopped_vel_th) {
         return std::signbit(v_vel);
       }

--- a/planning/autoware_trajectory_validator/README.md
+++ b/planning/autoware_trajectory_validator/README.md
@@ -9,7 +9,7 @@ This package provides a pluginlib-based C++ library for evaluating candidate tra
 For each input `CandidateTrajectories` message the library runs every loaded plugin against every trajectory:
 
 1. **Plugin evaluation**: each plugin's `is_feasible()` is called with the trajectory points and the current `ValidatorContext` (odometry, predicted objects, acceleration, HD map, traffic light states).
-2. **Feasibility decision**: a trajectory survives if every plugin listed in `filter_names` returns `is_feasible = true`. Plugins listed in `shadow_mode_filter_names` are evaluated and reported but never remove a trajectory.
+2. **Feasibility decision**: each plugin reports metrics with a risk level. A plugin accepts the trajectory when the worst risk level of its metrics is `SAFE`, `LOW_CAUTION`, or `HIGH_CAUTION`, and rejects it on `DANGER` or `FATAL`. A trajectory survives if every plugin listed in `filter_names` accepts it. Plugins listed in `shadow_mode_filter_names` are evaluated and reported but never remove a trajectory.
 3. **Diagnostics**: `TrajectoryValidatorDiagnostic` selects the best candidate (the one with the least severe action across all active filters), resolves the `(filter_name, action)` pair to a named `DiagnosticStatus` via the `configured_actions` parameter, and publishes every tracked status every cycle (active ones at their level, inactive ones at `OK` to prevent staleness). Shadow-mode filters never contribute to the action aggregation. See [docs/TrajectoryValidatorDiagnostic.md](docs/TrajectoryValidatorDiagnostic.md) for details.
 
 ## Built-in Plugins

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
@@ -57,8 +57,7 @@ inline RiskLevelType worst_risk_level(const std::vector<MetricReport> & metrics)
 
 inline bool is_feasible_based_on_risk(const RiskLevelType risk_level)
 {
-  return risk_level == RiskLevel::SAFE || risk_level == RiskLevel::LOW_CAUTION ||
-         risk_level == RiskLevel::HIGH_CAUTION;
+  return risk_level <= RiskLevel::HIGH_CAUTION;
 }
 }  // namespace autoware::trajectory_validator
 #endif  // AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__RISK_UTILS_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
@@ -55,6 +55,11 @@ inline RiskLevelType worst_risk_level(const std::vector<MetricReport> & metrics)
   return worst;
 }
 
+/**
+ * @brief Returns a boolean indicating the trajectory is feasible based on risk level.
+ * @param metrics Worst risk level.
+ * @return True if risk level is less or equal to HIGH_CAUTION.
+ */
 inline bool is_feasible(const RiskLevelType risk_level)
 {
   return risk_level <= RiskLevel::HIGH_CAUTION;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
@@ -55,7 +55,7 @@ inline RiskLevelType worst_risk_level(const std::vector<MetricReport> & metrics)
   return worst;
 }
 
-inline bool is_feasible_based_on_risk(const RiskLevelType risk_level)
+inline bool is_feasible(const RiskLevelType risk_level)
 {
   return risk_level <= RiskLevel::HIGH_CAUTION;
 }

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
@@ -54,5 +54,11 @@ inline RiskLevelType worst_risk_level(const std::vector<MetricReport> & metrics)
   }
   return worst;
 }
+
+inline bool is_feasible_based_on_risk(const RiskLevelType risk_level)
+{
+  return risk_level == RiskLevel::SAFE || risk_level == RiskLevel::LOW_CAUTION ||
+         risk_level == RiskLevel::HIGH_CAUTION;
+}
 }  // namespace autoware::trajectory_validator
 #endif  // AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__RISK_UTILS_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -45,7 +45,6 @@ using autoware_trajectory_validator::msg::RiskLevel;
 /** @brief Result of a single plugin's feasibility check. */
 struct ValidationResult
 {
-  bool is_feasible{true};
   std::vector<MetricReport> metrics;
   PlanningFactorArray planning_factors{};
 };

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -169,12 +169,13 @@ std::pair<PluginEvaluation, RiskLevel> TrajectoryValidator::summarize_feasibilit
   }
 
   const auto & val = res.value();
-  evaluation.is_feasible = val.is_feasible;
+  risk_level.level = worst_risk_level(val.metrics);
+  evaluation.is_feasible = is_feasible_based_on_risk(risk_level.level);
+
   if (!evaluation.is_feasible) {
     evaluation.reason = "Found failed metrics";
   }
 
-  risk_level.level = worst_risk_level(val.metrics);
   return {evaluation, risk_level};
 }
 

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -170,7 +170,7 @@ std::pair<PluginEvaluation, RiskLevel> TrajectoryValidator::summarize_feasibilit
 
   const auto & val = res.value();
   risk_level.level = worst_risk_level(val.metrics);
-  evaluation.is_feasible = is_feasible_based_on_risk(risk_level.level);
+  evaluation.is_feasible = is_feasible(risk_level.level);
 
   if (!evaluation.is_feasible) {
     evaluation.reason = "Found failed metrics";

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -157,7 +157,6 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     debug_markers_, global_params_.time_resolution);
 
   return ValidationResult{
-    calc_worst_risk({drac_artifact.risk, rss_artifact.risk}) < RiskLevel::DANGER,
     generate_metric_reports(drac_artifact, rss_artifact), std::move(planning_factors)};
 }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/point_cloud_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/point_cloud_collision_check_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "point_cloud_collision_check_filter.hpp"
 
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety
@@ -47,13 +48,14 @@ std::vector<pcc::StopObstacle> PointCloudCollisionCheckFilter::calc_obstacle_sto
   return {};
 }
 
-bool PointCloudCollisionCheckFilter::judge_stop_feasibility(
+RiskLevel PointCloudCollisionCheckFilter::judge_stop_risk(
   [[maybe_unused]] const std::vector<pcc::StopObstacle> & stop_obstacles,
   [[maybe_unused]] const geometry_msgs::msg::Twist & twist) const
 {
-  // It is not currently implemented. always return true.
-  bool is_feasible = true;
-  return is_feasible;
+  // It is not currently implemented. always return SAFE.
+  RiskLevel risk_level;
+  risk_level.level = RiskLevel::SAFE;
+  return risk_level;
 }
 
 PointCloudCollisionCheckFilter::result_t PointCloudCollisionCheckFilter::is_feasible(
@@ -70,10 +72,15 @@ PointCloudCollisionCheckFilter::result_t PointCloudCollisionCheckFilter::is_feas
 
   const auto stop_obstacles = calc_obstacle_stop(candidate_trajectory.points);
 
-  ValidationResult result{};
-  result.is_feasible = judge_stop_feasibility(stop_obstacles, context.odometry->twist.twist);
+  std::vector<MetricReport> metrics{
+    autoware_trajectory_validator::build<MetricReport>()
+      .validator_name(get_name())
+      .validator_category(category())
+      .metric_name("point_cloud_stop_feasibility")
+      .metric_value(static_cast<double>(stop_obstacles.size()))
+      .risk(judge_stop_risk(stop_obstacles, context.odometry->twist.twist))};
 
-  return result;
+  return ValidationResult{std::move(metrics)};
 }
 
 void PointCloudCollisionCheckFilter::update_parameters(const validator::Params & params)

--- a/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/point_cloud_collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/point_cloud_collision_check_filter.hpp
@@ -43,7 +43,7 @@ public:
 
 private:
   /// @brief 評価に必要な入力が揃っているかを判定する。
-  /// false のとき is_feasible は評価せず feasible（ValidationResult{}）を返す。
+  /// false のとき is_feasible は評価せず、メトリクスなし（ValidationResult{}）を返す。
   bool is_available_data(
     const CandidateTrajectory & candidate_trajectory, const FilterContext & context) const;
 
@@ -60,8 +60,8 @@ private:
   std::vector<point_cloud_collision_check::StopObstacle> calc_obstacle_stop(
     const std::vector<TrajectoryPoint> & raw_trajectory_points);
 
-  /// @brief 停止対象から停止可否を判定する。未実装のため現状は常に true を返す。
-  bool judge_stop_feasibility(
+  /// @brief 停止対象から停止可否のリスクレベルを判定する。未実装のため現状は常に SAFE を返す。
+  RiskLevel judge_stop_risk(
     const std::vector<point_cloud_collision_check::StopObstacle> & stop_obstacles,
     const geometry_msgs::msg::Twist & twist) const;
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/trajectory_feasibility_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/trajectory_feasibility_filter.cpp
@@ -177,17 +177,16 @@ TrajectoryFeasibilityFilter::result_t TrajectoryFeasibilityFilter::is_feasible(
     return tl::make_unexpected("Vehicle info not set");
   }
 
-  // NOTE: Feasibility decision logic might be more complex in the future, but for now we just
-  // check all constraints and return false if any are violated
-  bool is_feasible = true;
+  // Each checker reports its own risk level. The core derives feasibility from the worst risk
+  // level of these metrics, so a violated constraint reports HIGH_CAUTION and does not reject the
+  // trajectory on its own.
   std::vector<MetricReport> metrics;
   for (const auto & checker : checkers_) {
     auto report = (this->*checker)(traj_points, context);
-    is_feasible &= report.risk.level == RiskLevel::SAFE;
     metrics.push_back(report);
   }
 
-  return ValidationResult{is_feasible, std::move(metrics)};
+  return ValidationResult{std::move(metrics)};
 }
 
 MetricReport TrajectoryFeasibilityFilter::check_speed(

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -75,8 +75,9 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
                                       .metric_value(status.lat_dist_to_uncrossable_bound)
                                       .risk(risk_level)};
 
-  // Only a CRITICAL departure rejects the trajectory. NEAR_BOUNDARY is advisory.
-  return ValidationResult{!is_critical_departure, std::move(metrics)};
+  // Only a CRITICAL departure rejects the trajectory, because it reports DANGER. NEAR_BOUNDARY
+  // reports LOW_CAUTION and is advisory.
+  return ValidationResult{std::move(metrics)};
 }
 
 void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Params & params)

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
@@ -355,7 +355,7 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
   const auto target_crosswalks = get_target_crosswalks(candidate_trajectory.points, context);
 
   std::vector<MetricReport> metrics;
-  if (target_crosswalks.empty()) return ValidationResult{true, std::move(metrics)};
+  if (target_crosswalks.empty()) return ValidationResult{std::move(metrics)};
 
   update_target_objects(context, target_crosswalks);
 
@@ -406,7 +406,7 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
     return planning_factors;
   }();
 
-  return ValidationResult{feasible, std::move(metrics), std::move(planning_factors)};
+  return ValidationResult{std::move(metrics), std::move(planning_factors)};
 }
 
 RiskLevel::_level_type CrosswalkFilter::get_risk_level(const double arc_length_to_stop_line) const

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -218,9 +218,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       .metric_value(0.0)
       .risk(make_risk(is_crossing_amber, amber_arc_length_to_stop_line)));
 
-  const bool is_feasible = !is_crossing_red && !is_crossing_amber;
-
-  return ValidationResult{is_feasible, std::move(metrics)};
+  return ValidationResult{std::move(metrics)};
 }
 
 RiskLevel::_level_type TrafficLightFilter::get_risk_level(

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_collision_check_filter.cpp
@@ -191,7 +191,7 @@ TEST_F(CollisionCheckFilterTest, EmptyObjects)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
@@ -215,7 +215,7 @@ TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_FALSE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
@@ -239,7 +239,7 @@ TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_collision_check_filter.cpp
@@ -14,6 +14,8 @@
 
 // #include "../../../src/filters/safety/collision_check_filter/collision_check_filter.cpp"
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -189,7 +191,7 @@ TEST_F(CollisionCheckFilterTest, EmptyObjects)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
@@ -213,7 +215,7 @@ TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
 TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
@@ -237,7 +239,7 @@ TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
@@ -183,7 +183,7 @@ TEST_F(CollisionCheckFilterTest, DracWarnDoesNotRejectTrajectory)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
   EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::HIGH_CAUTION));
   EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
@@ -198,7 +198,7 @@ TEST_F(CollisionCheckFilterTest, DracErrorRejectsTrajectory)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_FALSE(is_feasible(worst_risk_level(result.value().metrics)));
   EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 }

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
@@ -14,6 +14,8 @@
 
 // #include "../../../src/filters/safety/collision_check_filter/collision_check_filter.cpp"
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -181,7 +183,7 @@ TEST_F(CollisionCheckFilterTest, DracWarnDoesNotRejectTrajectory)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
   EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::HIGH_CAUTION));
   EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
@@ -196,7 +198,7 @@ TEST_F(CollisionCheckFilterTest, DracErrorRejectsTrajectory)
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
   EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
@@ -43,7 +43,7 @@
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
-using autoware::trajectory_validator::is_feasible_based_on_risk;
+using autoware::trajectory_validator::is_feasible;
 using autoware::trajectory_validator::worst_risk_level;
 using autoware::trajectory_validator::plugin::traffic_rule::CrosswalkFilter;
 using autoware_perception_msgs::msg::ObjectClassification;
@@ -300,8 +300,7 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
-      << message;
+    EXPECT_EQ(is_feasible(worst_risk_level(res->metrics)), expected_feasible) << message;
   }
 
   void set_vehicle_front_offset(const double front_offset_m)
@@ -320,8 +319,7 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
-      << message;
+    EXPECT_EQ(is_feasible(worst_risk_level(res->metrics)), expected_feasible) << message;
 
     const auto it = std::find_if(res->metrics.begin(), res->metrics.end(), [](const auto & metric) {
       return metric.metric_name == "check_crosswalk_obstruction";

--- a/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
 #include "autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
@@ -42,6 +43,8 @@
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
+using autoware::trajectory_validator::is_feasible_based_on_risk;
+using autoware::trajectory_validator::worst_risk_level;
 using autoware::trajectory_validator::plugin::traffic_rule::CrosswalkFilter;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
@@ -297,7 +300,8 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
+      << message;
   }
 
   void set_vehicle_front_offset(const double front_offset_m)
@@ -316,7 +320,8 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
+      << message;
 
     const auto it = std::find_if(res->metrics.begin(), res->metrics.end(), [](const auto & metric) {
       return metric.metric_name == "check_crosswalk_obstruction";
@@ -600,8 +605,9 @@ TEST_F(CrosswalkFilterTest, RiskLevelHighCautionWhenOnlyHardBrakingCanStop)
   set_pedestrian_at(stop_line_x, -7.0);
 
   expect_obstruction_risk(
-    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, false,
-    "obstruction beyond minimum but within nominal stop distance should report HIGH_CAUTION");
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, true,
+    "obstruction beyond minimum but within nominal stop distance should report HIGH_CAUTION and "
+    "stay usable");
 }
 
 TEST_F(CrosswalkFilterTest, RiskLevelLowCautionWhenNominalBrakingCanStop)
@@ -618,8 +624,8 @@ TEST_F(CrosswalkFilterTest, RiskLevelLowCautionWhenNominalBrakingCanStop)
   set_pedestrian_at(stop_line_x, -7.0);
 
   expect_obstruction_risk(
-    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::LOW_CAUTION, false,
-    "obstruction beyond nominal stop distance should report LOW_CAUTION");
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::LOW_CAUTION, true,
+    "obstruction beyond nominal stop distance should report LOW_CAUTION and stay usable");
 }
 
 TEST_F(CrosswalkFilterTest, RiskLevelAccountsForVehicleFrontOffset)
@@ -643,6 +649,6 @@ TEST_F(CrosswalkFilterTest, RiskLevelAccountsForVehicleFrontOffset)
   set_pedestrian_at(stop_line_x, -7.0);
 
   expect_obstruction_risk(
-    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, false,
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, true,
     "risk should use ego-front-to-stop-line distance, not raw arc length");
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
@@ -34,6 +35,8 @@
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
+using autoware::trajectory_validator::is_feasible_based_on_risk;
+using autoware::trajectory_validator::worst_risk_level;
 using autoware::trajectory_validator::plugin::traffic_rule::TrafficLightFilter;
 using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
@@ -230,7 +233,25 @@ protected:
     candidate_trajectory.points = points;
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error";
-    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
+      << message;
+  }
+
+  void expect_violation_reported_without_rejection(
+    const std::vector<TrajectoryPoint> & points, const std::string & metric_name,
+    const std::string & message = "")
+  {
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    candidate_trajectory.points = points;
+    const auto res = filter_->is_feasible(candidate_trajectory, context_);
+    ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error";
+
+    const auto it = std::find_if(
+      res->metrics.begin(), res->metrics.end(),
+      [&metric_name](const auto & metric) { return metric.metric_name == metric_name; });
+    ASSERT_NE(it, res->metrics.end()) << "expected metric " << metric_name << ". " << message;
+    EXPECT_NE(it->risk.level, RiskLevel::SAFE) << message;
+    EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(res->metrics))) << message;
   }
 
   void set_risk_grading_params()
@@ -273,7 +294,8 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
+      << message;
 
     const auto it = std::find_if(
       res->metrics.begin(), res->metrics.end(),
@@ -548,7 +570,7 @@ TEST_F(TrafficLightFilterTest, RejectsWithZeroCannotStopAllowance)
     points, false, "Should preserve the old rejection behavior when allowance is disabled");
 }
 
-TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
+TEST_F(TrafficLightFilterTest, ReportsRiskWithAmberLightCanStop)
 {
   const lanelet::Id light_id = 200;
   const double stop_x = 20.0;  // Stop line at 20m
@@ -564,7 +586,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
 
   auto points = create_trajectory(0.0, 30.0, 5.0);
 
-  expect_feasibility(points, false, "Should return false if amber light can be stopped");
+  expect_violation_reported_without_rejection(
+    points, "check_crossing_amber_light",
+    "A stoppable amber light should be reported as a risk but should not reject the trajectory");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
@@ -590,7 +614,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
     points, true, "Should return true if amber light cannot be stopped but is reachable");
 }
 
-TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
+TEST_F(TrafficLightFilterTest, ReportsRiskWithAmberLightCanStopAndCannotPass)
 {
   const lanelet::Id light_id = 202;
   const double stop_x = 150.0;  // Stop line at 150m
@@ -614,7 +638,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
 
   auto points = create_trajectory(0.0, 200.0, 10.0);
 
-  expect_feasibility(points, false, "Should return false if ego can stop but cannot pass");
+  expect_violation_reported_without_rejection(
+    points, "check_crossing_amber_light",
+    "Ego can stop but cannot pass: report the risk, but do not reject the trajectory");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
@@ -857,8 +883,8 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
   set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
   auto points = create_trajectory(0.0, 30.0, 5.0);
 
-  // First check: should be infeasible (can stop for amber)
-  expect_feasibility(points, false);
+  // First check: the amber light is reported, but ego can stop, so the trajectory stays usable.
+  expect_violation_reported_without_rejection(points, "check_crossing_amber_light");
 
   // Advance time by 1s (less than 2s hysteresis)
   nav_msgs::msg::Odometry odometry = *context_.odometry;
@@ -1082,8 +1108,9 @@ TEST_F(TrafficLightFilterTest, RiskLevelHighCautionWhenDistanceLessThanNominalSt
   set_odometry(ego_velocity, node_->now());
 
   expect_risk_level(
-    create_trajectory(0.0, 80.0), "check_crossing_amber_light", RiskLevel::HIGH_CAUTION, false,
-    "violation beyond minimum but within nominal stop distance should report HIGH_CAUTION");
+    create_trajectory(0.0, 80.0), "check_crossing_amber_light", RiskLevel::HIGH_CAUTION, true,
+    "violation beyond minimum but within nominal stop distance should report HIGH_CAUTION and "
+    "stay usable");
 }
 
 TEST_F(TrafficLightFilterTest, RiskLevelLowCautionWhenDistanceGreaterThanNominalStopDistance)
@@ -1100,8 +1127,8 @@ TEST_F(TrafficLightFilterTest, RiskLevelLowCautionWhenDistanceGreaterThanNominal
   set_odometry(ego_velocity, node_->now());
 
   expect_risk_level(
-    create_trajectory(0.0, 80.0), "check_crossing_red_light", RiskLevel::LOW_CAUTION, false,
-    "violation beyond nominal stop distance should report LOW_CAUTION");
+    create_trajectory(0.0, 80.0), "check_crossing_red_light", RiskLevel::LOW_CAUTION, true,
+    "violation beyond nominal stop distance should report LOW_CAUTION and stay usable");
 }
 
 TEST_F(TrafficLightFilterTest, RiskLevelAccountsForVehicleFrontOffset)
@@ -1125,6 +1152,6 @@ TEST_F(TrafficLightFilterTest, RiskLevelAccountsForVehicleFrontOffset)
   set_odometry(ego_velocity, node_->now());
 
   expect_risk_level(
-    create_trajectory(0.0, 80.0), "check_crossing_amber_light", RiskLevel::HIGH_CAUTION, false,
+    create_trajectory(0.0, 80.0), "check_crossing_amber_light", RiskLevel::HIGH_CAUTION, true,
     "risk should use ego-front-to-stop-line distance, not raw arc length");
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
-using autoware::trajectory_validator::is_feasible_based_on_risk;
+using autoware::trajectory_validator::is_feasible;
 using autoware::trajectory_validator::worst_risk_level;
 using autoware::trajectory_validator::plugin::traffic_rule::TrafficLightFilter;
 using autoware_perception_msgs::msg::TrafficLightElement;
@@ -233,8 +233,7 @@ protected:
     candidate_trajectory.points = points;
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error";
-    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
-      << message;
+    EXPECT_EQ(is_feasible(worst_risk_level(res->metrics)), expected_feasible) << message;
   }
 
   void expect_violation_reported_without_rejection(
@@ -251,7 +250,7 @@ protected:
       [&metric_name](const auto & metric) { return metric.metric_name == metric_name; });
     ASSERT_NE(it, res->metrics.end()) << "expected metric " << metric_name << ". " << message;
     EXPECT_NE(it->risk.level, RiskLevel::SAFE) << message;
-    EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(res->metrics))) << message;
+    EXPECT_TRUE(is_feasible(worst_risk_level(res->metrics))) << message;
   }
 
   void set_risk_grading_params()
@@ -294,8 +293,7 @@ protected:
     const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
-    EXPECT_EQ(is_feasible_based_on_risk(worst_risk_level(res->metrics)), expected_feasible)
-      << message;
+    EXPECT_EQ(is_feasible(worst_risk_level(res->metrics)), expected_feasible) << message;
 
     const auto it = std::find_if(
       res->metrics.begin(), res->metrics.end(),

--- a/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
 #include "autoware/trajectory_validator/filters/safety/trajectory_feasibility_filter.hpp"
 
 #include <tf2/LinearMath/Quaternion.hpp>
@@ -123,10 +124,10 @@ TEST(TrajectoryFeasibilityFilterTest, FeasibleWhenAllConstraintsSatisfied)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSpeedExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSpeedExceedsMax)
 {
   // Create a trajectory that exceeds max speed
   TrajectoryPoints traj_points = {
@@ -150,10 +151,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSpeedExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenNearestTrajectoryPointExceedsLaneletSpeedLimit)
+TEST(VehicleConstraintFilterTest, HighCautionWhenNearestTrajectoryPointExceedsLaneletSpeedLimit)
 {
   TrajectoryPoints traj_points = {
     create_trajectory_point(0.0, 0.0, 0.0, 5.0, 0.0, 0.0),
@@ -183,10 +185,11 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenNearestTrajectoryPointExceedsLan
   const auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenAccelerationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenAccelerationExceedsMax)
 {
   // Create a trajectory that exceeds max acceleration
   TrajectoryPoints traj_points = {
@@ -210,10 +213,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenAccelerationExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenDecelerationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDecelerationExceedsMax)
 {
   // Create a trajectory that exceeds max deceleration
   TrajectoryPoints traj_points = {
@@ -238,10 +242,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenDecelerationExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenYawDeviationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenYawDeviationExceedsMax)
 {
   TrajectoryPoints traj_points = {
     create_trajectory_point(0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -264,10 +269,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenYawDeviationExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenVelocityDeviationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenVelocityDeviationExceedsMax)
 {
   TrajectoryPoints traj_points = {
     create_trajectory_point(0.0, 0.0, 0.0, 5.0, 0.0, 0.0),
@@ -290,10 +296,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenVelocityDeviationExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenLateralAccelerationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenLateralAccelerationExceedsMax)
 {
   TrajectoryPoints traj_points = {
     create_trajectory_point(0.0, 0.0, 0.0, 10.0, 0.0, 0.0),
@@ -318,10 +325,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenLateralAccelerationExceedsMa
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenDistanceDeviationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDistanceDeviationExceedsMax)
 {
   TrajectoryPoints traj_points = {
     create_trajectory_point(0.0, 0.0, 0.0, 5.0, 0.0, 0.0),
@@ -345,10 +353,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenDistanceDeviationExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringAngleExceedsMax)
 {
   // Create a trajectory that exceeds max steering angle after smoothing
   TrajectoryPoints traj_points = {
@@ -376,10 +385,11 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
-TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringRateExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringRateExceedsMax)
 {
   // Create a trajectory that exceeds max steering rate after smoothing
   TrajectoryPoints traj_points = {
@@ -409,7 +419,8 @@ TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringRateExceedsMax)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
+  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
 }
 
 // --- is_speed_ok(...) tests ---

--- a/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
@@ -124,7 +124,7 @@ TEST(TrajectoryFeasibilityFilterTest, FeasibleWhenAllConstraintsSatisfied)
   auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSpeedExceedsMax)
@@ -152,7 +152,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSpeedExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(VehicleConstraintFilterTest, HighCautionWhenNearestTrajectoryPointExceedsLaneletSpeedLimit)
@@ -186,7 +186,7 @@ TEST(VehicleConstraintFilterTest, HighCautionWhenNearestTrajectoryPointExceedsLa
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenAccelerationExceedsMax)
@@ -214,7 +214,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenAccelerationExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDecelerationExceedsMax)
@@ -243,7 +243,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDecelerationExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenYawDeviationExceedsMax)
@@ -270,7 +270,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenYawDeviationExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenVelocityDeviationExceedsMax)
@@ -297,7 +297,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenVelocityDeviationExceedsMax
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenLateralAccelerationExceedsMax)
@@ -326,7 +326,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenLateralAccelerationExceedsM
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDistanceDeviationExceedsMax)
@@ -354,7 +354,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenDistanceDeviationExceedsMax
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringAngleExceedsMax)
@@ -386,7 +386,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringAngleExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringRateExceedsMax)
@@ -420,7 +420,7 @@ TEST(TrajectoryFeasibilityFilterTest, HighCautionWhenSteeringRateExceedsMax)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(worst_risk_level(result.value().metrics), RiskLevel::HIGH_CAUTION);
-  EXPECT_TRUE(is_feasible_based_on_risk(worst_risk_level(result.value().metrics)));
+  EXPECT_TRUE(is_feasible(worst_risk_level(result.value().metrics)));
 }
 
 // --- is_speed_ok(...) tests ---


### PR DESCRIPTION
In `autoware_trajectory_validator`, replace each plugin's own boolean `is_feasible` field with a risk-level-driven decision computed centrally from the plugin's reported metrics. 


A plugin no longer decides pass/fail itself; it only reports a risk level (`SAFE`/`LOW_CAUTION`/`HIGH_CAUTION`/`DANGER`/`FATAL`) per metric, and `TrajectoryValidator` derives feasibility from the worst of those risk levels. 

Only `DANGER` (or worse) now rejects a trajectory; `HIGH_CAUTION` and below are reported but no longer block it, so filters like `CrosswalkFilter`, `TrafficLightFilter`, and `UncrossableBoundaryDepartureFilter` become advisory except at their most severe risk level.
