### PR TITLE
cherry-pick: build fixes from feat/v0.64/e2e (#3356, #3357)

### DIFF
--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -262,7 +262,8 @@ public:
   void update_parameters(const ::control_validator::Params & params)
   {
     enable_ = params.uncrossable_bound_departure_validator.enable;
-    params_.lateral_margin_m = params.uncrossable_bound_departure_validator.lateral_margin_m;
+    params_.critical_departure_lateral_th_m =
+      params.uncrossable_bound_departure_validator.lateral_margin_m;
     params_.longitudinal_margin_m =
       params.uncrossable_bound_departure_validator.longitudinal_margin_m;
     params_.max_deceleration_mps2 =

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -127,7 +127,7 @@ void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & p
     get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
 
   pointcloud_filter_ =
-    std::make_unique<trajectory_modifier::utils::obstacle_stop::PointCloudFilter>(
+    std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
       params_.target_objects.pointcloud);
 
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
@@ -18,7 +18,7 @@
 #include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
 #include "plugin_interface.hpp"
 
-#include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
+#include <autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -34,7 +34,7 @@ namespace autoware::minimum_rule_based_planner::plugin
 using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using autoware::trajectory_modifier::utils::obstacle_stop::PointCloud;
+using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
 
 class SurroundObstacleStop : public PluginInterface
 {
@@ -54,7 +54,7 @@ private:
   MinimumRuleBasedPlannerParams::SurroundObstacleStop params_;
 
   std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
-  std::unique_ptr<trajectory_modifier::utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
+  std::unique_ptr<trajectory_processor::utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
 
   std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
 

--- a/planning/autoware_trajectory_adapter/package.xml
+++ b/planning/autoware_trajectory_adapter/package.xml
@@ -25,6 +25,7 @@
   <depend>autoware_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -130,7 +130,7 @@ void SurroundObstacleStop::on_initialize(const TrajectoryProcessorParams & param
   trajectory_time_step_ = params.trajectory_time_step;
 
   pointcloud_filter_ =
-    std::make_unique<trajectory_modifier::utils::obstacle_stop::PointCloudFilter>(
+    std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
       params_.target_objects.pointcloud);
 
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(


### PR DESCRIPTION
## Description

Cherry-pick two build-fix PRs from `feat/v0.64/e2e` onto `feat/v0.64/e2e-experiment-2026_09_01`.

- https://github.com/tier4/autoware_universe/pull/3356 — `fix(control_validator): fix boundary depature build failure due to updating parameter struct`
- https://github.com/tier4/autoware_universe/pull/3357 — `fix incorrect namespace, add missing package dependency`

Both original commits sit directly on `7c82c830` (current experiment HEAD), so the cherry-picks applied cleanly.

## Related links

**Parent Issue:**

- N/A

- https://github.com/tier4/autoware_universe/pull/3356
- https://github.com/tier4/autoware_universe/pull/3357

## How was this PR tested?

Not run locally — cherry-pick only. Original PRs were merged to `feat/v0.64/e2e`. Please rely on CI.

## Notes for reviewers

Cherry-picked commits (in order):

1. `9d38029b80` → `a6384b9733` (#3356)
2. `290ea3947e` → `90af9e2cb3` (#3357)

## Interface changes

None.

## Effects on system behavior

None. Build/compile fixes only (`control_validator` parameter struct, `surround_obstacle_stop` namespace, missing `autoware_trajectory_adapter` dependency).

Made with [Cursor](https://cursor.com)