### PR TITLE
feat(minimum_rule_based_planner): stop for road shoulder

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -62,6 +62,7 @@
       stop_distance_from_crosswalk: 3.5 # [m]
       stop_distance_from_private_area: 3.0 # [m]
       stop_distance_from_intersection: 1.0 # [m]
+      stop_distance_from_road_shoulder: 0.5 # [m]
       max_deceleration: 4.0 # [m/s^2]
       max_jerk: 5.0 # [m/s^3]
       stop_point_diff_threshold: 0.5 # [m]

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -265,7 +265,7 @@ minimum_rule_based_planner:
     stop_distance_from_road_shoulder:
       type: double
       default_value: 0.5
-      description: distance to keep between the vehicle footprint and the road lane when stopping before departing from a road shoulder (added to stop_margin_distance) [m]
+      description: distance to keep between the vehicle footprint and the road-shoulder boundary when stopping before crossing it in either direction (added to stop_margin_distance) [m]
       validation:
         gt_eq<>: [0.0]
     max_deceleration:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -262,6 +262,12 @@ minimum_rule_based_planner:
       description: distance to stop before the first conflicting priority lane in an intersection (added to stop_margin_distance and the vehicle front offset) [m]
       validation:
         gt_eq<>: [0.0]
+    stop_distance_from_road_shoulder:
+      type: double
+      default_value: 0.5
+      description: distance to keep between the vehicle footprint and the road lane when stopping before departing from a road shoulder (added to stop_margin_distance) [m]
+      validation:
+        gt_eq<>: [0.0]
     max_deceleration:
       type: double
       default_value: 4.0

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -304,6 +304,12 @@
               "default": 1.0,
               "minimum": 0.0
             },
+            "stop_distance_from_road_shoulder": {
+              "type": "number",
+              "description": "Distance to keep between the vehicle footprint and the road lane when stopping before departing from a road shoulder (added to stop_margin_distance) [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
             "max_deceleration": {
               "type": "number",
               "description": "Maximum deceleration used to judge whether a stop line is reachable (braking distance) [m/s^2]",

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -306,7 +306,7 @@
             },
             "stop_distance_from_road_shoulder": {
               "type": "number",
-              "description": "Distance to keep between the vehicle footprint and the road lane when stopping before departing from a road shoulder (added to stop_margin_distance) [m]",
+              "description": "Distance to keep between the vehicle footprint and the road-shoulder boundary when stopping before crossing it in either direction (added to stop_margin_distance) [m]",
               "default": 0.5,
               "minimum": 0.0
             },

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
@@ -386,7 +386,7 @@ MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
     select_road_shoulder_stop_arc_length(trajectory.points, ego_pose, params);
 
   {
-    // NOTE(odashima): the shoulder departure target is not a map line, so it is synthesized for
+    // NOTE(odashima): the shoulder stop target is not a map line, so it is synthesized for
     // visualization only; it is fed to plan_single_stop as an arc length instead, because its
     // margin is measured from the footprint rather than from base_link_to_front.
     constexpr double stop_line_half_width_m = 3.0;
@@ -458,8 +458,7 @@ MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
 std::optional<MapBasedStopPlanner::SingleStopResult> MapBasedStopPlanner::plan_single_stop(
   const std::vector<StopLine> & stop_lines, const Trajectory & trajectory,
   const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
-  const double ego_acceleration, const StopSelectionParams & params,
-  const bool include_possibility,
+  const double ego_acceleration, const StopSelectionParams & params, const bool include_possibility,
   const std::optional<double> & road_shoulder_stop_arc_length) const
 {
   autoware_utils_debug::ScopedTimeTrack st(

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
@@ -14,6 +14,7 @@
 
 #include "map_based_stop_planner.hpp"
 
+#include <autoware/lanelet2_utils/kind.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp>
@@ -21,16 +22,20 @@
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/road_marking.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 #include <lanelet2_routing/RoutingGraph.h>
+#include <tf2/utils.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <map>
 #include <memory>
@@ -66,6 +71,7 @@ bool is_possibility_type(StopLineType type)
     case StopLineType::TrafficLight:
     case StopLineType::Intersection:
     case StopLineType::PrivateArea:
+    case StopLineType::RoadShoulder:
       return true;
   }
   return true;
@@ -193,8 +199,42 @@ const char * to_string(const StopLineType type)
       return "intersection";
     case StopLineType::PrivateArea:
       return "private_area";
+    case StopLineType::RoadShoulder:
+      return "road_shoulder";
   }
   return "unknown";
+}
+
+// Vehicle footprint rectangle at the given pose, counter-clockwise and open as boost expects for
+// lanelet::BasicPolygon2d.
+lanelet::BasicPolygon2d make_vehicle_footprint(
+  const geometry_msgs::msg::Pose & pose, const VehicleInfo & vehicle_info)
+{
+  const double yaw = tf2::getYaw(pose.orientation);
+  const double cos_yaw = std::cos(yaw);
+  const double sin_yaw = std::sin(yaw);
+  const std::array<std::pair<double, double>, 4> corners{
+    {{vehicle_info.max_longitudinal_offset_m, vehicle_info.max_lateral_offset_m},
+     {vehicle_info.min_longitudinal_offset_m, vehicle_info.max_lateral_offset_m},
+     {vehicle_info.min_longitudinal_offset_m, vehicle_info.min_lateral_offset_m},
+     {vehicle_info.max_longitudinal_offset_m, vehicle_info.min_lateral_offset_m}}};
+
+  lanelet::BasicPolygon2d footprint;
+  footprint.reserve(corners.size());
+  for (const auto & [x, y] : corners) {
+    footprint.emplace_back(
+      pose.position.x + cos_yaw * x - sin_yaw * y, pose.position.y + sin_yaw * x + cos_yaw * y);
+  }
+  return footprint;
+}
+
+lanelet::BoundingBox2d bounding_box_2d(const lanelet::BasicPolygon2d & polygon)
+{
+  lanelet::BoundingBox2d box;
+  for (const auto & point : polygon) {
+    box.extend(point);
+  }
+  return box;
 }
 
 bool is_crosswalk_or_walkway(const lanelet::ConstLanelet & lanelet, bool & is_walkway)
@@ -319,6 +359,7 @@ void MapBasedStopPlanner::set_planner_data(
   const LaneletMapBin::ConstSharedPtr & lanelet_map_bin_ptr,
   const LaneletRoute::ConstSharedPtr & route_ptr, const RouteContext & route_context)
 {
+  lanelet_map_ptr_ = route_context.lanelet_map_ptr;
   if (lanelet_map_bin_ptr == stop_lines_map_ptr_ && route_ptr == stop_lines_route_ptr_) {
     return;
   }
@@ -341,7 +382,26 @@ MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
   if (trajectory.points.size() < 2) return result;
 
   const auto stop_lines = filter_stop_lines_on_trajectory(stop_lines_, trajectory.points);
-  result.stop_line_markers = create_stop_line_marker_array(stop_lines);
+  const auto road_shoulder_stop_arc_length =
+    select_road_shoulder_stop_arc_length(trajectory.points, ego_pose, params);
+
+  {
+    // NOTE(odashima): the shoulder departure target is not a map line, so it is synthesized for
+    // visualization only; it is fed to plan_single_stop as an arc length instead, because its
+    // margin is measured from the footprint rather than from base_link_to_front.
+    constexpr double stop_line_half_width_m = 3.0;
+    constexpr lanelet::Id road_shoulder_line_id = -(INT64_C(1) << 43);
+    auto marker_lines = stop_lines;
+    if (road_shoulder_stop_arc_length) {
+      marker_lines.push_back(
+        StopLine{
+          make_perpendicular_line(
+            trajectory.points, *road_shoulder_stop_arc_length, stop_line_half_width_m,
+            road_shoulder_line_id),
+          StopLineType::RoadShoulder, false});
+    }
+    result.stop_line_markers = create_stop_line_marker_array(marker_lines);
+  }
 
   // Debug visualization of the intersection lanelet groups behind the non-priority judgement.
   {
@@ -373,16 +433,16 @@ MapBasedStopPlanner::Result MapBasedStopPlanner::plan(
       make_color(1.0f, 0.0f, 0.0f, 0.99f));
   }
 
-  if (stop_lines.empty()) return result;
+  if (stop_lines.empty() && !road_shoulder_stop_arc_length) return result;
 
   // The go trajectory stops only at mandatory targets (e.g. stop lines); the stop trajectory
   // additionally stops at possibility targets (e.g. traffic lights).
   const auto go_stop = plan_single_stop(
     stop_lines, trajectory, ego_pose, ego_velocity, ego_acceleration, params,
-    /*include_possibility=*/false);
+    /*include_possibility=*/false, road_shoulder_stop_arc_length);
   const auto stop_stop = plan_single_stop(
     stop_lines, trajectory, ego_pose, ego_velocity, ego_acceleration, params,
-    /*include_possibility=*/true);
+    /*include_possibility=*/true, road_shoulder_stop_arc_length);
 
   if (go_stop) result.go_trajectory = go_stop->trajectory;
 
@@ -399,14 +459,20 @@ std::optional<MapBasedStopPlanner::SingleStopResult> MapBasedStopPlanner::plan_s
   const std::vector<StopLine> & stop_lines, const Trajectory & trajectory,
   const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
   const double ego_acceleration, const StopSelectionParams & params,
-  const bool include_possibility) const
+  const bool include_possibility,
+  const std::optional<double> & road_shoulder_stop_arc_length) const
 {
   autoware_utils_debug::ScopedTimeTrack st(
     include_possibility ? "plan_single_stop(stop)" : "plan_single_stop(go)", *time_keeper_);
 
-  const auto stop_point_arc_length = select_stop_arc_length(
+  auto stop_point_arc_length = select_stop_arc_length(
     stop_lines, trajectory.points, ego_pose, ego_velocity, ego_acceleration, params,
     include_possibility);
+  if (
+    include_possibility && road_shoulder_stop_arc_length &&
+    (!stop_point_arc_length || *road_shoulder_stop_arc_length < *stop_point_arc_length)) {
+    stop_point_arc_length = road_shoulder_stop_arc_length;
+  }
   if (!stop_point_arc_length) return std::nullopt;
 
   if (autoware::trajectory_processor::utils::stop_point_exists(
@@ -803,6 +869,58 @@ std::optional<double> MapBasedStopPlanner::select_stop_arc_length(
   }
 
   return nearest_stop_point_arc_length;
+}
+
+std::optional<double> MapBasedStopPlanner::select_road_shoulder_stop_arc_length(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory_points,
+  const geometry_msgs::msg::Pose & ego_pose, const StopSelectionParams & params) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  if (!lanelet_map_ptr_ || trajectory_points.size() < 2) {
+    return std::nullopt;
+  }
+
+  // Lanelets of the given kind whose polygon overlaps the footprint.
+  const auto overlaps = [this](const lanelet::BasicPolygon2d & footprint, const bool road_lane) {
+    for (const auto & lanelet : lanelet_map_ptr_->laneletLayer.search(bounding_box_2d(footprint))) {
+      const bool kind_matches =
+        road_lane ? autoware::experimental::lanelet2_utils::is_road_lane(lanelet)
+                  : autoware::experimental::lanelet2_utils::is_shoulder_lane(lanelet);
+      if (!kind_matches) continue;
+      if (boost::geometry::intersects(footprint, lanelet.polygon2d().basicPolygon())) return true;
+    }
+    return false;
+  };
+
+  const auto ego_footprint = make_vehicle_footprint(ego_pose, params.vehicle_info);
+  if (
+    overlaps(ego_footprint, /*road_lane=*/true) || !overlaps(ego_footprint, /*road_lane=*/false)) {
+    return std::nullopt;
+  }
+
+  const double ego_arc_length =
+    autoware::motion_utils::calcSignedArcLength(trajectory_points, 0UL, ego_pose.position);
+
+  double arc_length = 0.0;
+  for (size_t i = 0; i < trajectory_points.size(); ++i) {
+    if (i > 0) {
+      arc_length += autoware_utils::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
+    }
+    if (arc_length < ego_arc_length) continue;
+    const auto footprint = make_vehicle_footprint(trajectory_points[i].pose, params.vehicle_info);
+    if (!overlaps(footprint, /*road_lane=*/true)) {
+      continue;
+    }
+    // NOTE(odashima): the braking-distance reachability check applied to map stop lines is
+    // deliberately skipped, and the stop point is clamped to ego instead: entering the road lane
+    // is what the vehicle must not do, and inside a shoulder it travels slowly enough that the
+    // clamp holds it in place rather than demanding an infeasible deceleration.
+    return std::max(
+      arc_length - params.stop_margin_distance - params.stop_distance_from_road_shoulder,
+      ego_arc_length);
+  }
+  return std::nullopt;
 }
 
 visualization_msgs::msg::MarkerArray MapBasedStopPlanner::create_stop_line_marker_array(

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.cpp
@@ -894,31 +894,59 @@ std::optional<double> MapBasedStopPlanner::select_road_shoulder_stop_arc_length(
   };
 
   const auto ego_footprint = make_vehicle_footprint(ego_pose, params.vehicle_info);
-  if (
-    overlaps(ego_footprint, /*road_lane=*/true) || !overlaps(ego_footprint, /*road_lane=*/false)) {
+  const bool ego_in_road_lane = overlaps(ego_footprint, /*road_lane=*/true);
+  const bool ego_in_shoulder_lane = overlaps(ego_footprint, /*road_lane=*/false);
+  const bool departing = !ego_in_road_lane && ego_in_shoulder_lane;
+  const bool entering = ego_in_road_lane && !ego_in_shoulder_lane;
+  if (!departing && !entering) {
     return std::nullopt;
   }
 
   const double ego_arc_length =
     autoware::motion_utils::calcSignedArcLength(trajectory_points, 0UL, ego_pose.position);
 
+  // NOTE(odashima): the braking-distance reachability check applied to map stop lines is
+  // deliberately skipped, and the stop point is clamped to ego instead: crossing the shoulder
+  // boundary is what the vehicle must not do, and around a shoulder it travels slowly enough that
+  // the clamp holds it in place rather than demanding an infeasible deceleration.
+  const auto stop_arc_length = [&](const double crossing_arc_length) {
+    return std::max(
+      crossing_arc_length - params.stop_margin_distance - params.stop_distance_from_road_shoulder,
+      ego_arc_length);
+  };
+
   double arc_length = 0.0;
+  double shoulder_touch_arc_length = 0.0;
+  bool shoulder_touched = false;
   for (size_t i = 0; i < trajectory_points.size(); ++i) {
     if (i > 0) {
       arc_length += autoware_utils::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
     }
     if (arc_length < ego_arc_length) continue;
     const auto footprint = make_vehicle_footprint(trajectory_points[i].pose, params.vehicle_info);
-    if (!overlaps(footprint, /*road_lane=*/true)) {
+    const bool in_road_lane = overlaps(footprint, /*road_lane=*/true);
+    const bool in_shoulder_lane = overlaps(footprint, /*road_lane=*/false);
+
+    if (departing) {
+      if (in_road_lane) return stop_arc_length(arc_length);
       continue;
     }
-    // NOTE(odashima): the braking-distance reachability check applied to map stop lines is
-    // deliberately skipped, and the stop point is clamped to ego instead: entering the road lane
-    // is what the vehicle must not do, and inside a shoulder it travels slowly enough that the
-    // clamp holds it in place rather than demanding an infeasible deceleration.
-    return std::max(
-      arc_length - params.stop_margin_distance - params.stop_distance_from_road_shoulder,
-      ego_arc_length);
+
+    // Entering: stop where the footprint starts to straddle the boundary, but only once the
+    // trajectory is known to end up wholly inside the shoulder — merely clipping a shoulder while
+    // staying in the road lane is normal driving and must not stop the vehicle.
+    if (!in_shoulder_lane) {
+      // The straddle that led here did not complete, so a later one anchors the stop instead.
+      shoulder_touched = false;
+      continue;
+    }
+    if (!shoulder_touched) {
+      shoulder_touch_arc_length = arc_length;
+      shoulder_touched = true;
+    }
+    if (!in_road_lane) {
+      return stop_arc_length(shoulder_touch_arc_length);
+    }
   }
   return std::nullopt;
 }

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
@@ -76,10 +76,11 @@ struct StopSelectionParams
   double stop_distance_from_private_area;
   //! extra stop distance before the first conflicting priority lane in an intersection [m]
   double stop_distance_from_intersection;
-  //! extra stop distance before the vehicle footprint reaches a road lane from a road shoulder [m]
+  //! extra stop distance before the vehicle footprint crosses a road-shoulder boundary, in either
+  //! direction [m]
   double stop_distance_from_road_shoulder;
   double base_link_to_front;  //!< vehicle front offset from base_link [m]
-  //! vehicle dimensions; used only by the road-shoulder departure stop, which sweeps the footprint
+  //! vehicle dimensions; used only by the road-shoulder stop, which sweeps the footprint
   //! along the trajectory instead of offsetting a line crossing by base_link_to_front
   VehicleInfo vehicle_info;
   //! min arc-length difference for the stop trajectory's stop point to be treated as different
@@ -245,7 +246,7 @@ private:
   IntersectionDebugLanelets intersection_debug_lanelets_;
   LaneletMapBin::ConstSharedPtr stop_lines_map_ptr_;
   LaneletRoute::ConstSharedPtr stop_lines_route_ptr_;
-  //! Map used by the road-shoulder departure stop, which is re-evaluated every cycle.
+  //! Map used by the road-shoulder stop, which is re-evaluated every cycle.
   lanelet::LaneletMapPtr lanelet_map_ptr_;
 };
 

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
@@ -42,7 +42,7 @@ enum class StopLineType {
   TrafficLight,  //!< stop line referenced by traffic light  -> possibility
   Intersection,  //!< lanelet with turn_direction attribute  -> possibility
   PrivateArea,   //!< private-area entry/exit transition     -> possibility
-  RoadShoulder,  //!< departure from a road shoulder to a road lane -> possibility
+  RoadShoulder,  //!< crossing a road-shoulder boundary either way  -> possibility
 };
 
 //! A map-defined stop line together with its classified type.
@@ -195,15 +195,21 @@ public:
     const bool include_possibility) const;
 
   /**
-   * @brief Arc length of the stop point that keeps ego inside the road shoulder it is parked in.
+   * @brief Arc length of the stop point placed before ego crosses a road-shoulder boundary.
    *
-   * Active only while the whole vehicle footprint is clear of every road lane and overlaps a
-   * shoulder lane; otherwise nullopt, so a trajectory that already straddles a road lane (e.g. a
-   * handover from another generator mid-avoidance) returns to the lane without stopping.
-   * The footprint is swept along the trajectory and the stop point is placed a margin before the
-   * first pose whose footprint reaches a road lane, so the stop position accounts for the corner
-   * that crosses first — a base_link line crossing would be several metres too late at the shallow
-   * angles the shift produces. Clamped to ego's own arc length so it is never behind ego.
+   * Two symmetric cases, selected from where the ego footprint currently is:
+   * - Departing: the footprint is clear of every road lane and overlaps a shoulder lane. The stop
+   *   is placed a margin before the first pose whose footprint reaches a road lane.
+   * - Entering: the footprint overlaps a road lane and no shoulder lane. The stop is placed a
+   *   margin before the first pose whose footprint touches a shoulder lane, but only when a later
+   *   pose is wholly inside the shoulder — clipping a shoulder while staying in the road lane is
+   *   normal driving and must not stop the vehicle.
+   *
+   * A footprint that already straddles both kinds returns nullopt, so a handover from another
+   * generator mid-crossing completes the crossing without stopping. The footprint is swept along
+   * the trajectory rather than intersecting a base_link line, which would be several metres late
+   * at the shallow angles the shift produces. Clamped to ego's own arc length so the stop is never
+   * behind ego.
    */
   std::optional<double> select_road_shoulder_stop_arc_length(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory_points,

--- a/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/map_based_stop_planner.hpp
@@ -42,6 +42,7 @@ enum class StopLineType {
   TrafficLight,  //!< stop line referenced by traffic light  -> possibility
   Intersection,  //!< lanelet with turn_direction attribute  -> possibility
   PrivateArea,   //!< private-area entry/exit transition     -> possibility
+  RoadShoulder,  //!< departure from a road shoulder to a road lane -> possibility
 };
 
 //! A map-defined stop line together with its classified type.
@@ -59,7 +60,7 @@ struct StopLine
  *
  * Mandatory targets (the go trajectory also stops): StopLine, Walkway.
  * Possibility targets (only the stop trajectory additionally stops): Crosswalk, TrafficLight,
- * Intersection, PrivateArea.
+ * Intersection, PrivateArea, RoadShoulder.
  */
 bool is_possibility_type(StopLineType type);
 
@@ -75,7 +76,12 @@ struct StopSelectionParams
   double stop_distance_from_private_area;
   //! extra stop distance before the first conflicting priority lane in an intersection [m]
   double stop_distance_from_intersection;
+  //! extra stop distance before the vehicle footprint reaches a road lane from a road shoulder [m]
+  double stop_distance_from_road_shoulder;
   double base_link_to_front;  //!< vehicle front offset from base_link [m]
+  //! vehicle dimensions; used only by the road-shoulder departure stop, which sweeps the footprint
+  //! along the trajectory instead of offsetting a line crossing by base_link_to_front
+  VehicleInfo vehicle_info;
   //! min arc-length difference for the stop trajectory's stop point to be treated as different
   //! from the go trajectory's [m]
   double stop_point_diff_threshold;
@@ -188,6 +194,21 @@ public:
     const double ego_acceleration, const StopSelectionParams & params,
     const bool include_possibility) const;
 
+  /**
+   * @brief Arc length of the stop point that keeps ego inside the road shoulder it is parked in.
+   *
+   * Active only while the whole vehicle footprint is clear of every road lane and overlaps a
+   * shoulder lane; otherwise nullopt, so a trajectory that already straddles a road lane (e.g. a
+   * handover from another generator mid-avoidance) returns to the lane without stopping.
+   * The footprint is swept along the trajectory and the stop point is placed a margin before the
+   * first pose whose footprint reaches a road lane, so the stop position accounts for the corner
+   * that crosses first — a base_link line crossing would be several metres too late at the shallow
+   * angles the shift produces. Clamped to ego's own arc length so it is never behind ego.
+   */
+  std::optional<double> select_road_shoulder_stop_arc_length(
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory_points,
+    const geometry_msgs::msg::Pose & ego_pose, const StopSelectionParams & params) const;
+
   //! Build a MarkerArray (frame "map") of the stop lines with a per-type text label above each.
   visualization_msgs::msg::MarkerArray create_stop_line_marker_array(
     const std::vector<StopLine> & stop_lines) const;
@@ -199,11 +220,15 @@ private:
     double stop_point_arc_length;
     Trajectory trajectory;
   };
+  //! @param road_shoulder_stop_arc_length possibility stop from
+  //! select_road_shoulder_stop_arc_length, considered alongside the map stop lines only when
+  //! include_possibility is true
   std::optional<SingleStopResult> plan_single_stop(
     const std::vector<StopLine> & stop_lines, const Trajectory & trajectory,
     const geometry_msgs::msg::Pose & ego_pose, const double ego_velocity,
     const double ego_acceleration, const StopSelectionParams & params,
-    const bool include_possibility) const;
+    const bool include_possibility,
+    const std::optional<double> & road_shoulder_stop_arc_length) const;
 
   rclcpp::Logger logger_;
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
@@ -214,6 +239,8 @@ private:
   IntersectionDebugLanelets intersection_debug_lanelets_;
   LaneletMapBin::ConstSharedPtr stop_lines_map_ptr_;
   LaneletRoute::ConstSharedPtr stop_lines_route_ptr_;
+  //! Map used by the road-shoulder departure stop, which is re-evaluated every cycle.
+  lanelet::LaneletMapPtr lanelet_map_ptr_;
 };
 
 }  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -383,7 +383,9 @@ StopSelectionParams MinimumRuleBasedPlannerNode::make_map_based_stop_params() co
   params.stop_distance_from_crosswalk = params_.map_based_stop.stop_distance_from_crosswalk;
   params.stop_distance_from_private_area = params_.map_based_stop.stop_distance_from_private_area;
   params.stop_distance_from_intersection = params_.map_based_stop.stop_distance_from_intersection;
+  params.stop_distance_from_road_shoulder = params_.map_based_stop.stop_distance_from_road_shoulder;
   params.base_link_to_front = vehicle_info_.max_longitudinal_offset_m;
+  params.vehicle_info = vehicle_info_;
   params.stop_point_diff_threshold = params_.map_based_stop.stop_point_diff_threshold;
   return params;
 }

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -35,6 +35,7 @@
 #include <autoware_utils/math/unit_conversion.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/LaneletMap.h>
 #include <tf2/utils.h>
 
 #include <algorithm>
@@ -1120,31 +1121,21 @@ bool route_deviation_stop(
   const lanelet::ConstLanelet & current_lanelet, const geometry_msgs::msg::Pose & current_pose,
   const RouteContext & planner_data)
 {
-  lanelet::ConstLanelets recoverable_lanelets;
-  const auto beside_lanelets = planner_data.routing_graph_ptr->besides(current_lanelet);
-  recoverable_lanelets.insert(
-    recoverable_lanelets.end(), beside_lanelets.begin(), beside_lanelets.end());
+  const lanelet::BasicPoint2d ego_point{current_pose.position.x, current_pose.position.y};
 
-  const auto left_lanelets =
-    planner_data.lanelet_map_ptr->laneletLayer.findUsages(current_lanelet.leftBound());
-
-  for (const auto & ll : left_lanelets) {
-    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(ll)) {
-      recoverable_lanelets.push_back(ll);
+  for (const auto & ll : planner_data.routing_graph_ptr->besides(current_lanelet)) {
+    if (lanelet::geometry::inside(ll, ego_point)) {
+      return false;
     }
   }
 
-  const auto right_lanelets =
-    planner_data.lanelet_map_ptr->laneletLayer.findUsages(current_lanelet.rightBound());
-
-  for (const auto & ll : right_lanelets) {
-    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(ll)) {
-      recoverable_lanelets.push_back(ll);
-    }
-  }
-
-  for (const auto & ll : recoverable_lanelets) {
-    if (lanelet::geometry::inside(ll, {current_pose.position.x, current_pose.position.y})) {
+  // NOTE(odashima): a shoulder lanelet is recognised by ego being inside it, not by it sharing a
+  // bound with the current route lanelet: a bus-stop bay has its own road-side linestring, so
+  // findUsages(bound) never reaches it and ego parked in the bay would be treated as off-route.
+  // The stop before re-entering the road lane is planned in MapBasedStopPlanner instead.
+  for (const auto & distance_and_lanelet : lanelet::geometry::findWithin2d(
+         planner_data.lanelet_map_ptr->laneletLayer, ego_point, 0.0)) {
+    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(distance_and_lanelet.second)) {
       return false;
     }
   }
@@ -1342,6 +1333,17 @@ bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & curren
     if (lanelet::utils::query::getClosestLaneletWithConstrains(
           route_context_.route_lanelets, current_pose, &closest,
           params_.path_planning.ego_nearest_lanelet.dist_threshold,
+          params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
+      current_lanelet_ = closest;
+      return true;
+    }
+    // NOTE(odashima): the same distance-unconstrained retry as the steady-state branch below.
+    // Parked in a bus-stop bay the nearest route lanelet is several metres away, and without this
+    // the first call leaves current_lanelet_ unset, so every later call re-enters this branch and
+    // fails again — the planner never produces a path at all.
+    if (lanelet::utils::query::getClosestLaneletWithConstrains(
+          route_context_.route_lanelets, current_pose, &closest,
+          /*dist_threshold=*/std::numeric_limits<double>::max(),
           params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
       current_lanelet_ = closest;
       return true;

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1346,17 +1346,6 @@ bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & curren
       current_lanelet_ = closest;
       return true;
     }
-    // NOTE(odashima): the same distance-unconstrained retry as the steady-state branch below.
-    // Parked in a bus-stop bay the nearest route lanelet is several metres away, and without this
-    // the first call leaves current_lanelet_ unset, so every later call re-enters this branch and
-    // fails again — the planner never produces a path at all.
-    if (lanelet::utils::query::getClosestLaneletWithConstrains(
-          route_context_.route_lanelets, current_pose, &closest,
-          /*dist_threshold=*/std::numeric_limits<double>::max(),
-          params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
-      current_lanelet_ = closest;
-      return true;
-    }
     current_lanelet_ = std::nullopt;
     return false;
   }

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -35,7 +35,6 @@
 #include <autoware_utils/math/unit_conversion.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
-#include <lanelet2_core/geometry/LaneletMap.h>
 #include <tf2/utils.h>
 
 #include <algorithm>
@@ -1121,21 +1120,31 @@ bool route_deviation_stop(
   const lanelet::ConstLanelet & current_lanelet, const geometry_msgs::msg::Pose & current_pose,
   const RouteContext & planner_data)
 {
-  const lanelet::BasicPoint2d ego_point{current_pose.position.x, current_pose.position.y};
+  lanelet::ConstLanelets recoverable_lanelets;
+  const auto beside_lanelets = planner_data.routing_graph_ptr->besides(current_lanelet);
+  recoverable_lanelets.insert(
+    recoverable_lanelets.end(), beside_lanelets.begin(), beside_lanelets.end());
 
-  for (const auto & ll : planner_data.routing_graph_ptr->besides(current_lanelet)) {
-    if (lanelet::geometry::inside(ll, ego_point)) {
-      return false;
+  const auto left_lanelets =
+    planner_data.lanelet_map_ptr->laneletLayer.findUsages(current_lanelet.leftBound());
+
+  for (const auto & ll : left_lanelets) {
+    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(ll)) {
+      recoverable_lanelets.push_back(ll);
     }
   }
 
-  // NOTE(odashima): a shoulder lanelet is recognised by ego being inside it, not by it sharing a
-  // bound with the current route lanelet: a bus-stop bay has its own road-side linestring, so
-  // findUsages(bound) never reaches it and ego parked in the bay would be treated as off-route.
-  // The stop before re-entering the road lane is planned in MapBasedStopPlanner instead.
-  for (const auto & distance_and_lanelet : lanelet::geometry::findWithin2d(
-         planner_data.lanelet_map_ptr->laneletLayer, ego_point, 0.0)) {
-    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(distance_and_lanelet.second)) {
+  const auto right_lanelets =
+    planner_data.lanelet_map_ptr->laneletLayer.findUsages(current_lanelet.rightBound());
+
+  for (const auto & ll : right_lanelets) {
+    if (autoware::experimental::lanelet2_utils::is_shoulder_lane(ll)) {
+      recoverable_lanelets.push_back(ll);
+    }
+  }
+
+  for (const auto & ll : recoverable_lanelets) {
+    if (lanelet::geometry::inside(ll, {current_pose.position.x, current_pose.position.y})) {
       return false;
     }
   }

--- a/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
@@ -49,6 +49,14 @@ TrajectoryPoint make_point(double x, double y)
   return pt;
 }
 
+geometry_msgs::msg::Pose make_ego_pose(double x)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+
 // A straight trajectory along +x at y = 0, 1 m spacing.
 std::vector<TrajectoryPoint> make_straight_trajectory(size_t num_points)
 {
@@ -78,8 +86,14 @@ StopSelectionParams make_params()
   params.stop_distance_from_crosswalk = 3.5;
   params.stop_distance_from_private_area = 3.0;
   params.stop_distance_from_intersection = 1.0;
+  params.stop_distance_from_road_shoulder = 0.5;
   params.base_link_to_front = 4.0;
   params.stop_point_diff_threshold = 0.5;
+  // 5 m long, 2 m wide box with base_link 1 m behind the rear bumper.
+  params.vehicle_info.max_longitudinal_offset_m = 4.0;
+  params.vehicle_info.min_longitudinal_offset_m = -1.0;
+  params.vehicle_info.max_lateral_offset_m = 1.0;
+  params.vehicle_info.min_lateral_offset_m = -1.0;
   return params;
 }
 
@@ -853,6 +867,52 @@ TEST(MapBasedStopPlannerTest, PlanReturnsStopTrajectoryOnlyForDistinctStopPoint)
   ASSERT_TRUE(result.stop_trajectory.has_value());
   EXPECT_NEAR(result.stop_trajectory->points.back().pose.position.x, 4.0, 1e-3);
   EXPECT_FLOAT_EQ(result.stop_trajectory->points.back().longitudinal_velocity_mps, 0.0f);
+}
+
+namespace
+{
+// A shoulder lanelet on x in [0, 20] followed by a road lanelet on x in [20, 50], both spanning
+// y in [-2, 2], registered in a map so the layer search finds them.
+lanelet::LaneletMapPtr make_shoulder_to_road_map()
+{
+  auto shoulder = make_road_lanelet(10, 0.0, 20.0);
+  shoulder.attributes()[lanelet::AttributeNamesString::Subtype] = "road_shoulder";
+  auto road = make_road_lanelet(20, 20.0, 30.0);
+  road.attributes()[lanelet::AttributeNamesString::Subtype] = lanelet::AttributeValueString::Road;
+  return lanelet::utils::createMap({shoulder, road});
+}
+}  // namespace
+
+TEST(MapBasedStopPlannerTest, RoadShoulderStopKeepsFootprintOutOfRoadLane)
+{
+  MapBasedStopPlanner planner(rclcpp::get_logger("test_map_based_stop_planner"));
+
+  RouteContext ctx;
+  ctx.lanelet_map_ptr = make_shoulder_to_road_map();
+  planner.set_planner_data(nullptr, nullptr, ctx);
+
+  // The footprint reaches the road lanelet (x = 20) at base_link x = 16, so the stop point keeps
+  // the configured margins ahead of it: 16 - 1.0 - 0.5.
+  const auto arc_length = planner.select_road_shoulder_stop_arc_length(
+    make_straight_trajectory(30), make_ego_pose(0.0), make_params());
+
+  ASSERT_TRUE(arc_length.has_value());
+  EXPECT_NEAR(*arc_length, 14.5, 1e-3);
+}
+
+TEST(MapBasedStopPlannerTest, RoadShoulderStopInactiveOnceFootprintReachesRoadLane)
+{
+  MapBasedStopPlanner planner(rclcpp::get_logger("test_map_based_stop_planner"));
+
+  RouteContext ctx;
+  ctx.lanelet_map_ptr = make_shoulder_to_road_map();
+  planner.set_planner_data(nullptr, nullptr, ctx);
+
+  // Ego already straddles the road lanelet: the trajectory must return to the lane without a stop.
+  EXPECT_FALSE(planner
+                 .select_road_shoulder_stop_arc_length(
+                   make_straight_trajectory(30), make_ego_pose(18.0), make_params())
+                 .has_value());
 }
 
 }  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_map_based_stop_planner.cpp
@@ -49,14 +49,6 @@ TrajectoryPoint make_point(double x, double y)
   return pt;
 }
 
-geometry_msgs::msg::Pose make_ego_pose(double x)
-{
-  geometry_msgs::msg::Pose pose;
-  pose.position.x = x;
-  pose.orientation.w = 1.0;
-  return pose;
-}
-
 // A straight trajectory along +x at y = 0, 1 m spacing.
 std::vector<TrajectoryPoint> make_straight_trajectory(size_t num_points)
 {
@@ -881,7 +873,61 @@ lanelet::LaneletMapPtr make_shoulder_to_road_map()
   road.attributes()[lanelet::AttributeNamesString::Subtype] = lanelet::AttributeValueString::Road;
   return lanelet::utils::createMap({shoulder, road});
 }
+
+// A road lanelet on x in [0, 25] followed by a shoulder lanelet on x in [25, 55], both spanning
+// y in [-2, 2].
+lanelet::LaneletMapPtr make_road_to_shoulder_map()
+{
+  auto road = make_road_lanelet(30, 0.0, 25.0);
+  road.attributes()[lanelet::AttributeNamesString::Subtype] = lanelet::AttributeValueString::Road;
+  auto shoulder = make_road_lanelet(40, 25.0, 30.0);
+  shoulder.attributes()[lanelet::AttributeNamesString::Subtype] = "road_shoulder";
+  return lanelet::utils::createMap({road, shoulder});
+}
+
+// A road lanelet on x in [0, 50] with a shoulder lanelet laid over x in [20, 25]: the footprint
+// touches the shoulder but never leaves the road lane.
+lanelet::LaneletMapPtr make_road_with_clipped_shoulder_map()
+{
+  auto road = make_road_lanelet(50, 0.0, 50.0);
+  road.attributes()[lanelet::AttributeNamesString::Subtype] = lanelet::AttributeValueString::Road;
+  auto shoulder = make_road_lanelet(60, 20.0, 5.0);
+  shoulder.attributes()[lanelet::AttributeNamesString::Subtype] = "road_shoulder";
+  return lanelet::utils::createMap({road, shoulder});
+}
 }  // namespace
+
+TEST(MapBasedStopPlannerTest, RoadShoulderStopBeforeEnteringShoulder)
+{
+  MapBasedStopPlanner planner(rclcpp::get_logger("test_map_based_stop_planner"));
+
+  RouteContext ctx;
+  ctx.lanelet_map_ptr = make_road_to_shoulder_map();
+  planner.set_planner_data(nullptr, nullptr, ctx);
+
+  // The footprint first touches the shoulder (x = 25) at base_link x = 21, and is wholly inside it
+  // from base_link x = 27, so the stop keeps the margins ahead of the first touch: 21 - 1.0 - 0.5.
+  const auto arc_length = planner.select_road_shoulder_stop_arc_length(
+    make_straight_trajectory(30), make_ego_pose(0.0), make_params());
+
+  ASSERT_TRUE(arc_length.has_value());
+  EXPECT_NEAR(*arc_length, 19.5, 1e-3);
+}
+
+TEST(MapBasedStopPlannerTest, RoadShoulderStopInactiveWhenShoulderIsOnlyClipped)
+{
+  MapBasedStopPlanner planner(rclcpp::get_logger("test_map_based_stop_planner"));
+
+  RouteContext ctx;
+  ctx.lanelet_map_ptr = make_road_with_clipped_shoulder_map();
+  planner.set_planner_data(nullptr, nullptr, ctx);
+
+  // The footprint never leaves the road lane, so passing the shoulder must not insert a stop.
+  EXPECT_FALSE(planner
+                 .select_road_shoulder_stop_arc_length(
+                   make_straight_trajectory(40), make_ego_pose(0.0), make_params())
+                 .has_value());
+}
 
 TEST(MapBasedStopPlannerTest, RoadShoulderStopKeepsFootprintOutOfRoadLane)
 {


### PR DESCRIPTION
## Description

Adds a stop before the vehicle footprint crosses a road-shoulder boundary, in both directions: departing a shoulder for a road lane (e.g. resuming from a bus-stop bay) and entering a shoulder from a road lane. The footprint is swept along the trajectory and the stop point is placed a margin before the first pose that reaches the other lane kind; the stop is a possibility target, so it is embedded only in the stop trajectory. A trajectory that merely clips a shoulder while staying in the road lane never triggers a stop. Also fixes `route_deviation_stop` and `update_current_lanelet` so that ego parked in a bus-stop bay (a shoulder lanelet not sharing a bound with the route lanelet) is not treated as off-route.

Pull Over
<img width="1803" height="1128" alt="image" src="https://github.com/user-attachments/assets/54b31ca3-184e-4c64-b5a1-e8de2286d645" />

Pull Out
<img width="1999" height="1037" alt="image" src="https://github.com/user-attachments/assets/1fb7ce1f-78eb-4df8-a46a-f19bceabe99f" />




## Related links

## How was this PR tested?

- `colcon build --packages-select autoware_minimum_rule_based_planner`
- Unit tests: 100 tests passed, including the new `RoadShoulderStop*` cases

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `map_based_stop.stop_distance_from_road_shoulder` | `double` | `0.5` | Distance to keep between the vehicle footprint and the road-shoulder boundary when stopping before crossing it (added to `stop_margin_distance`) [m] |

## Effects on system behavior

The stop trajectory gains a stop point before the footprint crosses a road-shoulder boundary in either direction. Ego parked in a bus-stop bay is treated as on-route (no route-deviation stop) and the planner produces a path from there.
