### PR TITLE
feat(minimum_rule_based_planner): improve backup planner path shifting

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -44,10 +44,11 @@
 
       path_shift:
         enable: true
+        start_time_offset: 0.1
         minimum_shift_length: 0.5
         minimum_shift_distance: 3.0
         min_speed_for_curvature: 1.39  # [m/s] 5 km/h
-        lateral_accel_limit: 1.0      # [m/s^2]
+        lateral_accel_limit: 0.8      # [m/s^2]
         curvature_limit: 0.156          # [1/m] R = 10 m
 
       waypoint_group:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -206,6 +206,13 @@ minimum_rule_based_planner:
         default_value: true
         description: enable path shifting from ego position to centerline
 
+      start_time_offset:
+        type: double
+        default_value: 0.1
+        description: time offset from current ego state to start path shifting [s]
+        validation:
+          gt<>: [0.0]
+
       minimum_shift_length:
         type: double
         default_value: 0.1
@@ -225,7 +232,7 @@ minimum_rule_based_planner:
 
       lateral_accel_limit:
         type: double
-        default_value: 0.5
+        default_value: 0.8
         description: allowed lateral acceleration budget for the shift polynomial (comfort/safety limit) [m/s^2]
         validation:
           gt<>: [0.0]

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -213,6 +213,12 @@
                   "description": "Enable path shifting to ego pose",
                   "default": true
                 },
+                "start_time_offset": {
+                  "type": "number",
+                  "description": "Time offset from current ego state to start path shifting [s]",
+                  "default": 0.1,
+                  "minimum": 0.0
+                },
                 "minimum_shift_length": {
                   "type": "number",
                   "description": "Lateral offset threshold to trigger shift [m]",
@@ -234,7 +240,7 @@
                 "lateral_accel_limit": {
                   "type": "number",
                   "description": "Lateral acceleration limit for shift [m/s^2]",
-                  "default": 1.0,
+                  "default": 0.8,
                   "minimum": 0.0
                 }
               },

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -23,6 +23,8 @@
 #include <autoware/velocity_smoother/resample.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 
+#include <tf2/utils.h>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -422,6 +424,63 @@ std::optional<PathWithLaneId> MinimumRuleBasedPlannerNode::plan_path(const Input
     input_data.odometry_ptr->header.stamp);
 }
 
+geometry_msgs::msg::Pose predict_ego_pose(
+  const geometry_msgs::msg::Pose & pose, const double longitudinal_velocity, const double yaw_rate,
+  const double dt)
+{
+  if (dt < 1e-3) return pose;
+
+  // Treat near-zero yaw rate as straight-line motion to avoid v/ω blow-up.
+  if (std::abs(yaw_rate) < 1e-6) {
+    return autoware_utils_geometry::calc_offset_pose(pose, longitudinal_velocity * dt, 0.0, 0.0);
+  }
+
+  const double yaw = tf2::getYaw(pose.orientation);
+  geometry_msgs::msg::Pose predicted = pose;
+  const double r = longitudinal_velocity / yaw_rate;
+  const double yaw_next = yaw + yaw_rate * dt;
+  predicted.position.x += r * (std::sin(yaw_next) - std::sin(yaw));
+  predicted.position.y += r * (-std::cos(yaw_next) + std::cos(yaw));
+  predicted.orientation = autoware_utils::create_quaternion_from_yaw(yaw_next);
+  return predicted;
+}
+
+void prepend_predicted_connection(
+  Trajectory & trajectory, const geometry_msgs::msg::Pose & current_pose, const double current_vel,
+  const double accel, const double yaw_rate, const double time_offset)
+{
+  if (trajectory.points.empty()) return;
+
+  constexpr double min_interval = 0.1;
+  const auto & first_pose = trajectory.points.front().pose;
+  if (autoware_utils::calc_distance2d(current_pose, first_pose) < min_interval) {
+    return;
+  }
+
+  std::vector<TrajectoryPoint> prefix;
+  TrajectoryPoint pt;
+  pt.pose = current_pose;
+  pt.longitudinal_velocity_mps = static_cast<float>(current_vel);
+  pt.acceleration_mps2 = static_cast<float>(accel);
+  prefix.push_back(pt);
+
+  auto t = min_interval / std::max(std::abs(current_vel), 1.0e-3);
+  for (; t < time_offset;) {
+    // Average speed over [0, t] for constant-accel arc integration.
+    pt.pose = predict_ego_pose(current_pose, current_vel + 0.5 * accel * t, yaw_rate, t);
+    const double v_t = current_vel + accel * t;
+    pt.longitudinal_velocity_mps = static_cast<float>(v_t);
+    if (autoware_utils::calc_distance2d(pt.pose, first_pose) < min_interval) {
+      break;
+    }
+    prefix.push_back(pt);
+    if (std::abs(v_t) < 1.0e-3) break;
+    t += min_interval / std::abs(v_t);
+  }
+
+  trajectory.points.insert(trajectory.points.begin(), prefix.begin(), prefix.end());
+}
+
 Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
   const Trajectory & trajectory, const InputData & input_data) const
 {
@@ -436,11 +495,22 @@ Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
   shift_params.lateral_accel_limit = params_.path_planning.path_shift.lateral_accel_limit;
   shift_params.curvature_limit = params_.path_planning.path_shift.curvature_limit;
 
-  const double ego_velocity = input_data.odometry_ptr->twist.twist.linear.x;
-  const double ego_yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;
-  const auto shifted_trajectory = path_planner_->shift_trajectory_to_ego(
-    trajectory, input_data.odometry_ptr->pose.pose, ego_velocity, ego_yaw_rate, shift_params,
+  const double time_offset = params_.path_planning.path_shift.start_time_offset;
+  const auto & current_pose = input_data.odometry_ptr->pose.pose;
+  const double current_vel = input_data.odometry_ptr->twist.twist.linear.x;
+  const double accel = input_data.acceleration_ptr->accel.accel.linear.x;
+  const double yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;
+
+  const double pred_ego_vel = current_vel + accel * time_offset;
+  const auto pred_ego_pose =
+    predict_ego_pose(current_pose, 0.5 * (current_vel + pred_ego_vel), yaw_rate, time_offset);
+
+  auto shifted_trajectory = path_planner_->shift_trajectory_to_ego(
+    trajectory, pred_ego_pose, pred_ego_vel, yaw_rate, shift_params,
     params_.path_planning.output.delta_arc_length);
+
+  prepend_predicted_connection(
+    shifted_trajectory, current_pose, current_vel, accel, yaw_rate, time_offset);
 
   if (params_.debug.enable_shifted_trajectory) {
     Trajectory shifted_traj;


### PR DESCRIPTION
## Description
Backup planner path shifter uses the current instantaneous ego state, when ego is deviated from the lane (due to following DP traj), BP generates a trajectory that turns back abruptly from current ego state, combined with pipeline latency this can result in unstable controls.

This PR introduces a parameterized time delay to offset the trajectory shift start point to account for pipeline latency and control errors.

### Changes
- add new parameter `path_shift.start_time_offset` with default value of 0.1
- add helper function `predict_ego_pose()` to get offset ego pose from kinematics
- add helper function `prepend_predicted_connection()` to connect current ego state to shifted traj start point
- set `path_shift.lateral_accel_limit` default to 0.8

## How was this PR tested?
PSIM

| current | Time offset = 0.1 | Time offset = 0.2 | Time offset = 0.3 |
| :--- | :--- | :--- | :--- |
| <img width="1377" height="936" alt="Screenshot from 2026-09-03 09-39-29" src="https://github.com/user-attachments/assets/acc0750b-7f7a-48cc-a822-9eb6b42ab3d5" /> | <img width="1405" height="939" alt="Screenshot from 2026-09-03 11-00-28" src="https://github.com/user-attachments/assets/1c0f5b25-dd0a-46b6-a1b5-e57369409acd" /> | <img width="1405" height="945" alt="Screenshot from 2026-09-03 11-02-47" src="https://github.com/user-attachments/assets/4750f355-f74c-4d3e-b85c-bcf1a7045458" /> | <img width="1410" height="940" alt="Screenshot from 2026-09-03 11-05-51" src="https://github.com/user-attachments/assets/e5872c9b-e871-4c75-8cf5-56284a451d93" /> |

## Related Links

requires https://github.com/tier4/autoware_launch.x2/pull/2848