### PR TITLE
feat(planning_validator): add uncrossable-boundary departure plugin

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/lowpass_filter.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/lowpass_filter.hpp
@@ -75,6 +75,12 @@ public:
   double filter(const double & u);
 
   /**
+   * @brief Force filter internal state (y,u history) to a value without changing coefficients.
+   * Used so the steering LPF tracks the published command after post-MPC soft hold / stop freeze.
+   */
+  void resetState(const double value);
+
+  /**
    * @brief filtering for time-series data
    * @param [in] t time-series data for input vector
    * @param [out] u object vector

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -31,6 +31,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 
 #include <deque>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -156,6 +157,14 @@ struct MPCData
   // Pose (position and orientation) of the nearest point in the trajectory.
   Pose nearest_pose{};
 
+  // Temporal tracking debug values.
+  double temporal_predicted_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_observed_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_fused_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_window_min{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_window_max{std::numeric_limits<double>::quiet_NaN()};
+  bool temporal_observation_used{false};
+
   // Current steering angle.
   double steer{};
 
@@ -226,6 +235,8 @@ private:
   double m_yaw_error_prev = 0.0;       // Previous heading error for derivative calculation.
 
   bool m_is_forward_shift = true;  // Flag indicating if the shift is in the forward direction.
+  bool m_reference_trajectory_has_steering =
+    false;  // True when the complete received trajectory contains a nonzero steering state.
 
   rclcpp::Publisher<Trajectory>::SharedPtr m_debug_frenet_predicted_trajectory_pub;
   rclcpp::Publisher<Trajectory>::SharedPtr m_debug_resampled_reference_trajectory_pub;
@@ -437,6 +448,12 @@ public:
   bool m_use_delayed_initial_state =
     true;  // Flag to use x0_delayed as initial state for predicted trajectory
 
+  bool m_use_temporal_trajectory =
+    false;  // true: use timestamps; false: spatial distance/velocity time
+
+  bool m_use_trajectory_steering_for_feedforward =
+    false;  // Prefer temporal trajectory steering when the received field is populated.
+
   bool m_publish_debug_trajectories = false;  // Flag to publish predicted trajectory and
                                               // resampled reference trajectory for debug purpose
 
@@ -471,6 +488,12 @@ public:
    * @param current_steer Current steering report.
    */
   void resetPrevResult(const SteeringReport & current_steer);
+
+  /**
+   * @brief Reset steering-command LPF internal state to a published command value.
+   * Keeps the filter tracking post-MPC output (soft hold / stop freeze) instead of raw Uex.
+   */
+  void resetSteeringCmdFilter(const double steering_tire_angle);
 
   /**
    * @brief Set the vehicle model for this MPC.

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -36,6 +36,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -101,6 +102,23 @@ private:
 
   // Flag indicating whether to keep the steering control until it converges.
   bool m_keep_steer_control_until_converged;
+
+  // Shared duration [s]:
+  // - stop: eligibility must last longer than this before isStoppedState() is true
+  // - confidence: low-confidence soft hold expires after this without a confident refresh
+  double m_stop_state_steer_hold_duration{2.0};
+
+  std::optional<rclcpp::Time> m_stop_state_hold_started_at;
+
+  // Reference-confidence steer soft hold (outside MPC QP).
+  bool m_enable_confidence_steer_slew_limit{false};
+  double m_reference_confidence_L_ahead_min{0.4};
+  double m_reference_confidence_L_ahead_ref{2.0};
+  double m_steer_slew_rate_min_rad_s{0.02};
+  double m_ctrl_period{0.0};
+
+  // Started on first low-confidence cycle; cleared only when confidence returns.
+  std::optional<rclcpp::Time> m_confidence_hold_started_at;
 
   // MPC solver checker.
   ResultWithReason m_mpc_solved_status{true};
@@ -247,8 +265,9 @@ private:
   [[nodiscard]] Lateral getInitialControlCommand() const;
 
   /**
-   * @brief Check if the ego car is in a stopped state.
-   * @return True if the ego car is stopped, false otherwise.
+   * @brief Check if the ego car is in a confirmed full stop.
+   * True only after stop eligibility has lasted longer than stop_state_steer_hold_duration.
+   * Until then the controller stays in control.
    */
   [[nodiscard]] bool isStoppedState() const;
 
@@ -271,6 +290,56 @@ private:
    * @return True if the steering control is converged and stable, false otherwise.
    */
   [[nodiscard]] bool isSteerConverged(const Lateral & cmd) const;
+
+  /**
+   * @brief Minimum target velocity ahead of ego over the stop-state distance margin.
+   */
+  [[nodiscard]] double getMinTargetVelocityAhead() const;
+
+  /**
+   * @brief True when ego and trajectory target speed indicate a full stop (stop-state kinematics).
+   */
+  [[nodiscard]] bool isEgoAndTrajectoryStopped() const;
+
+  /**
+   * @brief True when stop-state kinematics are met and steer convergence gate allows hold.
+   */
+  [[nodiscard]] bool isStopStateSteerHoldEligible() const;
+
+  /**
+   * @brief Update the stop-state confirmation timer from current kinematics.
+   */
+  void updateStopStateHoldTimer();
+
+  /**
+   * @brief Get spatial arc length of the reference trajectory remaining ahead of ego [m].
+   */
+  [[nodiscard]] double getReferenceRemainingArcLength() const;
+  /**
+   * @brief Compute reference confidence weight in [0, 1] from remaining spatial extent ahead of
+   * ego.
+   */
+  [[nodiscard]] double computeReferenceConfidenceWeight() const;
+
+  /**
+   * @brief True when remaining spatial extent is at/above the full-confidence threshold.
+   */
+  [[nodiscard]] bool isReferenceFullyConfident() const;
+
+  /**
+   * @brief Soft-limit steering toward MPC while reference confidence is low.
+   * ds_max blends from min_rate*period (conf=0) to |MPC delta| (conf=1).
+   * Timer starts on first low-confidence cycle and refreshes only when confidence returns;
+   * after stop_state_steer_hold_duration without refresh, soft hold expires and MPC is used.
+   * Flickering short trajectories are treated as low confidence, not as stop.
+   * @return true if the command was modified by the slew limiter
+   */
+  bool applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd);
+
+  /**
+   * @brief Sync delay buffer and steering LPF to the published steer command.
+   */
+  void syncMpcSteerStateToCommand(const float steering_tire_angle);
 
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
 

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_trajectory.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_trajectory.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__MPC_LATERAL_CONTROLLER__MPC_TRAJECTORY_HPP_
 
 #include "autoware_utils/geometry/geometry.hpp"
+#include "builtin_interfaces/msg/time.hpp"
 
 #include "geometry_msgs/msg/point.hpp"
 
@@ -40,6 +41,7 @@ public:
   double vx;
   double k;
   double smooth_k;
+  double steer;
   double relative_time;
 };
 
@@ -48,6 +50,8 @@ public:
 class MPCTrajectory
 {
 public:
+  //!< @brief absolute time origin of the source trajectory
+  builtin_interfaces::msg::Time stamp{};
   std::vector<double> x;              //!< @brief x position x vector
   std::vector<double> y;              //!< @brief y position y vector
   std::vector<double> z;              //!< @brief z position z vector
@@ -55,6 +59,7 @@ public:
   std::vector<double> vx;             //!< @brief vx velocity vx vector
   std::vector<double> k;              //!< @brief k curvature k vector
   std::vector<double> smooth_k;       //!< @brief k smoothed-curvature k vector
+  std::vector<double> steer;          //!< @brief trajectory steering state vector
   std::vector<double> relative_time;  //!< @brief relative_time duration time from start point
 
   /**
@@ -63,6 +68,14 @@ public:
   void push_back(
     const double & xp, const double & yp, const double & zp, const double & yawp,
     const double & vxp, const double & kp, const double & smooth_kp, const double & tp);
+
+  /**
+   * @brief push_back for all values, including the trajectory steering state
+   */
+  void push_back(
+    const double & xp, const double & yp, const double & zp, const double & yawp,
+    const double & vxp, const double & kp, const double & smooth_kp, const double & steerp,
+    const double & tp);
 
   /**
    * @brief push_back for all values
@@ -119,6 +132,7 @@ public:
       point.pose.position.z = z.at(i);
       point.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw.at(i));
       point.longitudinal_velocity_mps = vx.at(i);
+      point.front_wheel_angle_rad = steer.at(i);
       points.push_back(point);
     }
     return points;

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -28,6 +28,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include <cmath>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -68,9 +69,12 @@ double calcLateralError(const Pose & ego_pose, const Pose & ref_pose);
 /**
  * @brief convert the given Trajectory msg to a MPCTrajectory object
  * @param [in] input trajectory to convert
+ * @param [in] use_temporal_trajectory if true, use time_from_start directly; if false, calculate
+ * from distance/velocity
  * @return resulting MPCTrajectory
  */
-MPCTrajectory convertToMPCTrajectory(const Trajectory & input);
+MPCTrajectory convertToMPCTrajectory(
+  const Trajectory & input, const bool use_temporal_trajectory = false);
 
 /**
  * @brief convert the given MPCTrajectory to a Trajectory msg
@@ -93,6 +97,15 @@ void calcMPCTrajectoryArcLength(const MPCTrajectory & trajectory, std::vector<do
  * @return total arc length
  */
 double calcMPCTrajectoryArcLength(const MPCTrajectory & trajectory);
+
+/**
+ * @brief calculate spatial arc length from a start index to the trajectory end
+ * @param [in] trajectory trajectory to measure
+ * @param [in] start_idx index from which to start accumulating distance
+ * @return accumulated 2D distance from start_idx to the last point
+ */
+double calcMPCTrajectoryRemainingArcLength(
+  const MPCTrajectory & trajectory, const size_t start_idx);
 
 /**
  * @brief resample the given trajectory with the given fixed interval
@@ -130,17 +143,22 @@ bool calcMPCTrajectoryTime(MPCTrajectory & traj);
  * @param [in] acc_lim limit on the acceleration
  * @param [in] tau constant to control the smoothing (high-value = very smooth)
  * @param [inout] traj MPCTrajectory for which to calculate the smoothed velocity
+ * @param [in] use_temporal_trajectory if true, preserve timestamps; if false, recalculate time from
+ * velocity
  */
 void dynamicSmoothingVelocity(
   const size_t start_seg_idx, const double start_vel, const double acc_lim, const double tau,
-  MPCTrajectory & traj);
+  MPCTrajectory & traj, const bool use_temporal_trajectory = false);
 
 /**
  * @brief calculate yaw angle in MPCTrajectory from xy vector
  * @param [inout] traj object trajectory
  * @param [in] shift is forward or not
+ * @param [in] use_input_yaw_for_short_segment if true, preserve input yaw for very short segments
  */
-void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift);
+void calcTrajectoryYawFromXY(
+  MPCTrajectory & traj, const bool is_forward_shift,
+  const bool use_input_yaw_for_short_segment = false);
 
 /**
  * @brief Calculate path curvature by 3-points circle fitting with smoothing num (use nearest 3
@@ -152,7 +170,7 @@ void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift);
  */
 void calcTrajectoryCurvature(
   const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
-  MPCTrajectory & traj);
+  MPCTrajectory & traj, const bool use_short_segment_protection = false);
 
 /**
  * @brief Calculate path curvature by 3-points circle fitting with smoothing num (use nearest 3
@@ -162,7 +180,23 @@ void calcTrajectoryCurvature(
  * @return vector of curvatures at each point of the given trajectory
  */
 std::vector<double> calcTrajectoryCurvature(
-  const int curvature_smoothing_num, const MPCTrajectory & traj);
+  const int curvature_smoothing_num, const MPCTrajectory & traj,
+  const bool use_short_segment_protection = false);
+
+/**
+ * @brief Calculate curvature for temporal trajectories by spatially resampling.
+ * Temporal trajectories have non-uniform spatial point distribution, which makes index-based
+ * curvature calculation unreliable. This function resamples the trajectory at equal spatial
+ * intervals, calculates curvature on the resampled points, then maps the result back to the
+ * original temporal trajectory points via arc-length interpolation.
+ * @param [in] curvature_smoothing_num_traj index distance for 3 points for curvature calculation
+ * @param [in] curvature_smoothing_num_ref_steer index distance for 3 points for smoothed curvature
+ * @param [in] resample_interval_dist spatial resampling interval [m]
+ * @param [inout] traj temporal trajectory whose k and smooth_k will be updated
+ */
+void calcTrajectoryCurvatureBySpatialResample(
+  const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
+  const double resample_interval_dist, MPCTrajectory & traj);
 
 /**
  * @brief calculate nearest pose on MPCTrajectory with linear interpolation

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/taubin_curvature.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/taubin_curvature.hpp
@@ -1,0 +1,240 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPC_LATERAL_CONTROLLER__TAUBIN_CURVATURE_HPP_
+#define AUTOWARE__MPC_LATERAL_CONTROLLER__TAUBIN_CURVATURE_HPP_
+
+#include <Eigen/Dense>
+#include <Eigen/Eigenvalues>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+
+namespace autoware::motion::control::mpc_lateral_controller
+{
+
+constexpr double kDefaultStraightThreshold = 5e-3;
+constexpr double kMinDiscriminant = 1e-14;
+constexpr double kMinKappa = 1e-9;
+
+struct TaubinResult
+{
+  double kappa{0.0};
+  double radius{std::numeric_limits<double>::infinity()};
+  std::optional<Eigen::Vector2d> center{std::nullopt};
+  bool is_straight{false};
+  double rms_residual{0.0};
+  Eigen::Vector4d eigenvector{Eigen::Vector4d::Zero()};
+  double discriminant{0.0};
+};
+
+namespace detail
+{
+
+[[nodiscard]] inline double collinearity_ratio(const Eigen::MatrixX2d & pts_centered)
+{
+  const Eigen::JacobiSVD<Eigen::MatrixX2d> svd(
+    pts_centered, Eigen::ComputeThinU | Eigen::ComputeThinV);
+
+  const auto & sv = svd.singularValues();
+  if (sv[0] < 1e-12) {
+    return 0.0;
+  }
+  return sv[1] / sv[0];
+}
+
+[[nodiscard]] inline double curvature_sign(const Eigen::MatrixX2d & pts)
+{
+  const int N = static_cast<int>(pts.rows());
+  double signed_area = 0.0;
+  for (int i = 0; i < N - 1; ++i) {
+    signed_area += pts(i, 0) * pts(i + 1, 1) - pts(i + 1, 0) * pts(i, 1);
+  }
+  return (signed_area >= 0.0) ? 1.0 : -1.0;
+}
+
+inline void build_taubin_matrices(
+  const Eigen::VectorXd & x, const Eigen::VectorXd & y, Eigen::Matrix4d & M, Eigen::Matrix4d & C)
+{
+  const int N = static_cast<int>(x.size());
+  const double inv_N = 1.0 / static_cast<double>(N);
+
+  const Eigen::VectorXd z = x.array().square() + y.array().square();
+
+  const double Mzz = z.dot(z) * inv_N;
+  const double Mxz = x.dot(z) * inv_N;
+  const double Myz = y.dot(z) * inv_N;
+  const double Mxx = x.dot(x) * inv_N;
+  const double Myy = y.dot(y) * inv_N;
+  const double Mxy = x.dot(y) * inv_N;
+  const double Mzo = z.mean();
+  const double Mxo = x.mean();
+  const double Myo = y.mean();
+
+  // clang-format off
+  M << Mzz, Mxz, Myz, Mzo,
+       Mxz, Mxx, Mxy, Mxo,
+       Myz, Mxy, Myy, Myo,
+       Mzo, Mxo, Myo, 1.0;
+  // clang-format on
+
+  C.setZero();
+  C(0, 3) = 2.0;
+  C(1, 1) = 1.0;
+  C(2, 2) = 1.0;
+  C(3, 0) = 2.0;
+}
+
+inline void solve_and_extract_kappa(
+  const Eigen::Matrix4d & M, const Eigen::Matrix4d & C, Eigen::Vector4d & eigenvector,
+  double & kappa_abs, double & discriminant)
+{
+  const Eigen::Matrix4d CinvM = C.inverse() * M;
+  const Eigen::EigenSolver<Eigen::Matrix4d> solver(CinvM);
+
+  const Eigen::Vector4cd & evals = solver.eigenvalues();
+  const Eigen::Matrix4cd & evecs = solver.eigenvectors();
+
+  int best_idx = -1;
+  double best_abs_eval = std::numeric_limits<double>::max();
+
+  for (int i = 0; i < 4; ++i) {
+    const double re = evals[i].real();
+    const double im = std::abs(evals[i].imag());
+
+    if (im > 1e-6 * std::abs(re)) {
+      continue;
+    }
+
+    const Eigen::Vector4d v = evecs.col(i).real();
+    const double v0 = v[0];
+    const double v1 = v[1];
+    const double v2 = v[2];
+    const double v3 = v[3];
+    const double disc = v1 * v1 + v2 * v2 - 4.0 * v0 * v3;
+
+    if (disc <= kMinDiscriminant) {
+      continue;
+    }
+
+    const double k_abs = 2.0 * std::abs(v0) / std::sqrt(disc);
+    if (k_abs <= 0.0) {
+      continue;
+    }
+
+    const double abs_eval = std::abs(re);
+    if (abs_eval < best_abs_eval) {
+      best_abs_eval = abs_eval;
+      best_idx = i;
+    }
+  }
+
+  if (best_idx < 0) {
+    eigenvector = Eigen::Vector4d::Zero();
+    kappa_abs = 0.0;
+    discriminant = 0.0;
+    return;
+  }
+
+  eigenvector = evecs.col(best_idx).real();
+
+  const double v0 = eigenvector[0];
+  const double v1 = eigenvector[1];
+  const double v2 = eigenvector[2];
+  const double v3 = eigenvector[3];
+
+  discriminant = v1 * v1 + v2 * v2 - 4.0 * v0 * v3;
+  kappa_abs = 2.0 * std::abs(v0) / std::sqrt(discriminant);
+}
+
+[[nodiscard]] inline double compute_rms_residual(
+  const Eigen::MatrixX2d & pts_c, const Eigen::Vector4d & v)
+{
+  const double v0 = v[0];
+  const double v1 = v[1];
+  const double v2 = v[2];
+  const double v3 = v[3];
+  const auto & x = pts_c.col(0);
+  const auto & y = pts_c.col(1);
+
+  const Eigen::VectorXd z = x.array().square() + y.array().square();
+  const Eigen::VectorXd F = v0 * z + v1 * x + v2 * y + Eigen::VectorXd::Constant(x.size(), v3);
+
+  const Eigen::VectorXd gx = 2.0 * v0 * x.array() + v1;
+  const Eigen::VectorXd gy = 2.0 * v0 * y.array() + v2;
+  const Eigen::VectorXd g_norm = (gx.array().square() + gy.array().square()).sqrt();
+
+  const Eigen::VectorXd safe_g = g_norm.array().max(1e-12);
+  const Eigen::VectorXd sampson = F.array().abs() / safe_g.array();
+
+  return std::sqrt(sampson.squaredNorm() / static_cast<double>(x.size()));
+}
+
+}  // namespace detail
+
+[[nodiscard]] inline TaubinResult taubin_curvature(
+  const Eigen::MatrixX2d & points, const double straight_threshold = kDefaultStraightThreshold)
+{
+  if (points.cols() != 2 || points.rows() < 3) {
+    throw std::invalid_argument("taubin_curvature: input must be (N×2) with N ≥ 3");
+  }
+
+  TaubinResult result;
+
+  const Eigen::Vector2d centroid = points.colwise().mean();
+  const Eigen::MatrixX2d pts_c = points.rowwise() - centroid.transpose();
+
+  const double col_ratio = detail::collinearity_ratio(pts_c);
+  if (col_ratio < straight_threshold) {
+    result.is_straight = true;
+    result.kappa = 0.0;
+    result.radius = std::numeric_limits<double>::infinity();
+    result.rms_residual = 0.0;
+    return result;
+  }
+
+  const Eigen::VectorXd x = pts_c.col(0);
+  const Eigen::VectorXd y = pts_c.col(1);
+
+  Eigen::Matrix4d M;
+  Eigen::Matrix4d C;
+  detail::build_taubin_matrices(x, y, M, C);
+
+  double kappa_abs{0.0};
+  detail::solve_and_extract_kappa(M, C, result.eigenvector, kappa_abs, result.discriminant);
+
+  const double sign = detail::curvature_sign(pts_c);
+  result.kappa = sign * kappa_abs;
+
+  if (kappa_abs > kMinKappa) {
+    result.radius = 1.0 / kappa_abs;
+
+    const double v0 = result.eigenvector[0];
+    const double v1 = result.eigenvector[1];
+    const double v2 = result.eigenvector[2];
+    const Eigen::Vector2d center_c{-v1 / (2.0 * v0), -v2 / (2.0 * v0)};
+    result.center = center_c + centroid;
+  }
+
+  result.rms_residual = detail::compute_rms_residual(pts_c, result.eigenvector);
+
+  return result;
+}
+
+}  // namespace autoware::motion::control::mpc_lateral_controller
+
+#endif  // AUTOWARE__MPC_LATERAL_CONTROLLER__TAUBIN_CURVATURE_HPP_

--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -4,6 +4,7 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     use_delayed_initial_state: true # flag to use x0_delayed as initial state for predicted trajectory
+    use_trajectory_steering_for_feedforward: true
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing
@@ -63,6 +64,13 @@
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
     mpc_converged_threshold_rps:  0.01 # threshold of mpc convergence check [rad/s]
+    stop_state_steer_hold_duration: 2.0  # [s] confirm full stop / expire confidence hold
+
+    # reference-confidence steer soft hold (post-MPC): flicker is low confidence, not stop
+    enable_confidence_steer_slew_limit: true
+    reference_confidence_L_ahead_min: 0.5   # [m] low-confidence remaining spatial extent
+    reference_confidence_L_ahead_ref: 1.0   # [m] full confidence; refresh hold timer
+    steer_slew_rate_min_rad_s: 0.02         # [rad/s] soft-hold rate at zero confidence
 
     # steer offset
     steering_offset:

--- a/control/autoware_mpc_lateral_controller/schema/mpc_lateral_controller.schema.json
+++ b/control/autoware_mpc_lateral_controller/schema/mpc_lateral_controller.schema.json
@@ -15,6 +15,9 @@
         "vehicle_model": { "$ref": "sub/vehicle_model.json#/definitions/vehicle_model" },
         "lowpass_filter": { "$ref": "sub/lowpass_filter.json#/definitions/lowpass_filter" },
         "stop_state": { "$ref": "sub/stop_state.json#/definitions/stop_state" },
+        "reference_confidence_steer_slew": {
+          "$ref": "sub/reference_confidence_steer_slew.json#/definitions/reference_confidence_steer_slew"
+        },
         "steering_offset": { "$ref": "sub/steering_offset.json#/definitions/steering_offset" },
         "dynamics_model": { "$ref": "sub/dynamics_model.json#/definitions/dynamics_model" }
       },
@@ -26,6 +29,7 @@
         "vehicle_model",
         "lowpass_filter",
         "stop_state",
+        "reference_confidence_steer_slew",
         "steering_offset",
         "dynamics_model"
       ],

--- a/control/autoware_mpc_lateral_controller/schema/sub/reference_confidence_steer_slew.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/reference_confidence_steer_slew.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MPC Lateral Controller Params",
+  "type": "object",
+  "definitions": {
+    "reference_confidence_steer_slew": {
+      "type": "object",
+      "properties": {
+        "enable_confidence_steer_slew_limit": {
+          "type": "boolean",
+          "description": "when enabled, soft-limit published steering rate when remaining spatial extent ahead of ego is short; timer refreshes only when confidence returns",
+          "default": false
+        },
+        "reference_confidence_L_ahead_min": {
+          "type": "number",
+          "description": "spatial arc length [m] below which reference is treated as low-confidence",
+          "default": 0.4
+        },
+        "reference_confidence_L_ahead_ref": {
+          "type": "number",
+          "description": "spatial arc length [m] at or above which reference is fully trusted and the low-confidence hold timer is refreshed",
+          "default": 2.0
+        },
+        "steer_slew_rate_min_rad_s": {
+          "type": "number",
+          "description": "steering rate limit [rad/s] at zero reference confidence; allowed per-cycle steer change blends linearly from min_rate*period (conf=0) to full MPC delta (conf=1)",
+          "default": 0.02
+        }
+      },
+      "required": [
+        "enable_confidence_steer_slew_limit",
+        "reference_confidence_L_ahead_min",
+        "reference_confidence_L_ahead_ref",
+        "steer_slew_rate_min_rad_s"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/reference_confidence_steer_slew"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/control/autoware_mpc_lateral_controller/schema/sub/stop_state.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/stop_state.json
@@ -40,6 +40,11 @@
           "type": "number",
           "description": "threshold value to be sure output of the optimization is converged, it is used in stopped state",
           "default": 0.01
+        },
+        "stop_state_steer_hold_duration": {
+          "type": "number",
+          "description": "shared duration [s]: (1) stop eligibility must last longer than this before isStoppedState() is true; (2) low-confidence soft hold expires after this without a confident refresh",
+          "default": 2.0
         }
       },
       "required": [
@@ -49,7 +54,8 @@
         "keep_steer_control_until_converged",
         "new_traj_duration_time",
         "new_traj_end_dist",
-        "mpc_converged_threshold_rps"
+        "mpc_converged_threshold_rps",
+        "stop_state_steer_hold_duration"
       ],
       "additionalProperties": false
     }

--- a/control/autoware_mpc_lateral_controller/schema/sub/system.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/system.json
@@ -20,6 +20,11 @@
           "type": "boolean",
           "description": "flag to use x0_delayed as initial state for predicted trajectory",
           "default": true
+        },
+        "use_trajectory_steering_for_feedforward": {
+          "type": "boolean",
+          "description": "in temporal mode, use trajectory steering for feed-forward when at least one input steering value is nonzero; otherwise use geometric curvature",
+          "default": true
         }
       },
       "required": [

--- a/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
@@ -63,6 +63,14 @@ double Butterworth2dFilter::filter(const double & u0)
   return y0;
 }
 
+void Butterworth2dFilter::resetState(const double value)
+{
+  m_y1 = value;
+  m_y2 = value;
+  m_u1 = value;
+  m_u2 = value;
+}
+
 void Butterworth2dFilter::filt_vector(const std::vector<double> & t, std::vector<double> & u) const
 {
   u.resize(t.size());

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -17,12 +17,14 @@
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/mpc_lateral_controller/mpc_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/unit_conversion.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -34,6 +36,46 @@ namespace autoware::motion::control::mpc_lateral_controller
 using autoware_utils::calc_distance2d;
 using autoware_utils::normalize_radian;
 using autoware_utils::rad2deg;
+
+namespace
+{
+bool interpolateReferenceStateAtTime(
+  const MPCTrajectory & traj, const double target_time, Pose * pose, double * nearest_time,
+  size_t * nearest_index)
+{
+  if (!pose || !nearest_time || !nearest_index) {
+    return false;
+  }
+  if (traj.empty()) {
+    return false;
+  }
+
+  const std::vector<double> out_time{
+    std::clamp(target_time, traj.relative_time.front(), traj.relative_time.back())};
+  MPCTrajectory interpolated;
+  if (!MPCUtils::linearInterpMPCTrajectory(traj.relative_time, traj, out_time, interpolated)) {
+    return false;
+  }
+  if (interpolated.empty()) {
+    return false;
+  }
+
+  pose->position.x = interpolated.x.front();
+  pose->position.y = interpolated.y.front();
+  pose->position.z = interpolated.z.front();
+  pose->orientation = autoware_utils::create_quaternion_from_yaw(interpolated.yaw.front());
+  *nearest_time = interpolated.relative_time.front();
+
+  const auto upper =
+    std::lower_bound(traj.relative_time.begin(), traj.relative_time.end(), *nearest_time);
+  if (upper == traj.relative_time.end()) {
+    *nearest_index = traj.size() - 1;
+  } else {
+    *nearest_index = static_cast<size_t>(std::distance(traj.relative_time.begin(), upper));
+  }
+  return true;
+}
+}  // namespace
 
 MPC::MPC(rclcpp::Node & node)
 {
@@ -54,10 +96,21 @@ ResultWithReason MPC::calculateMPC(
     applyVelocityDynamicsFilter(m_reference_trajectory, current_kinematics);
 
   // get the necessary data
-  const auto [get_data_result, mpc_data] =
+  const auto [get_data_result, mpc_data_raw] =
     getData(reference_trajectory, current_steer, current_kinematics);
   if (!get_data_result.result) {
     return ResultWithReason{false, fmt::format("getting MPC Data ({}).", get_data_result.reason)};
+  }
+
+  // For temporal mode, shift the internal MPC time origin to the ego-projected nearest point.
+  MPCTrajectory mpc_reference_trajectory = reference_trajectory;
+  MPCData mpc_data = mpc_data_raw;
+  if (m_use_temporal_trajectory) {
+    const double nearest_time_offset = mpc_data_raw.nearest_time;
+    for (auto & t : mpc_reference_trajectory.relative_time) {
+      t -= nearest_time_offset;
+    }
+    mpc_data.nearest_time = 0.0;
   }
 
   // calculate initial state of the error dynamics
@@ -65,7 +118,7 @@ ResultWithReason MPC::calculateMPC(
 
   // apply time delay compensation to the initial state
   const auto [success_delay, x0_delayed] =
-    updateStateForDelayCompensation(reference_trajectory, mpc_data.nearest_time, x0);
+    updateStateForDelayCompensation(mpc_reference_trajectory, mpc_data.nearest_time, x0);
   if (!success_delay) {
     return ResultWithReason{false, "delay compensation."};
   }
@@ -73,10 +126,10 @@ ResultWithReason MPC::calculateMPC(
   // resample reference trajectory with mpc sampling time
   const double mpc_start_time = mpc_data.nearest_time + m_param.input_delay;
   const double prediction_dt =
-    getPredictionDeltaTime(mpc_start_time, reference_trajectory, current_kinematics);
+    getPredictionDeltaTime(mpc_start_time, mpc_reference_trajectory, current_kinematics);
 
   const auto [resample_result, mpc_resampled_ref_trajectory] =
-    resampleMPCTrajectoryByTime(mpc_start_time, prediction_dt, reference_trajectory);
+    resampleMPCTrajectoryByTime(mpc_start_time, prediction_dt, mpc_reference_trajectory);
   if (!resample_result.result) {
     return ResultWithReason{
       false, fmt::format("trajectory resampling ({}).", resample_result.reason)};
@@ -192,6 +245,12 @@ Float32MultiArrayStamped MPC::generateDiagData(
   append_diag(iteration_num);             // [18] iteration number
   append_diag(runtime);                   // [19] runtime of the latest problem solved
   append_diag(objective_value);           // [20] objective value of the latest problem solved
+  append_diag(mpc_data.temporal_predicted_time);                // [21] temporal predicted time
+  append_diag(mpc_data.temporal_observed_time);                 // [22] temporal observed time
+  append_diag(mpc_data.temporal_fused_time);                    // [23] temporal fused time
+  append_diag(mpc_data.temporal_observation_used ? 1.0 : 0.0);  // [24] observation used
+  append_diag(mpc_data.temporal_window_min);                    // [25] temporal window min
+  append_diag(mpc_data.temporal_window_max);                    // [26] temporal window max
 
   return diagnostic;
 }
@@ -207,14 +266,22 @@ void MPC::setReferenceTrajectory(
   const double ego_offset_to_segment = autoware::motion_utils::calcLongitudinalOffsetToSegment(
     trajectory_msg.points, nearest_seg_idx, current_kinematics.pose.pose.position);
 
-  const auto mpc_traj_raw = MPCUtils::convertToMPCTrajectory(trajectory_msg);
+  const auto mpc_traj_raw =
+    MPCUtils::convertToMPCTrajectory(trajectory_msg, m_use_temporal_trajectory);
 
   // resampling
-  const auto [success_resample, mpc_traj_resampled] = MPCUtils::resampleMPCTrajectoryByDistance(
-    mpc_traj_raw, param.traj_resample_dist, nearest_seg_idx, ego_offset_to_segment);
-  if (!success_resample) {
-    warn_throttle("[setReferenceTrajectory] spline error when resampling by distance");
-    return;
+  // Note: For temporal trajectories, skip distance-based resampling to preserve timestamps.
+  MPCTrajectory mpc_traj_resampled;
+  if (m_use_temporal_trajectory) {
+    mpc_traj_resampled = mpc_traj_raw;
+  } else {
+    const auto [success_resample, resampled] = MPCUtils::resampleMPCTrajectoryByDistance(
+      mpc_traj_raw, param.traj_resample_dist, nearest_seg_idx, ego_offset_to_segment);
+    if (!success_resample) {
+      warn_throttle("[setReferenceTrajectory] spline error when resampling by distance");
+      return;
+    }
+    mpc_traj_resampled = resampled;
   }
 
   const auto is_forward_shift =
@@ -252,12 +319,20 @@ void MPC::setReferenceTrajectory(
   }
 
   // calculate yaw angle
-  MPCUtils::calcTrajectoryYawFromXY(mpc_traj_smoothed, m_is_forward_shift);
+  MPCUtils::calcTrajectoryYawFromXY(
+    mpc_traj_smoothed, m_is_forward_shift, m_use_temporal_trajectory);
   MPCUtils::convertEulerAngleToMonotonic(mpc_traj_smoothed.yaw);
 
   // calculate curvature
-  MPCUtils::calcTrajectoryCurvature(
-    param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer, mpc_traj_smoothed);
+  if (m_use_temporal_trajectory) {
+    MPCUtils::calcTrajectoryCurvatureBySpatialResample(
+      param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer,
+      param.traj_resample_dist, mpc_traj_smoothed);
+  } else {
+    MPCUtils::calcTrajectoryCurvature(
+      param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer,
+      mpc_traj_smoothed);
+  }
 
   // stop velocity at a terminal point
   mpc_traj_smoothed.vx.back() = 0.0;
@@ -273,7 +348,15 @@ void MPC::setReferenceTrajectory(
     return;
   }
 
+  mpc_traj_smoothed.stamp = trajectory_msg.header.stamp;
   m_reference_trajectory = mpc_traj_smoothed;
+  constexpr double steering_availability_threshold = 1.0e-6;
+  m_reference_trajectory_has_steering = std::any_of(
+    trajectory_msg.points.begin(), trajectory_msg.points.end(),
+    [steering_availability_threshold](const auto & point) {
+      return std::abs(static_cast<double>(point.front_wheel_angle_rad)) >
+             steering_availability_threshold;
+    });
 }
 
 void MPC::resetPrevResult(const SteeringReport & current_steer)
@@ -285,6 +368,16 @@ void MPC::resetPrevResult(const SteeringReport & current_steer)
   m_raw_steer_cmd_pprev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
 }
 
+void MPC::resetSteeringCmdFilter(const double steering_tire_angle)
+{
+  m_lpf_steering_cmd.resetState(steering_tire_angle);
+  m_raw_steer_cmd_prev = steering_tire_angle;
+  m_raw_steer_cmd_pprev = steering_tire_angle;
+  for (auto & value : m_input_buffer) {
+    value = steering_tire_angle;
+  }
+}
+
 std::pair<ResultWithReason, MPCData> MPC::getData(
   const MPCTrajectory & traj, const SteeringReport & current_steer,
   const Odometry & current_kinematics)
@@ -292,9 +385,23 @@ std::pair<ResultWithReason, MPCData> MPC::getData(
   const auto current_pose = current_kinematics.pose.pose;
 
   MPCData data;
-  if (!MPCUtils::calcNearestPoseInterp(
-        traj, current_pose, &(data.nearest_pose), &(data.nearest_idx), &(data.nearest_time),
-        ego_nearest_dist_threshold, ego_nearest_yaw_threshold)) {
+  if (m_use_temporal_trajectory) {
+    const double traj_start_time = traj.relative_time.front();
+    const double traj_end_time = traj.relative_time.back();
+
+    const rclcpp::Time traj_stamp(traj.stamp);
+    const double elapsed_time = (m_clock->now() - traj_stamp).seconds();
+    const double fused_time = std::clamp(elapsed_time, traj_start_time, traj_end_time);
+    data.temporal_predicted_time = fused_time;
+    data.temporal_fused_time = fused_time;
+
+    if (!interpolateReferenceStateAtTime(
+          traj, fused_time, &(data.nearest_pose), &(data.nearest_time), &(data.nearest_idx))) {
+      return {ResultWithReason{false, "error in calculating temporal nearest pose"}, MPCData{}};
+    }
+  } else if (!MPCUtils::calcNearestPoseInterp(
+               traj, current_pose, &(data.nearest_pose), &(data.nearest_idx), &(data.nearest_time),
+               ego_nearest_dist_threshold, ego_nearest_yaw_threshold)) {
     return {ResultWithReason{false, "error in calculating nearest pose"}, MPCData{}};
   }
 
@@ -308,9 +415,14 @@ std::pair<ResultWithReason, MPCData> MPC::getData(
   data.predicted_steer = m_steering_predictor->calcSteerPrediction();
 
   // check trajectory time length
-  const double max_prediction_time =
-    m_param.min_prediction_length / static_cast<double>(m_param.prediction_horizon - 1);
-  auto end_time = data.nearest_time + m_param.input_delay + m_ctrl_period + max_prediction_time;
+  const double required_prediction_time = [&]() {
+    if (m_use_temporal_trajectory) {
+      return m_param.prediction_dt * static_cast<double>(m_param.prediction_horizon - 1);
+    }
+    return m_param.min_prediction_length / static_cast<double>(m_param.prediction_horizon - 1);
+  }();
+  auto end_time =
+    data.nearest_time + m_param.input_delay + m_ctrl_period + required_prediction_time;
   if (end_time > traj.relative_time.back()) {
     return {ResultWithReason{false, "path is too short for prediction."}, MPCData{}};
   }
@@ -423,7 +535,7 @@ MPCTrajectory MPC::applyVelocityDynamicsFilter(
   MPCTrajectory output = input;
   MPCUtils::dynamicSmoothingVelocity(
     nearest_seg_idx, current_kinematics.twist.twist.linear.x, m_param.acceleration_limit,
-    m_param.velocity_time_constant, output);
+    m_param.velocity_time_constant, output, m_use_temporal_trajectory);
 
   auto last_point = output.back();
   last_point.relative_time += 100.0;  // extra time to prevent mpc calc failure due to short time
@@ -523,9 +635,19 @@ MPCMatrix MPC::generateMPCMatrix(
     m.Qex.block(idx_y_i, idx_y_i, DIM_Y, DIM_Y) = Q_adaptive;
     m.R1ex.block(idx_u_i, idx_u_i, DIM_U, DIM_U) = R_adaptive;
 
-    // get reference input (feed-forward)
-    m_vehicle_model_ptr->setCurvature(ref_smooth_k);
-    m_vehicle_model_ptr->calculateReferenceInput(Uref);
+    // Get reference input (feed-forward). Temporal trajectories may provide a steering state
+    // directly, avoiding numerical spatial derivatives of a time-sampled path. Geometric
+    // curvature remains in use for model linearization, weights, and the default fallback.
+    const double trajectory_steer = reference_trajectory.steer.at(i);
+    if (
+      m_use_temporal_trajectory && m_use_trajectory_steering_for_feedforward &&
+      m_reference_trajectory_has_steering && std::isfinite(trajectory_steer)) {
+      Uref.setZero();
+      Uref(0, 0) = std::clamp(trajectory_steer, -m_steer_lim, m_steer_lim);
+    } else {
+      m_vehicle_model_ptr->setCurvature(ref_smooth_k);
+      m_vehicle_model_ptr->calculateReferenceInput(Uref);
+    }
     if (std::fabs(Uref(0, 0)) < autoware_utils::deg2rad(m_param.zero_ff_steer_deg)) {
       Uref(0, 0) = 0.0;  // ignore curvature noise
     }
@@ -698,6 +820,20 @@ void MPC::addSteerWeightF(const double prediction_dt, MatrixXd & f) const
 double MPC::getPredictionDeltaTime(
   const double start_time, const MPCTrajectory & input, const Odometry & current_kinematics) const
 {
+  if (m_use_temporal_trajectory) {
+    const double horizon_end_time =
+      start_time + m_param.prediction_dt * static_cast<double>(m_param.prediction_horizon - 1);
+    const double t_ext = 100.0;
+    const double available_end_time = input.relative_time.back() - t_ext;
+    if (horizon_end_time > available_end_time) {
+      const double available_time = available_end_time - start_time;
+      const double reduced_dt =
+        available_time / static_cast<double>(m_param.prediction_horizon - 1);
+      return std::max(reduced_dt, m_param.prediction_dt * 0.1);
+    }
+    return m_param.prediction_dt;
+  }
+
   // Calculate the time min_prediction_length ahead from current_pose
   const auto autoware_traj = MPCUtils::convertToAutowareTrajectory(input);
   const size_t nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -26,9 +26,11 @@
 #include <tf2/utils.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <deque>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,6 +52,7 @@ MpcLateralController::MpcLateralController(
 
   const auto ctrl_period = node.get_parameter("ctrl_period").as_double();
   m_mpc->m_ctrl_period = ctrl_period;
+  m_ctrl_period = ctrl_period;
 
   auto & p_filt = m_trajectory_filtering_param;
   p_filt.enable_path_smoothing = dp_bool("enable_path_smoothing");
@@ -70,6 +73,17 @@ MpcLateralController::MpcLateralController(
   m_new_traj_duration_time = dp_double("new_traj_duration_time");            // [s]
   m_new_traj_end_dist = dp_double("new_traj_end_dist");                      // [m]
   m_mpc_converged_threshold_rps = dp_double("mpc_converged_threshold_rps");  // [rad/s]
+  m_stop_state_steer_hold_duration =
+    node.declare_parameter<double>("stop_state_steer_hold_duration", 2.0);
+
+  /* reference-confidence steer soft hold */
+  m_enable_confidence_steer_slew_limit =
+    node.declare_parameter<bool>("enable_confidence_steer_slew_limit", true);
+  m_reference_confidence_L_ahead_min =
+    node.declare_parameter<double>("reference_confidence_L_ahead_min", 0.5);
+  m_reference_confidence_L_ahead_ref =
+    node.declare_parameter<double>("reference_confidence_L_ahead_ref", 1.0);
+  m_steer_slew_rate_min_rad_s = node.declare_parameter<double>("steer_slew_rate_min_rad_s", 0.02);
 
   /* mpc parameters */
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
@@ -144,6 +158,21 @@ MpcLateralController::MpcLateralController(
   m_mpc->ego_nearest_yaw_threshold = m_ego_nearest_yaw_threshold;
 
   m_mpc->m_use_delayed_initial_state = dp_bool("use_delayed_initial_state");
+
+  const auto trajectory_reference_mode =
+    node.has_parameter("trajectory_reference_mode")
+      ? node.get_parameter("trajectory_reference_mode").as_string()
+      : node.declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+  if (trajectory_reference_mode == "temporal") {
+    m_mpc->m_use_temporal_trajectory = true;
+  } else if (trajectory_reference_mode == "spatial") {
+    m_mpc->m_use_temporal_trajectory = false;
+  } else {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
+  m_mpc->m_use_trajectory_steering_for_feedforward =
+    node.declare_parameter<bool>("use_trajectory_steering_for_feedforward", true);
 
   m_mpc->m_publish_debug_trajectories = dp_bool("publish_debug_trajectories");
 
@@ -325,20 +354,21 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     return output;
   };
 
+  updateStopStateHoldTimer();
+
+  // Confirmed full stop only (elapsed > duration). Until then stay in control.
   if (isStoppedState()) {
-    // Reset input buffer
-    debug_throttle("Stopped state detected, use previous control command");
-    for (auto & value : m_mpc->m_input_buffer) {
-      value = m_ctrl_cmd_prev.steering_tire_angle;
-    }
-    // Use previous command value as previous raw steer command
-    m_mpc->m_raw_steer_cmd_prev = m_ctrl_cmd_prev.steering_tire_angle;
+    syncMpcSteerStateToCommand(m_ctrl_cmd_prev.steering_tire_angle);
     return createLateralOutput(m_ctrl_cmd_prev, false, ctrl_cmd_horizon);
   }
 
   if (!mpc_solved_status.result) {
     debug_throttle("MPC is not solved, use stop control command");
     ctrl_cmd = getStopControlCommand();
+    syncMpcSteerStateToCommand(ctrl_cmd.steering_tire_angle);
+  } else if (m_enable_confidence_steer_slew_limit && applyConfidenceSteerSlewLimit(ctrl_cmd)) {
+    // Low-confidence / flicker: soft-slew (not stop). Sync LPF to published output.
+    syncMpcSteerStateToCommand(ctrl_cmd.steering_tire_angle);
   }
 
   m_ctrl_cmd_prev = ctrl_cmd;
@@ -433,25 +463,12 @@ Lateral MpcLateralController::getInitialControlCommand() const
   return cmd;
 }
 
-bool MpcLateralController::isStoppedState() const
+double MpcLateralController::getMinTargetVelocityAhead() const
 {
-  const double current_vel = m_current_kinematic_state.twist.twist.linear.x;
-  // If the nearest index is not found, return false
-  if (
-    m_current_trajectory.points.empty() || std::fabs(current_vel) > m_stop_state_entry_ego_speed) {
-    return false;
+  if (m_current_trajectory.points.empty()) {
+    return std::numeric_limits<double>::infinity();
   }
 
-  const auto latest_published_cmd = m_ctrl_cmd_prev;  // use prev_cmd as a latest published command
-  if (m_keep_steer_control_until_converged && !isSteerConverged(latest_published_cmd)) {
-    debug_throttle("steering is not converged.");
-    return false;  // not stopState: keep control
-  }
-
-  // Note: This function used to take into account the distance to the stop line
-  // for the stop state judgement. However, it has been removed since the steering
-  // control was turned off when approaching/exceeding the stop line on a curve or
-  // emergency stop situation and it caused large tracking error.
   const size_t nearest = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
@@ -460,19 +477,70 @@ bool MpcLateralController::isStoppedState() const
   // will not start when the distance from ego to stop point is less than 0.5 meter.
   // So we use a distance margin to ensure we can detect stopped state.
   static constexpr double distance_margin = 1.0;
-  const double target_vel = std::invoke([&]() -> double {
-    auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
-    auto covered_distance = 0.0;
-    for (auto i = nearest + 1; i < m_current_trajectory.points.size(); ++i) {
-      min_vel = std::min(min_vel, m_current_trajectory.points.at(i).longitudinal_velocity_mps);
-      covered_distance += autoware_utils::calc_distance2d(
-        m_current_trajectory.points.at(i - 1).pose, m_current_trajectory.points.at(i).pose);
-      if (covered_distance > distance_margin) break;
+  auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
+  auto covered_distance = 0.0;
+  for (auto i = nearest + 1; i < m_current_trajectory.points.size(); ++i) {
+    min_vel = std::min(min_vel, m_current_trajectory.points.at(i).longitudinal_velocity_mps);
+    covered_distance += autoware_utils::calc_distance2d(
+      m_current_trajectory.points.at(i - 1).pose, m_current_trajectory.points.at(i).pose);
+    if (covered_distance > distance_margin) {
+      break;
     }
-    return min_vel;
-  });
+  }
+  return min_vel;
+}
 
-  return std::fabs(target_vel) < m_stop_state_entry_target_speed;
+bool MpcLateralController::isEgoAndTrajectoryStopped() const
+{
+  if (m_current_trajectory.points.empty()) {
+    return false;
+  }
+
+  const double current_vel = m_current_kinematic_state.twist.twist.linear.x;
+  if (std::fabs(current_vel) > m_stop_state_entry_ego_speed) {
+    return false;
+  }
+
+  return std::fabs(getMinTargetVelocityAhead()) < m_stop_state_entry_target_speed;
+}
+
+bool MpcLateralController::isStopStateSteerHoldEligible() const
+{
+  if (!isEgoAndTrajectoryStopped()) {
+    return false;
+  }
+
+  const auto latest_published_cmd = m_ctrl_cmd_prev;
+  if (m_keep_steer_control_until_converged && !isSteerConverged(latest_published_cmd)) {
+    debug_throttle("steering is not converged.");
+    return false;
+  }
+
+  return true;
+}
+
+void MpcLateralController::updateStopStateHoldTimer()
+{
+  if (!isStopStateSteerHoldEligible()) {
+    m_stop_state_hold_started_at.reset();
+    return;
+  }
+
+  if (!m_stop_state_hold_started_at.has_value()) {
+    m_stop_state_hold_started_at = clock_->now();
+  }
+}
+
+bool MpcLateralController::isStoppedState() const
+{
+  // Confirmed full stop only after eligibility lasts longer than the hold duration.
+  // Until then the system is still in control. Flickering short trajectories are not stop.
+  if (!isStopStateSteerHoldEligible() || !m_stop_state_hold_started_at.has_value()) {
+    return false;
+  }
+
+  const double elapsed = (clock_->now() - m_stop_state_hold_started_at.value()).seconds();
+  return elapsed > m_stop_state_steer_hold_duration;
 }
 
 Lateral MpcLateralController::createCtrlCmdMsg(const Lateral & ctrl_cmd)
@@ -650,6 +718,10 @@ rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
     update_param(parameters, "mpc_velocity_time_constant", param.velocity_time_constant);
     update_param(parameters, "mpc_min_prediction_length", param.min_prediction_length);
 
+    update_param(
+      parameters, "use_trajectory_steering_for_feedforward",
+      m_mpc->m_use_trajectory_steering_for_feedforward);
+
     // initialize input buffer
     update_param(parameters, "input_delay", param.input_delay);
     const double delay_step = std::round(param.input_delay / m_mpc->m_ctrl_period);
@@ -669,6 +741,87 @@ rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
   return result;
 }
 
+double MpcLateralController::getReferenceRemainingArcLength() const
+{
+  const auto & ref_traj = m_mpc->m_reference_trajectory;
+  if (ref_traj.size() < 2) {
+    return 0.0;
+  }
+
+  const auto traj_points = ref_traj.toTrajectoryPoints();
+  if (traj_points.empty()) {
+    return 0.0;
+  }
+
+  const size_t nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+    traj_points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
+    m_ego_nearest_yaw_threshold);
+
+  return MPCUtils::calcMPCTrajectoryRemainingArcLength(ref_traj, nearest_idx);
+}
+
+double MpcLateralController::computeReferenceConfidenceWeight() const
+{
+  const double L_ahead = getReferenceRemainingArcLength();
+
+  const double L_span =
+    std::max(m_reference_confidence_L_ahead_ref - m_reference_confidence_L_ahead_min, 1.0e-6);
+  return std::clamp((L_ahead - m_reference_confidence_L_ahead_min) / L_span, 0.0, 1.0);
+}
+
+bool MpcLateralController::isReferenceFullyConfident() const
+{
+  return computeReferenceConfidenceWeight() >= 1.0 - 1.0e-6;
+}
+
+bool MpcLateralController::applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd)
+{
+  // Confident: accept MPC and refresh the low-confidence hold timer.
+  if (isReferenceFullyConfident()) {
+    m_confidence_hold_started_at.reset();
+    return false;
+  }
+
+  // Low confidence / flicker: not a stop. Soft-limit |Δsteer| toward MPC until confidence
+  // returns (timer refresh) or hold duration expires (allow full MPC restore).
+  if (!m_confidence_hold_started_at.has_value()) {
+    m_confidence_hold_started_at = clock_->now();
+  }
+
+  const double elapsed = (clock_->now() - m_confidence_hold_started_at.value()).seconds();
+  if (elapsed > m_stop_state_steer_hold_duration) {
+    return false;
+  }
+
+  const double confidence_weight = computeReferenceConfidenceWeight();
+  const double ds =
+    static_cast<double>(ctrl_cmd.steering_tire_angle - m_ctrl_cmd_prev.steering_tire_angle);
+  const double ds_abs = std::abs(ds);
+
+  // Linear blend: conf=0 -> ds_max = min_rate*period; conf=1 -> ds_max = |ds| (pass-through).
+  const double ds_max_at_zero_confidence = m_steer_slew_rate_min_rad_s * m_ctrl_period;
+  const double ds_max =
+    (1.0 - confidence_weight) * ds_max_at_zero_confidence + confidence_weight * ds_abs;
+
+  if (ds_abs <= ds_max) {
+    return false;
+  }
+
+  const double ds_clamped = std::clamp(ds, -ds_max, ds_max);
+  ctrl_cmd.steering_tire_angle =
+    m_ctrl_cmd_prev.steering_tire_angle + static_cast<float>(ds_clamped);
+  ctrl_cmd.steering_tire_rotation_rate =
+    m_ctrl_period > 0.0 ? static_cast<float>(ds_clamped / m_ctrl_period) : 0.0f;
+  return true;
+}
+
+void MpcLateralController::syncMpcSteerStateToCommand(const float steering_tire_angle)
+{
+  // Align delay buffer and steering LPF with the published command so soft hold / stop freeze
+  // is not undone by LPF state that tracked raw Uex.
+  m_mpc->resetSteeringCmdFilter(static_cast<double>(steering_tire_angle));
+}
+
 bool MpcLateralController::isTrajectoryShapeChanged() const
 {
   // TODO(Horibe): update implementation to check trajectory shape around ego vehicle.
@@ -685,6 +838,7 @@ bool MpcLateralController::isTrajectoryShapeChanged() const
 
 bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
 {
+  double prev_time_from_start = -std::numeric_limits<double>::infinity();
   for (const auto & p : traj.points) {
     if (
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
@@ -694,6 +848,13 @@ bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
       !isfinite(p.heading_rate_rps) || !isfinite(p.front_wheel_angle_rad) ||
       !isfinite(p.rear_wheel_angle_rad)) {
       return false;
+    }
+    if (m_mpc->m_use_temporal_trajectory) {
+      const double t = rclcpp::Duration(p.time_from_start).seconds();
+      if (!std::isfinite(t) || t <= prev_time_from_start) {
+        return false;
+      }
+      prev_time_from_start = t;
     }
   }
   return true;

--- a/control/autoware_mpc_lateral_controller/src/mpc_trajectory.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_trajectory.cpp
@@ -22,6 +22,13 @@ void MPCTrajectory::push_back(
   const double & xp, const double & yp, const double & zp, const double & yawp, const double & vxp,
   const double & kp, const double & smooth_kp, const double & tp)
 {
+  push_back(xp, yp, zp, yawp, vxp, kp, smooth_kp, 0.0, tp);
+}
+
+void MPCTrajectory::push_back(
+  const double & xp, const double & yp, const double & zp, const double & yawp, const double & vxp,
+  const double & kp, const double & smooth_kp, const double & steerp, const double & tp)
+{
   x.push_back(xp);
   y.push_back(yp);
   z.push_back(zp);
@@ -29,6 +36,7 @@ void MPCTrajectory::push_back(
   vx.push_back(vxp);
   k.push_back(kp);
   smooth_k.push_back(smooth_kp);
+  steer.push_back(steerp);
   relative_time.push_back(tp);
 }
 
@@ -41,6 +49,7 @@ void MPCTrajectory::push_back(const MPCTrajectoryPoint & p)
   vx.push_back(p.vx);
   k.push_back(p.k);
   smooth_k.push_back(p.smooth_k);
+  steer.push_back(p.steer);
   relative_time.push_back(p.relative_time);
 }
 
@@ -55,6 +64,7 @@ MPCTrajectoryPoint MPCTrajectory::back()
   p.vx = vx.back();
   p.k = k.back();
   p.smooth_k = smooth_k.back();
+  p.steer = steer.back();
   p.relative_time = relative_time.back();
 
   return p;
@@ -71,6 +81,7 @@ MPCTrajectoryPoint MPCTrajectory::at(const size_t i) const
   p.vx = vx.at(i);
   p.k = k.at(i);
   p.smooth_k = smooth_k.at(i);
+  p.steer = steer.at(i);
   p.relative_time = relative_time.at(i);
 
   return p;
@@ -85,6 +96,7 @@ void MPCTrajectory::clear()
   vx.clear();
   k.clear();
   smooth_k.clear();
+  steer.clear();
   relative_time.clear();
 }
 
@@ -93,7 +105,7 @@ size_t MPCTrajectory::size() const
   if (
     x.size() == y.size() && x.size() == z.size() && x.size() == yaw.size() &&
     x.size() == vx.size() && x.size() == k.size() && x.size() == smooth_k.size() &&
-    x.size() == relative_time.size()) {
+    x.size() == steer.size() && x.size() == relative_time.size()) {
     return x.size();
   } else {
     std::cerr << "[MPC trajectory] trajectory size is inappropriate" << std::endl;

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -18,10 +18,14 @@
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/interpolation/spline_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/mpc_lateral_controller/taubin_curvature.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/normalization.hpp"
 
+#include <Eigen/Dense>
+
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
@@ -41,6 +45,50 @@ double calcLongitudinalOffset(
   const Eigen::Vector3d target_vec{p_target.x - p_front.x, p_target.y - p_front.y, 0};
 
   return segment_vec.dot(target_vec) / segment_vec.norm();
+}
+
+bool isTemporalShortSegment(
+  const double ds, const double dt, const double vx, const bool use_short_segment_protection)
+{
+  if (!use_short_segment_protection) {
+    return ds < 1.0e-3;
+  }
+
+  constexpr double min_distance_threshold = 2.0e-2;
+  constexpr double stop_like_velocity_threshold = 1.0e-1;
+  constexpr double min_velocity_floor = 1.0e-1;
+  constexpr double expected_distance_ratio = 0.5;
+  constexpr double min_time_step = 1.0e-3;
+
+  if (ds < min_distance_threshold && std::fabs(vx) < stop_like_velocity_threshold) {
+    return true;
+  }
+
+  const double bounded_dt = std::max(dt, min_time_step);
+  const double expected_distance = std::max(std::fabs(vx), min_velocity_floor) * bounded_dt;
+  return ds < expected_distance_ratio * expected_distance;
+}
+
+std::pair<size_t, size_t> findYawDifferentiationWindow(
+  const std::vector<double> & arc_length, const size_t idx, const double min_baseline_m)
+{
+  if (arc_length.size() == 1) return {0, 0};
+
+  const size_t last = arc_length.size() - 1;
+  size_t front = (idx > 0) ? idx - 1 : 0;
+  size_t back = (idx < last) ? idx + 1 : last;
+  while (arc_length.at(back) - arc_length.at(front) < min_baseline_m) {
+    if (front == 0 && back == last) {
+      break;
+    }
+    if (front > 0) {
+      --front;
+    }
+    if (back < last) {
+      ++back;
+    }
+  }
+  return {front, back};
 }
 }  // namespace
 
@@ -97,6 +145,19 @@ double calcMPCTrajectoryArcLength(const MPCTrajectory & trajectory)
 {
   double length = 0.0;
   for (size_t i = 1; i < trajectory.size(); ++i) {
+    length += calcDistance2d(trajectory, i, i - 1);
+  }
+  return length;
+}
+
+double calcMPCTrajectoryRemainingArcLength(const MPCTrajectory & trajectory, const size_t start_idx)
+{
+  if (trajectory.size() < 2 || start_idx >= trajectory.size() - 1) {
+    return 0.0;
+  }
+
+  double length = 0.0;
+  for (size_t i = start_idx + 1; i < trajectory.size(); ++i) {
     length += calcDistance2d(trajectory, i, i - 1);
   }
   return length;
@@ -160,6 +221,7 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
     output.vx = lerp_arc_length(input.vx);  // must be linear
     output.k = spline_arc_length(input.k);
     output.smooth_k = spline_arc_length(input.smooth_k);
+    output.steer = lerp_arc_length(input.steer);
     output.relative_time = lerp_arc_length(input.relative_time);  // must be linear
   } catch (const std::exception & e) {
     const auto logger = rclcpp::get_logger("mpc_util");
@@ -200,6 +262,7 @@ bool linearInterpMPCTrajectory(
     out_traj.vx = lerp_arc_length(in_traj.vx);
     out_traj.k = lerp_arc_length(in_traj.k);
     out_traj.smooth_k = lerp_arc_length(in_traj.smooth_k);
+    out_traj.steer = lerp_arc_length(in_traj.steer);
     out_traj.relative_time = lerp_arc_length(in_traj.relative_time);
   } catch (const std::exception & e) {
     std::cerr << "linearInterpMPCTrajectory error!: " << e.what() << std::endl;
@@ -213,7 +276,8 @@ bool linearInterpMPCTrajectory(
   return true;
 }
 
-void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift)
+void calcTrajectoryYawFromXY(
+  MPCTrajectory & traj, const bool is_forward_shift, const bool use_input_yaw_for_short_segment)
 {
   if (traj.yaw.size() < 3) {  // at least 3 points are required to calculate yaw
     return;
@@ -223,40 +287,111 @@ void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift)
     return;
   }
 
-  // interpolate yaw
-  for (int i = 1; i < static_cast<int>(traj.yaw.size()) - 1; ++i) {
-    const double dx = traj.x.at(i + 1) - traj.x.at(i - 1);
-    const double dy = traj.y.at(i + 1) - traj.y.at(i - 1);
-    traj.yaw.at(i) = is_forward_shift ? std::atan2(dy, dx) : std::atan2(dy, dx) + M_PI;
+  if (!use_input_yaw_for_short_segment) {
+    for (int i = 1; i < static_cast<int>(traj.yaw.size()) - 1; ++i) {
+      const double dx = traj.x.at(i + 1) - traj.x.at(i - 1);
+      const double dy = traj.y.at(i + 1) - traj.y.at(i - 1);
+      traj.yaw.at(i) = is_forward_shift ? std::atan2(dy, dx) : std::atan2(dy, dx) + M_PI;
+    }
+    if (traj.yaw.size() > 1) {
+      traj.yaw.at(0) = traj.yaw.at(1);
+      traj.yaw.back() = traj.yaw.at(traj.yaw.size() - 2);
+    }
+    return;
   }
-  if (traj.yaw.size() > 1) {
-    traj.yaw.at(0) = traj.yaw.at(1);
-    traj.yaw.back() = traj.yaw.at(traj.yaw.size() - 2);
+
+  const auto input_yaw = traj.yaw;
+  std::vector<double> arc_length;
+  calcMPCTrajectoryArcLength(traj, arc_length);
+  constexpr double min_yaw_baseline_m = 0.5;
+  const auto is_short_segment = [&](const size_t front, const size_t back) {
+    const double ds = calcDistance2d(traj, back, front);
+    const double dt = traj.relative_time.at(back) - traj.relative_time.at(front);
+    const double vx = 0.5 * (traj.vx.at(front) + traj.vx.at(back));
+    return isTemporalShortSegment(ds, dt, vx, true);
+  };
+
+  for (size_t i = 0; i < traj.yaw.size(); ++i) {
+    if (
+      (i > 0 && is_short_segment(i - 1, i)) ||
+      (i + 1 < traj.yaw.size() && is_short_segment(i, i + 1))) {
+      traj.yaw.at(i) = (i == 0) ? input_yaw.at(i) : traj.yaw.at(i - 1);
+      if (use_input_yaw_for_short_segment) {
+        traj.yaw.at(i) = input_yaw.at(i);
+      }
+      continue;
+    }
+
+    const auto [front, back] = findYawDifferentiationWindow(arc_length, i, min_yaw_baseline_m);
+    const double dx = traj.x.at(back) - traj.x.at(front);
+    const double dy = traj.y.at(back) - traj.y.at(front);
+    if (
+      arc_length.at(back) - arc_length.at(front) < min_yaw_baseline_m ||
+      std::hypot(dx, dy) < 1.0e-3) {
+      traj.yaw.at(i) = input_yaw.at(i);
+      continue;
+    }
+    traj.yaw.at(i) = is_forward_shift ? std::atan2(dy, dx) : std::atan2(dy, dx) + M_PI;
   }
 }
 
 void calcTrajectoryCurvature(
   const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
-  MPCTrajectory & traj)
+  MPCTrajectory & traj, const bool use_short_segment_protection)
 {
-  traj.k = calcTrajectoryCurvature(curvature_smoothing_num_traj, traj);
-  traj.smooth_k = calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, traj);
+  traj.k =
+    calcTrajectoryCurvature(curvature_smoothing_num_traj, traj, use_short_segment_protection);
+  traj.smooth_k =
+    calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, traj, use_short_segment_protection);
 }
 
 std::vector<double> calcTrajectoryCurvature(
-  const int curvature_smoothing_num, const MPCTrajectory & traj)
+  const int curvature_smoothing_num, const MPCTrajectory & traj,
+  const bool use_short_segment_protection)
 {
-  std::vector<double> curvature_vec(traj.x.size());
+  const size_t n = traj.x.size();
+  std::vector<double> curvature_vec(n);
+  if (n < 3) {
+    return curvature_vec;
+  }
+
+  const int max_smoothing_num = static_cast<int>(std::floor(0.5 * (static_cast<double>(n - 1))));
+
+  Eigen::MatrixX2d pts(static_cast<Eigen::Index>(n), 2);
+  if (max_smoothing_num < curvature_smoothing_num) {
+    for (size_t i = 0; i < n; ++i) {
+      pts(static_cast<Eigen::Index>(i), 0) = traj.x.at(i);
+      pts(static_cast<Eigen::Index>(i), 1) = traj.y.at(i);
+    }
+    // Get a constant curvature and assign to all indices
+    const double kappa = taubin_curvature(pts).kappa;
+    curvature_vec.assign(n, kappa);
+    return curvature_vec;
+  }
 
   /* calculate curvature by circle fitting from three points */
   geometry_msgs::msg::Point p1, p2, p3;
-  const int max_smoothing_num =
-    static_cast<int>(std::floor(0.5 * (static_cast<double>(traj.x.size() - 1))));
   const size_t L = static_cast<size_t>(std::min(curvature_smoothing_num, max_smoothing_num));
   for (size_t i = L; i < traj.x.size() - L; ++i) {
     const size_t curr_idx = i;
     const size_t prev_idx = curr_idx - L;
     const size_t next_idx = curr_idx + L;
+    const double dist_prev = calcDistance2d(traj, curr_idx, prev_idx);
+    const double dist_next = calcDistance2d(traj, next_idx, curr_idx);
+    const double dist_span = calcDistance2d(traj, next_idx, prev_idx);
+    const double dt_prev = traj.relative_time.at(curr_idx) - traj.relative_time.at(prev_idx);
+    const double dt_next = traj.relative_time.at(next_idx) - traj.relative_time.at(curr_idx);
+    const double dt_span = traj.relative_time.at(next_idx) - traj.relative_time.at(prev_idx);
+    const double vx_prev = 0.5 * (traj.vx.at(prev_idx) + traj.vx.at(curr_idx));
+    const double vx_next = 0.5 * (traj.vx.at(curr_idx) + traj.vx.at(next_idx));
+    const double vx_span = 0.5 * (traj.vx.at(prev_idx) + traj.vx.at(next_idx));
+    if (
+      isTemporalShortSegment(dist_prev, dt_prev, vx_prev, use_short_segment_protection) ||
+      isTemporalShortSegment(dist_next, dt_next, vx_next, use_short_segment_protection) ||
+      isTemporalShortSegment(dist_span, dt_span, vx_span, use_short_segment_protection)) {
+      curvature_vec.at(curr_idx) = curr_idx > 0 ? curvature_vec.at(curr_idx - 1) : 0.0;
+      continue;
+    }
     p1.x = traj.x.at(prev_idx);
     p2.x = traj.x.at(curr_idx);
     p3.x = traj.x.at(next_idx);
@@ -267,7 +402,7 @@ std::vector<double> calcTrajectoryCurvature(
       curvature_vec.at(curr_idx) = autoware_utils::calc_curvature(p1, p2, p3);
     } catch (...) {
       std::cerr << "[MPC] 2 points are too close to calculate curvature." << std::endl;
-      curvature_vec.at(curr_idx) = 0.0;
+      curvature_vec.at(curr_idx) = curr_idx > 0 ? curvature_vec.at(curr_idx - 1) : 0.0;
     }
   }
 
@@ -280,20 +415,104 @@ std::vector<double> calcTrajectoryCurvature(
   return curvature_vec;
 }
 
-MPCTrajectory convertToMPCTrajectory(const Trajectory & input)
+void calcTrajectoryCurvatureBySpatialResample(
+  const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
+  const double resample_interval_dist, MPCTrajectory & traj)
+{
+  if (traj.size() < 3) {
+    return;
+  }
+
+  std::vector<double> orig_arclength;
+  calcMPCTrajectoryArcLength(traj, orig_arclength);
+  const double total_length = orig_arclength.back();
+  if (total_length < 1e-6) {
+    return;
+  }
+
+  constexpr double dedup_eps = 1e-3;
+  std::vector<double> unique_arclength;
+  std::vector<double> unique_x;
+  std::vector<double> unique_y;
+  unique_arclength.push_back(orig_arclength.front());
+  unique_x.push_back(traj.x.front());
+  unique_y.push_back(traj.y.front());
+  for (size_t i = 1; i < orig_arclength.size(); ++i) {
+    if (orig_arclength[i] - unique_arclength.back() > dedup_eps) {
+      unique_arclength.push_back(orig_arclength[i]);
+      unique_x.push_back(traj.x[i]);
+      unique_y.push_back(traj.y[i]);
+    }
+  }
+  if (unique_arclength.size() < 3) {
+    return;
+  }
+
+  std::vector<double> resampled_arclength;
+  for (double s = 0.0; s < total_length; s += resample_interval_dist) {
+    resampled_arclength.push_back(s);
+  }
+  if (resampled_arclength.back() < total_length - 1e-6) {
+    resampled_arclength.push_back(total_length);
+  }
+  if (resampled_arclength.size() < 3) {
+    return;
+  }
+
+  MPCTrajectory spatial_traj;
+  spatial_traj.x = autoware::interpolation::spline(unique_arclength, unique_x, resampled_arclength);
+  spatial_traj.y = autoware::interpolation::spline(unique_arclength, unique_y, resampled_arclength);
+  const auto n = resampled_arclength.size();
+  spatial_traj.z.resize(n, 0.0);
+  spatial_traj.yaw.resize(n, 0.0);
+  spatial_traj.vx.resize(n, 0.0);
+  spatial_traj.k.resize(n, 0.0);
+  spatial_traj.smooth_k.resize(n, 0.0);
+  spatial_traj.steer.resize(n, 0.0);
+  spatial_traj.relative_time.resize(n, 0.0);
+
+  const auto k_spatial = calcTrajectoryCurvature(curvature_smoothing_num_traj, spatial_traj);
+  const auto smooth_k_spatial =
+    calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, spatial_traj);
+
+  const auto k_at_unique =
+    autoware::interpolation::lerp(resampled_arclength, k_spatial, unique_arclength);
+  const auto smooth_k_at_unique =
+    autoware::interpolation::lerp(resampled_arclength, smooth_k_spatial, unique_arclength);
+
+  traj.k.assign(traj.size(), 0.0);
+  traj.smooth_k.assign(traj.size(), 0.0);
+  size_t unique_idx = 0;
+  for (size_t i = 0; i < traj.size(); ++i) {
+    while (unique_idx + 1 < unique_arclength.size() &&
+           unique_arclength[unique_idx + 1] <= orig_arclength[i] + dedup_eps) {
+      ++unique_idx;
+    }
+    if (i == 0 || orig_arclength[i] - orig_arclength[i - 1] > dedup_eps) {
+      traj.k[i] = k_at_unique[unique_idx];
+      traj.smooth_k[i] = smooth_k_at_unique[unique_idx];
+    }
+  }
+}
+
+MPCTrajectory convertToMPCTrajectory(const Trajectory & input, const bool use_temporal_trajectory)
 {
   MPCTrajectory output;
+  output.stamp = input.header.stamp;
   for (const TrajectoryPoint & p : input.points) {
     const double x = p.pose.position.x;
     const double y = p.pose.position.y;
     const double z = p.pose.position.z;
     const double yaw = tf2::getYaw(p.pose.orientation);
     const double vx = p.longitudinal_velocity_mps;
+    const double steer = p.front_wheel_angle_rad;
     const double k = 0.0;
-    const double t = 0.0;
-    output.push_back(x, y, z, yaw, vx, k, k, t);
+    const double t = use_temporal_trajectory ? rclcpp::Duration(p.time_from_start).seconds() : 0.0;
+    output.push_back(x, y, z, yaw, vx, k, k, steer, t);
   }
-  calcMPCTrajectoryTime(output);
+  if (!use_temporal_trajectory) {
+    calcMPCTrajectoryTime(output);
+  }
   return output;
 }
 
@@ -312,6 +531,8 @@ Trajectory convertToAutowareTrajectory(const MPCTrajectory & input, const double
       rclcpp::Duration::from_seconds(input.relative_time.at(i) - input.relative_time.front());
     if (wheelbase != 0.0) {
       p.front_wheel_angle_rad = static_cast<float>(std::atan(input.smooth_k.at(i) * wheelbase));
+    } else if (std::isfinite(input.steer.at(i))) {
+      p.front_wheel_angle_rad = static_cast<float>(input.steer.at(i));
     }
     output.points.push_back(p);
     if (output.points.size() == output.points.max_size()) {
@@ -338,7 +559,7 @@ bool calcMPCTrajectoryTime(MPCTrajectory & traj)
 
 void dynamicSmoothingVelocity(
   const size_t start_seg_idx, const double start_vel, const double acc_lim, const double tau,
-  MPCTrajectory & traj)
+  MPCTrajectory & traj, const bool use_temporal_trajectory)
 {
   double curr_v = start_vel;
   // set current velocity in both start and end point of the segment
@@ -349,14 +570,24 @@ void dynamicSmoothingVelocity(
 
   for (size_t i = start_seg_idx + 2; i < traj.size(); ++i) {
     const double ds = calcDistance2d(traj, i, i - 1);
-    const double dt = ds / std::max(std::fabs(curr_v), std::numeric_limits<double>::epsilon());
+    const double dt = [&]() {
+      if (use_temporal_trajectory) {
+        const double time_dt = traj.relative_time.at(i) - traj.relative_time.at(i - 1);
+        constexpr double min_time_dt = 1.0e-4;
+        return std::max(time_dt, min_time_dt);
+      }
+      return ds / std::max(std::fabs(curr_v), std::numeric_limits<double>::epsilon());
+    }();
     const double a = tau / std::max(tau + dt, std::numeric_limits<double>::epsilon());
     const double updated_v = a * curr_v + (1.0 - a) * traj.vx.at(i);
     const double dv = std::max(-acc_lim * dt, std::min(acc_lim * dt, updated_v - curr_v));
     curr_v = curr_v + dv;
     traj.vx.at(i) = curr_v;
   }
-  calcMPCTrajectoryTime(traj);
+
+  if (!use_temporal_trajectory) {
+    calcMPCTrajectoryTime(traj);
+  }
 }
 
 bool calcNearestPoseInterp(
@@ -495,7 +726,8 @@ void extendTrajectoryInYawDirection(
     extended_pose = autoware_utils::calc_offset_pose(extended_pose, x_offset, 0.0, 0.0);
     traj.push_back(
       extended_pose.position.x, extended_pose.position.y, extended_pose.position.z, traj.yaw.back(),
-      extend_vel, traj.k.back(), traj.smooth_k.back(), traj.relative_time.back() + dt);
+      extend_vel, traj.k.back(), traj.smooth_k.back(), traj.steer.back(),
+      traj.relative_time.back() + dt);
   }
 }
 

--- a/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
@@ -35,6 +35,9 @@
     time_threshold_before_pid_integration: 2.0
     ff_scale_min: 0.5
     ff_scale_max: 2.0
+    enable_velocity_lookahead_feedback: true
+    velocity_lookahead_time: 1.0
+    velocity_lookahead_blend_weight: 0.5
     enable_brake_keeping_before_stop: false
     brake_keeping_acc: -0.2
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/debug_values.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/debug_values.hpp
@@ -64,6 +64,12 @@ public:
     PITCH_LPF_RAD = 34,
     PITCH_LPF_DEG = 35,
     SMOOTH_STOP_MODE = 36,
+    TEMPORAL_PREDICTED_TIME = 37,
+    TEMPORAL_OBSERVED_TIME = 38,
+    TEMPORAL_FUSED_TIME = 39,
+    TEMPORAL_OBSERVATION_USED = 40,
+    TEMPORAL_WINDOW_MIN = 41,
+    TEMPORAL_WINDOW_MAX = 42,
 
     SIZE  // this is the number of enum elements
   };

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -27,10 +27,12 @@
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "rclcpp/duration.hpp"
 
 #include <cmath>
 #include <limits>
 #include <utility>
+#include <vector>
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
@@ -46,7 +48,7 @@ using geometry_msgs::msg::Quaternion;
 /**
  * @brief check if trajectory is invalid or not
  */
-bool isValidTrajectory(const Trajectory & traj);
+bool isValidTrajectory(const Trajectory & traj, const bool use_temporal_trajectory = false);
 
 /**
  * @brief calculate distance to stopline from current vehicle position where velocity is 0
@@ -125,6 +127,15 @@ std::pair<TrajectoryPoint, size_t> lerpTrajectoryPoint(
 
   return std::make_pair(interpolated_point, seg_idx);
 }
+
+/**
+ * @brief apply linear interpolation to trajectory point at specified trajectory time
+ * @param [in] points trajectory points (time_from_start must be strictly increasing)
+ * @param [in] target_time target time_from_start [s]
+ * @return interpolated trajectory point and source segment index
+ */
+std::pair<TrajectoryPoint, size_t> lerpTrajectoryPointByTime(
+  const std::vector<TrajectoryPoint> & points, const double target_time);
 
 /**
  * @brief limit variable whose differential is within a certain value

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -42,6 +42,7 @@
 #include "visualization_msgs/msg/marker.hpp"
 
 #include <deque>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -93,6 +94,12 @@ private:
     double stop_dist{0.0};  // signed distance that is positive when car is before the stopline
     double slope_angle{0.0};
     double dt{0.0};
+    double temporal_predicted_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_observed_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_fused_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_window_min{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_window_max{std::numeric_limits<double>::quiet_NaN()};
+    bool temporal_observation_used{false};
   };
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
   rclcpp::Clock::SharedPtr clock_;
@@ -138,6 +145,7 @@ private:
 
   // delay compensation
   double m_delay_compensation_time;
+  bool m_use_temporal_trajectory{false};
 
   // enable flags
   bool m_enable_smooth_stop;
@@ -171,6 +179,9 @@ private:
   double m_time_threshold_before_pid_integrate;
   double m_ff_scale_min{0.5};
   double m_ff_scale_max{2.0};
+  bool m_enable_velocity_lookahead_feedback{true};
+  double m_velocity_lookahead_time{1.0};
+  double m_velocity_lookahead_blend_weight{0.5};
   bool m_enable_brake_keeping_before_stop;
   double m_brake_keeping_acc;
 

--- a/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
+++ b/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
@@ -156,6 +156,21 @@
           "description": "maximum clamp value for feedforward scaling",
           "default": "2.0"
         },
+        "enable_velocity_lookahead_feedback": {
+          "type": "boolean",
+          "description": "when true, blend current-point acceleration with a look-ahead velocity-error term",
+          "default": "true"
+        },
+        "velocity_lookahead_time": {
+          "type": "number",
+          "description": "look-ahead horizon used to sample a future trajectory point for velocity feedback [s]",
+          "default": "1.0"
+        },
+        "velocity_lookahead_blend_weight": {
+          "type": "number",
+          "description": "blend weight between look-ahead velocity-error acceleration and target acceleration",
+          "default": "0.5"
+        },
         "enable_brake_keeping_before_stop": {
           "type": "boolean",
           "description": "flag to keep a certain acceleration during DRIVE state before the ego stops. See [Brake keeping]",

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -31,8 +31,13 @@ namespace autoware::motion::control::pid_longitudinal_controller
 namespace longitudinal_utils
 {
 
-bool isValidTrajectory(const Trajectory & traj)
+bool isValidTrajectory(const Trajectory & traj, const bool use_temporal_trajectory)
 {
+  if (traj.points.empty()) {
+    return false;
+  }
+
+  double prev_t = -std::numeric_limits<double>::infinity();
   for (const auto & p : traj.points) {
     if (
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
@@ -43,11 +48,14 @@ bool isValidTrajectory(const Trajectory & traj)
       !isfinite(p.heading_rate_rps)) {
       return false;
     }
-  }
 
-  // when trajectory is empty
-  if (traj.points.empty()) {
-    return false;
+    if (use_temporal_trajectory) {
+      const double t = rclcpp::Duration(p.time_from_start).seconds();
+      if (!std::isfinite(t) || t <= prev_t) {
+        return false;
+      }
+      prev_t = t;
+    }
   }
 
   return true;
@@ -185,5 +193,60 @@ geometry_msgs::msg::Pose findTrajectoryPoseAfterDistance(
   }
   return p;
 }
+
+std::pair<TrajectoryPoint, size_t> lerpTrajectoryPointByTime(
+  const std::vector<TrajectoryPoint> & points, const double target_time)
+{
+  if (points.empty()) {
+    return std::make_pair(TrajectoryPoint{}, 0);
+  }
+  if (points.size() == 1) {
+    return std::make_pair(points.front(), 0);
+  }
+
+  const double front_time = rclcpp::Duration(points.front().time_from_start).seconds();
+  if (target_time <= front_time) {
+    return std::make_pair(points.front(), 0);
+  }
+
+  const double back_time = rclcpp::Duration(points.back().time_from_start).seconds();
+  if (target_time >= back_time) {
+    return std::make_pair(points.back(), points.size() - 1);
+  }
+
+  for (size_t i = 0; i < points.size() - 1; ++i) {
+    const double t0 = rclcpp::Duration(points.at(i).time_from_start).seconds();
+    const double t1 = rclcpp::Duration(points.at(i + 1).time_from_start).seconds();
+    if (target_time > t1) {
+      continue;
+    }
+    const double ratio = std::clamp(
+      (target_time - t0) / std::max(t1 - t0, std::numeric_limits<double>::epsilon()), 0.0, 1.0);
+    auto interpolated = points.at(i);
+    const auto & p0 = points.at(i);
+    const auto & p1 = points.at(i + 1);
+    interpolated.pose.position.x =
+      autoware::interpolation::lerp(p0.pose.position.x, p1.pose.position.x, ratio);
+    interpolated.pose.position.y =
+      autoware::interpolation::lerp(p0.pose.position.y, p1.pose.position.y, ratio);
+    interpolated.pose.position.z =
+      autoware::interpolation::lerp(p0.pose.position.z, p1.pose.position.z, ratio);
+    interpolated.pose.orientation =
+      autoware::interpolation::lerpOrientation(p0.pose.orientation, p1.pose.orientation, ratio);
+    interpolated.longitudinal_velocity_mps = autoware::interpolation::lerp(
+      p0.longitudinal_velocity_mps, p1.longitudinal_velocity_mps, ratio);
+    interpolated.lateral_velocity_mps =
+      autoware::interpolation::lerp(p0.lateral_velocity_mps, p1.lateral_velocity_mps, ratio);
+    interpolated.acceleration_mps2 =
+      autoware::interpolation::lerp(p0.acceleration_mps2, p1.acceleration_mps2, ratio);
+    interpolated.heading_rate_rps =
+      autoware::interpolation::lerp(p0.heading_rate_rps, p1.heading_rate_rps, ratio);
+    interpolated.time_from_start = rclcpp::Duration::from_seconds(target_time);
+    return std::make_pair(interpolated, i);
+  }
+
+  return std::make_pair(points.back(), points.size() - 1);
+}
+
 }  // namespace longitudinal_utils
 }  // namespace autoware::motion::control::pid_longitudinal_controller

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,6 +43,19 @@ PidLongitudinalController::PidLongitudinalController(
 
   // parameters timer
   m_longitudinal_ctrl_period = node.get_parameter("ctrl_period").as_double();
+
+  const auto trajectory_reference_mode =
+    node.has_parameter("trajectory_reference_mode")
+      ? node.get_parameter("trajectory_reference_mode").as_string()
+      : node.declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+  if (trajectory_reference_mode == "temporal") {
+    m_use_temporal_trajectory = true;
+  } else if (trajectory_reference_mode == "spatial") {
+    m_use_temporal_trajectory = false;
+  } else {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
 
   m_wheel_base = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo().wheel_base_m;
   m_vehicle_width =
@@ -114,6 +128,13 @@ PidLongitudinalController::PidLongitudinalController(
       node.declare_parameter<double>("time_threshold_before_pid_integration");  // [s]
     m_ff_scale_min = node.declare_parameter<double>("ff_scale_min");
     m_ff_scale_max = node.declare_parameter<double>("ff_scale_max");
+
+    m_enable_velocity_lookahead_feedback =
+      node.declare_parameter<bool>("enable_velocity_lookahead_feedback", true);
+    m_velocity_lookahead_time =
+      node.declare_parameter<double>("velocity_lookahead_time", 1.0);  // [s]
+    m_velocity_lookahead_blend_weight =
+      node.declare_parameter<double>("velocity_lookahead_blend_weight", 0.5);  // [-]
 
     m_enable_brake_keeping_before_stop =
       node.declare_parameter<bool>("enable_brake_keeping_before_stop");         // [-]
@@ -248,7 +269,7 @@ void PidLongitudinalController::setCurrentOperationMode(const OperationModeState
 
 void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg::Trajectory & msg)
 {
-  if (!longitudinal_utils::isValidTrajectory(msg)) {
+  if (!longitudinal_utils::isValidTrajectory(msg, m_use_temporal_trajectory)) {
     RCLCPP_ERROR_THROTTLE(logger_, *clock_, 3000, "received invalid trajectory. ignore.");
     return;
   }
@@ -325,6 +346,8 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
     update_param("time_threshold_before_pid_integration", m_time_threshold_before_pid_integrate);
     update_param("ff_scale_min", m_ff_scale_min);
     update_param("ff_scale_max", m_ff_scale_max);
+    update_param("velocity_lookahead_time", m_velocity_lookahead_time);
+    update_param("velocity_lookahead_blend_weight", m_velocity_lookahead_blend_weight);
   }
 
   // stopping state
@@ -457,19 +480,41 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   control_data.current_motion.vel = m_current_kinematic_state.twist.twist.linear.x;
   control_data.current_motion.acc = m_current_accel.accel.accel.linear.x;
   control_data.interpolated_traj = m_trajectory;
+  const double traj_start_time =
+    rclcpp::Duration(control_data.interpolated_traj.points.front().time_from_start).seconds();
+  const double traj_end_time =
+    rclcpp::Duration(control_data.interpolated_traj.points.back().time_from_start).seconds();
 
-  // calculate the interpolated point and segment
-  const auto current_interpolated_pose =
-    calcInterpolatedTrajPointAndSegment(control_data.interpolated_traj, current_pose);
+  autoware_planning_msgs::msg::TrajectoryPoint nearest_point;
+  autoware_planning_msgs::msg::TrajectoryPoint target_point;
 
-  // Insert the interpolated point
-  control_data.interpolated_traj.points.insert(
-    control_data.interpolated_traj.points.begin() + current_interpolated_pose.second + 1,
-    current_interpolated_pose.first);
-  control_data.nearest_idx = current_interpolated_pose.second + 1;
-  control_data.target_idx = control_data.nearest_idx;
-  const auto nearest_point = current_interpolated_pose.first;
-  auto target_point = current_interpolated_pose.first;
+  if (m_use_temporal_trajectory) {
+    const rclcpp::Time traj_stamp(m_trajectory.header.stamp);
+    const double elapsed_time = (clock_->now() - traj_stamp).seconds();
+    const double nearest_time = std::clamp(elapsed_time, traj_start_time, traj_end_time);
+    control_data.temporal_predicted_time = nearest_time;
+    control_data.temporal_fused_time = nearest_time;
+
+    const auto nearest_interpolated_point = longitudinal_utils::lerpTrajectoryPointByTime(
+      control_data.interpolated_traj.points, nearest_time);
+    control_data.nearest_idx = nearest_interpolated_point.second + 1;
+    control_data.target_idx = control_data.nearest_idx;
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + control_data.nearest_idx,
+      nearest_interpolated_point.first);
+    nearest_point = nearest_interpolated_point.first;
+    target_point = nearest_interpolated_point.first;
+  } else {
+    const auto current_interpolated_pose =
+      calcInterpolatedTrajPointAndSegment(control_data.interpolated_traj, current_pose);
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + current_interpolated_pose.second + 1,
+      current_interpolated_pose.first);
+    control_data.nearest_idx = current_interpolated_pose.second + 1;
+    control_data.target_idx = control_data.nearest_idx;
+    nearest_point = current_interpolated_pose.first;
+    target_point = current_interpolated_pose.first;
+  }
 
   // Delay compensation - Calculate the distance we got, predicted velocity and predicted
   // acceleration after delay
@@ -478,7 +523,17 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
 
   // calculate the target motion for delay compensation
   constexpr double min_running_dist = 0.01;
-  if (control_data.state_after_delay.running_distance > min_running_dist) {
+  if (m_use_temporal_trajectory) {
+    const double nearest_time = rclcpp::Duration(nearest_point.time_from_start).seconds();
+    const double target_time = nearest_time + m_delay_compensation_time;
+    const auto target_interpolated_point = longitudinal_utils::lerpTrajectoryPointByTime(
+      control_data.interpolated_traj.points, target_time);
+    control_data.target_idx = target_interpolated_point.second + 1;
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + control_data.target_idx,
+      target_interpolated_point.first);
+    target_point = target_interpolated_point.first;
+  } else if (control_data.state_after_delay.running_distance > min_running_dist) {
     control_data.interpolated_traj.points =
       autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
     const auto target_pose = longitudinal_utils::findTrajectoryPoseAfterDistance(
@@ -494,21 +549,19 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   }
 
   // ==========================================================================================
-  // NOTE: due to removeOverlapPoints(), the obtained control_data.target_idx and
-  // control_data.nearest_idx may become invalid if the number of points decreased.
-  // current API does not provide the way to check duplication beforehand and this function
-  // does not tell how many/which index points were removed, so there is no way
-  // to tell if our `control_data.target_idx` point still exists or removed.
+  // Temporal path skips removeOverlapPoints() to preserve same-position points with different
+  // timestamps.
   // ==========================================================================================
-  // Remove overlapped points after inserting the interpolated points
-  control_data.interpolated_traj.points =
-    autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
-  control_data.nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
-    control_data.interpolated_traj.points, nearest_point.pose, m_ego_nearest_dist_threshold,
-    m_ego_nearest_yaw_threshold);
-  control_data.target_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
-    control_data.interpolated_traj.points, target_point.pose, m_ego_nearest_dist_threshold,
-    m_ego_nearest_yaw_threshold);
+  if (!m_use_temporal_trajectory) {
+    control_data.interpolated_traj.points =
+      autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
+    control_data.nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      control_data.interpolated_traj.points, nearest_point.pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold);
+    control_data.target_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      control_data.interpolated_traj.points, target_point.pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold);
+  }
 
   // send debug values
   m_debug_values.setValues(DebugValues::TYPE::PREDICTED_VEL, control_data.state_after_delay.vel);
@@ -942,6 +995,17 @@ void PidLongitudinalController::publishDebugData(
   m_debug_values.setValues(DebugValues::TYPE::STOP_DIST, control_data.stop_dist);
   m_debug_values.setValues(DebugValues::TYPE::CONTROL_STATE, static_cast<double>(m_control_state));
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PUBLISHED, ctrl_cmd.acc);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_PREDICTED_TIME, control_data.temporal_predicted_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_OBSERVED_TIME, control_data.temporal_observed_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_FUSED_TIME, control_data.temporal_fused_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_OBSERVATION_USED,
+    control_data.temporal_observation_used ? 1.0 : 0.0);
+  m_debug_values.setValues(DebugValues::TYPE::TEMPORAL_WINDOW_MIN, control_data.temporal_window_min);
+  m_debug_values.setValues(DebugValues::TYPE::TEMPORAL_WINDOW_MAX, control_data.temporal_window_max);
 
   // publish debug values
   autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};
@@ -1136,6 +1200,58 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
                             ? 1.0
                             : (control_data.shift == Shift::Reverse ? -1.0 : 0.0);
   const double current_vel = control_data.current_motion.vel;
+
+  if (m_enable_velocity_lookahead_feedback) {
+    const double dt_target = m_velocity_lookahead_time;
+    const double w = m_velocity_lookahead_blend_weight;
+
+    const double current_vel_abs = std::max(std::abs(current_vel), 0.1);
+    const double lookahead_distance = current_vel_abs * dt_target;
+
+    size_t future_idx = control_data.target_idx;
+    double accumulated_dist = 0.0;
+
+    for (size_t i = control_data.target_idx; i + 1 < control_data.interpolated_traj.points.size();
+         ++i) {
+      const auto & p0 = control_data.interpolated_traj.points.at(i).pose.position;
+      const auto & p1 = control_data.interpolated_traj.points.at(i + 1).pose.position;
+
+      const double dx = p1.x - p0.x;
+      const double dy = p1.y - p0.y;
+      const double dz = p1.z - p0.z;
+      const double ds = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+      accumulated_dist += ds;
+      future_idx = i + 1;
+
+      if (accumulated_dist >= lookahead_distance) {
+        break;
+      }
+    }
+
+    const auto lookahead_motion = Motion{
+      control_data.interpolated_traj.points.at(future_idx).longitudinal_velocity_mps,
+      control_data.interpolated_traj.points.at(future_idx).acceleration_mps2};
+
+    const double lookahead_diff_vel = (lookahead_motion.vel - current_vel) * vel_sign;
+    const double lookahead_error_vel_filtered = m_lpf_vel_error->filter(lookahead_diff_vel);
+
+    const double a_connect = lookahead_error_vel_filtered / dt_target;
+
+    double target_acc = lookahead_motion.acc;
+
+    // Detect stopped points, on the trajectory they have acceleration 0 based on the speed diff,
+    // but we still need deceleration to enter stop.
+    if (
+      abs(lookahead_motion.vel) < m_state_transition_params.stopped_state_entry_vel &&
+      lookahead_motion.acc < m_state_transition_params.stopped_state_entry_acc) {
+      target_acc =
+        control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2;
+    }
+
+    return w * a_connect + (1.0 - w) * target_acc;
+  }
+
   const auto target_motion = Motion{
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};

--- a/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
@@ -2,4 +2,5 @@
   ros__parameters:
     ctrl_period: 0.03
     timeout_thr_sec: 0.5
+    trajectory_reference_mode: "spatial"  # "spatial" or "temporal"
     cyclic_message_timeout_thr_sec: 0.9

--- a/control/autoware_trajectory_follower_node/src/controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/src/controller_node.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -55,6 +56,12 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
   using std::placeholders::_1;
 
   const double ctrl_period = declare_parameter<double>("ctrl_period");
+  const auto trajectory_reference_mode =
+    declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+  if (trajectory_reference_mode != "spatial" && trajectory_reference_mode != "temporal") {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
   timeout_thr_sec_ = declare_parameter<double>("timeout_thr_sec");
   cyclic_message_timeout_thr_sec_ = declare_parameter<double>("cyclic_message_timeout_thr_sec");
   // NOTE: It is possible that using control_horizon could be expected to enhance performance,

--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp
   src/trajectory_modifier_plugins/obstacle_stop.cpp
   src/trajectory_modifier_plugins/traffic_light_stop.cpp
+  src/trajectory_modifier_plugins/velocity_modifier.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -3,10 +3,12 @@
     plugin_names:
       - "autoware::trajectory_modifier::plugin::ObstacleStop"
       - "autoware::trajectory_modifier::plugin::TrafficLightStop"
+      - "autoware::trajectory_modifier::plugin::VelocityModifier"
       - "autoware::trajectory_modifier::plugin::StopPointFixer"
     use_stop_point_fixer: true
     use_obstacle_stop: true
     use_traffic_light_stop: true
+    use_velocity_modifier: true
     trajectory_time_step: 0.1 # [s]
 
     # Stop Point Fixer Plugin Parameters
@@ -30,9 +32,6 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
-      nominal_stopping_decel: 1.0 # [m/s^2]
-      maximum_stopping_decel: 4.0 # [m/s^2]
-      stopping_jerk: 3.0 # [m/s^3]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -62,6 +62,7 @@ protected:
 
 private:
   TrajectoryModifierParams::ObstacleStop params_;
+  TrajectoryModifierParams::StoppingConstraints stopping_params_;
 
   std::optional<CollisionPoint> nearest_collision_point_;
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
@@ -1,0 +1,55 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+class VelocityModifier : public TrajectoryModifierPluginBase
+{
+public:
+  VelocityModifier() = default;
+
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override
+  {
+    enabled_ = params.use_velocity_modifier;
+    trajectory_time_step_ = params.trajectory_time_step;
+    params_ = params.stopping_constraints;
+  };
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  TrajectoryModifierParams::StoppingConstraints params_;
+
+  size_t update_velocities(
+    TrajectoryPoints & trajectory, const double jerk, const double decel) const;
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -6,6 +6,7 @@ trajectory_modifier_params:
         autoware::trajectory_modifier::plugin::ObstacleStop,
         autoware::trajectory_modifier::plugin::TrafficLightStop,
         autoware::trajectory_modifier::plugin::StopPointFixer,
+        autoware::trajectory_modifier::plugin::VelocityModifier,
       ]
     description: List of trajectory modifier plugins to load
     read_only: false
@@ -23,6 +24,11 @@ trajectory_modifier_params:
     type: bool
     default_value: true
     description: Enable the use of traffic light stop
+    read_only: false
+  use_velocity_modifier:
+    type: bool
+    default_value: true
+    description: Enable the use of velocity modifier
     read_only: false
   trajectory_time_step:
     type: double
@@ -122,27 +128,6 @@ trajectory_modifier_params:
       description: Distance to maintain from an obstacle when stopped [m]
       validation:
         bounds<>: [0.0, 100.0]
-      read_only: false
-    nominal_stopping_decel:
-      type: double
-      default_value: 1.0
-      description: Nominal deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    maximum_stopping_decel:
-      type: double
-      default_value: 4.0
-      description: Maximum deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    stopping_jerk:
-      type: double
-      default_value: 3.0
-      description: Jerk during stopping [m/s^3]
-      validation:
-        bounds<>: [0.0, 10.0]
       read_only: false
     lateral_margin:
       type: double

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -18,4 +18,10 @@
       Inserts a stop before a traffic-light stop line on red or amber
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::VelocityModifier"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Modifies the velocity of a trajectory to smooth the motion
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -11,7 +11,8 @@
           "description": "List of trajectory modifier plugins to load",
           "default": [
             "autoware::trajectory_modifier::plugin::ObstacleStop",
-            "autoware::trajectory_modifier::plugin::StopPointFixer"
+            "autoware::trajectory_modifier::plugin::StopPointFixer",
+            "autoware::trajectory_modifier::plugin::VelocityModifier"
           ],
           "items": {
             "type": "string"
@@ -25,6 +26,11 @@
         "use_obstacle_stop": {
           "type": "boolean",
           "description": "Enable the obstacle stop modifier plugin",
+          "default": true
+        },
+        "use_velocity_modifier": {
+          "type": "boolean",
+          "description": "Enable the velocity modifier plugin",
           "default": true
         },
         "trajectory_time_step": {
@@ -68,6 +74,31 @@
           "required": [],
           "additionalProperties": false
         },
+        "stopping_constraints": {
+          "type": "object",
+          "properties": {
+            "nominal_deceleration": {
+              "type": "number",
+              "description": "Nominal deceleration during stopping [m/s^2]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "maximum_deceleration": {
+              "type": "number",
+              "description": "Maximum deceleration during stopping [m/s^2]",
+              "default": 4.0,
+              "minimum": 0.0
+            },
+            "jerk_limit": {
+              "type": "number",
+              "description": "Jerk limit during stopping [m/s^3]",
+              "default": 3.0,
+              "minimum": 0.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
         "obstacle_stop": {
           "type": "object",
           "properties": {
@@ -96,21 +127,6 @@
               "description": "Distance to maintain from an obstacle when stopped [m]",
               "default": 6.0,
               "minimum": 0.0
-            },
-            "nominal_stopping_decel": {
-              "type": "number",
-              "description": "Nominal deceleration during stopping [m/s^2]",
-              "default": 1.0
-            },
-            "maximum_stopping_decel": {
-              "type": "number",
-              "description": "Maximum deceleration during stopping [m/s^2]",
-              "default": 4.0
-            },
-            "stopping_jerk": {
-              "type": "number",
-              "description": "Jerk during stopping [m/s^3]",
-              "default": 3.0
             },
             "lateral_margin": {
               "type": "number",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -18,8 +18,7 @@
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
-#include <autoware/trajectory/interpolator/akima_spline.hpp>
-#include <autoware/trajectory/interpolator/interpolator.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
@@ -42,10 +41,6 @@ using utils::obstacle_stop::get_trajectory_shape;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
 
-using autoware::experimental::trajectory::interpolator::AkimaSpline;
-using InterpolationTrajectory =
-  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
-
 void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 {
   const auto node_ptr = get_node_ptr();
@@ -59,6 +54,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
     "~/obstacle_stop/debug/marker", 1);
 
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
@@ -99,6 +95,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 {
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
@@ -153,8 +150,8 @@ bool ObstacleStop::is_trajectory_modification_required(
     debug_data_.trajectory_shape = get_trajectory_shape(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.nominal_stopping_decel,
-      params_.stopping_jerk, params_.stop_margin, params_.lateral_margin);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
+      stopping_params_.jerk_limit, params_.stop_margin, params_.lateral_margin);
   }
 
   check_obstacles(traj_points, input);
@@ -192,8 +189,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
     auto min_stopping_distance = motion_utils::calculate_stop_distance(
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.maximum_stopping_decel,
-      params_.stopping_jerk, 0.0);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
+      stopping_params_.jerk_limit, 0.0);
     if (!min_stopping_distance) min_stopping_distance = 0.0;
     return std::clamp(
       nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
@@ -238,39 +235,6 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   return true;
 }
 
-size_t update_velocities(TrajectoryPoints & trajectory, const double jerk, const double decel)
-{
-  if (trajectory.size() < 2) return 0;
-
-  auto get_vel_accel = [&](
-                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
-    const auto v_ref = ref_point.longitudinal_velocity_mps;
-    const auto a_ref = std::abs(ref_point.acceleration_mps2);
-
-    const auto ds =
-      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
-    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
-    const auto a_curr = std::min(a_ref + da, decel);
-    const auto a_avg = (a_ref + a_curr) / 2.0;
-    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
-    return {v_curr, -1.0 * a_curr};
-  };
-
-  const auto stop_index = trajectory.size() - 1;
-  auto vel_update_start_index = stop_index;
-  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
-    auto & curr = trajectory.at(i);
-    auto & next = trajectory.at(i + 1);
-    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
-
-    if (v_curr >= curr.longitudinal_velocity_mps) break;
-    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
-    curr.acceleration_mps2 = static_cast<float>(a_curr);
-    vel_update_start_index = i;
-  }
-  return vel_update_start_index;
-}
-
 size_t insert_stop_point(
   TrajectoryPoints & trajectory, const double target_stop_point_arc_length,
   const double traj_length)
@@ -304,71 +268,12 @@ bool ObstacleStop::apply_stopping(
 {
   if (target_stop_point_arc_length < 1e-3) return false;
 
-  auto trajectory = traj_points;
-
   const auto stop_index = insert_stop_point(
-    trajectory, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
+    traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
 
-  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
-  trajectory.back().longitudinal_velocity_mps = 0.0;
-  trajectory.back().acceleration_mps2 = 0.0;
-
-  constexpr double min_v_ref = 1.0;
-  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
-  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * target_stop_point_arc_length));
-  const auto jerk = std::abs(params_.stopping_jerk);
-  const auto decel = std::clamp(
-    required_decel, std::abs(params_.nominal_stopping_decel),
-    std::abs(params_.maximum_stopping_decel));
-
-  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
-  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
-
-  auto trajectory_interpolation_util =
-    InterpolationTrajectory::Builder{}
-      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
-      .set_longitudinal_velocity_interpolator<AkimaSpline>()
-      .build(trajectory);
-  if (!trajectory_interpolation_util) {
-    RCLCPP_WARN_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Failed to build interpolation trajectory");
-    return false;
-  }
-
-  const auto dt = trajectory_time_step_;
-
-  if (dt < 1e-3) {
-    RCLCPP_ERROR_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Invalid trajectory time step: %f, unable to interpolate trajectory", dt);
-    traj_points = std::move(trajectory);
-    return true;
-  }
-
-  const auto s_max = trajectory_interpolation_util->length();
-  const auto interpolate_start_arc_length =
-    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
-  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
-  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
-  double s_curr{interpolate_start_arc_length};
-  while (s_curr <= s_max) {
-    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
-    const auto a_curr = traj_points.back().acceleration_mps2;
-    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
-    if (v_curr < 1e-3) break;
-
-    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
-    if (ds < 1e-3) break;
-
-    s_curr += ds;
-    const auto s_clamped = std::min(s_curr, s_max);
-
-    auto p = trajectory_interpolation_util->compute(s_clamped);
-    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
-    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
-    traj_points.push_back(p);
-  }
+  traj_points.erase(traj_points.begin() + stop_index + 1, traj_points.end());
+  traj_points.back().longitudinal_velocity_mps = 0.0;
+  traj_points.back().acceleration_mps2 = 0.0;
 
   return true;
 }
@@ -449,7 +354,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, context_->vehicle_info, active_objects,
       object_decel_map_, input.current_odometry->twist.twist.linear.x,
-      params_.nominal_stopping_decel, params_.rss_params.reaction_time,
+      stopping_params_.nominal_deceleration, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.rss_params.min_vel_th, debug_data_.target_polygons,
       colliding_object);
   });

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <autoware/trajectory/interpolator/akima_spline.hpp>
+#include <autoware/trajectory/interpolator/interpolator.hpp>
+#include <autoware/trajectory/trajectory_point.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+using autoware::experimental::trajectory::interpolator::AkimaSpline;
+using InterpolationTrajectory =
+  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
+
+void VelocityModifier::on_initialize(const TrajectoryModifierParams & params)
+{
+  enabled_ = params.use_velocity_modifier;
+  trajectory_time_step_ = params.trajectory_time_step;
+  params_ = params.stopping_constraints;
+}
+
+bool VelocityModifier::is_trajectory_modification_required(
+  const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  if (traj_points.size() < 2) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  const auto & stop_point = traj_points.at(stop_idx.value());
+  const auto & prev_point = traj_points.at(stop_idx.value() - 1);
+
+  const auto ds =
+    autoware_utils_geometry::calc_distance2d(stop_point.pose.position, prev_point.pose.position);
+
+  const auto v_prev = prev_point.longitudinal_velocity_mps;
+
+  static constexpr double epsilon = 1e-3;
+  if (ds < epsilon) return v_prev > epsilon;
+
+  const auto expected_accel = -1.0 * (v_prev * v_prev) / (2.0 * ds);
+  const auto a_prev = prev_point.acceleration_mps2;
+
+  constexpr double tolerance = 0.1;
+  return std::abs(a_prev - expected_accel) > tolerance;
+}
+
+bool VelocityModifier::modify_trajectory(TrajectoryPoints & traj_points, const InputData & input)
+{
+  if (!enabled_ || !is_trajectory_modification_required(traj_points, input)) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  auto trajectory = traj_points;
+
+  trajectory.erase(trajectory.begin() + stop_idx.value() + 1, trajectory.end());
+  trajectory.back().longitudinal_velocity_mps = 0.0;
+  trajectory.back().acceleration_mps2 = 0.0;
+
+  const auto traj_length = motion_utils::calcArcLength(trajectory);
+
+  constexpr double min_v_ref = 1.0;
+  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
+  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * traj_length));
+  const auto jerk = std::abs(params_.jerk_limit);
+  const auto decel = std::clamp(
+    required_decel, std::abs(params_.nominal_deceleration), std::abs(params_.maximum_deceleration));
+
+  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
+  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
+
+  auto trajectory_interpolation_util =
+    InterpolationTrajectory::Builder{}
+      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
+      .set_longitudinal_velocity_interpolator<AkimaSpline>()
+      .build(trajectory);
+  if (!trajectory_interpolation_util) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Failed to build interpolation trajectory");
+    return false;
+  }
+
+  const auto dt = trajectory_time_step_;
+
+  if (dt < 1e-3) {
+    RCLCPP_ERROR_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Invalid trajectory time step: %f, unable to interpolate trajectory",
+      dt);
+    traj_points = std::move(trajectory);
+    return true;
+  }
+
+  const auto s_max = trajectory_interpolation_util->length();
+  const auto interpolate_start_arc_length =
+    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
+  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
+  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
+  double s_curr{interpolate_start_arc_length};
+  while (s_curr <= s_max) {
+    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
+    const auto a_curr = traj_points.back().acceleration_mps2;
+    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
+    if (v_curr < 1e-3) break;
+
+    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
+    if (ds < 1e-3) break;
+
+    s_curr += ds;
+    const auto s_clamped = std::min(s_curr, s_max);
+
+    auto p = trajectory_interpolation_util->compute(s_clamped);
+    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
+    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
+    traj_points.push_back(p);
+  }
+
+  return true;
+}
+
+size_t VelocityModifier::update_velocities(
+  TrajectoryPoints & trajectory, const double jerk, const double decel) const
+{
+  if (trajectory.size() < 2) return 0;
+
+  auto get_vel_accel = [&](
+                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
+    const auto v_ref = ref_point.longitudinal_velocity_mps;
+    const auto a_ref = std::abs(ref_point.acceleration_mps2);
+
+    const auto ds =
+      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
+    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
+    const auto a_curr = std::min(a_ref + da, decel);
+    const auto a_avg = (a_ref + a_curr) / 2.0;
+    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
+    return {v_curr, -1.0 * a_curr};
+  };
+
+  const auto stop_index = trajectory.size() - 1;
+  auto vel_update_start_index = stop_index;
+  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
+    auto & curr = trajectory.at(i);
+    auto & next = trajectory.at(i + 1);
+    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
+
+    if (v_curr >= curr.longitudinal_velocity_mps) break;
+    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
+    curr.acceleration_mps2 = static_cast<float>(a_curr);
+    vel_update_start_index = i;
+  }
+  return vel_update_start_index;
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::VelocityModifier,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -217,15 +217,16 @@ protected:
     params_.use_stop_point_fixer = false;
     params_.trajectory_time_step = 0.1;
 
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+
     auto & p = params_.obstacle_stop;
     p.use_objects = true;
     p.use_pointcloud = true;
     p.enable_stop_for_objects = true;
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
-    p.nominal_stopping_decel = 1.0;
-    p.maximum_stopping_decel = 4.0;
-    p.stopping_jerk = 3.0;
     p.lateral_margin = 0.5;
     p.arrived_distance_threshold = 0.5;
 

--- a/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using autoware::trajectory_modifier::TrajectoryModifierContext;
+using autoware::trajectory_modifier::plugin::InputData;
+using autoware::trajectory_modifier::plugin::TrajectoryPoints;
+using autoware::trajectory_modifier::plugin::VelocityModifier;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+TrajectoryPoint create_trajectory_point(
+  double x, double y, double velocity, double acceleration = 0.0)
+{
+  TrajectoryPoint point;
+  point.pose.position.x = x;
+  point.pose.position.y = y;
+  point.pose.position.z = 0.0;
+  point.pose.orientation.x = 0.0;
+  point.pose.orientation.y = 0.0;
+  point.pose.orientation.z = 0.0;
+  point.pose.orientation.w = 1.0;
+  point.longitudinal_velocity_mps = static_cast<float>(velocity);
+  point.acceleration_mps2 = static_cast<float>(acceleration);
+  return point;
+}
+
+TrajectoryPoints create_constant_velocity_trajectory(
+  double length, double velocity, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_step_change_zero_velocity_trajectory(
+  double length, double default_velocity, double zero_velocity_length, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = x < zero_velocity_length ? default_velocity : 0.0;
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, 0.0));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_constant_deceleration_trajectory(
+  double length, double initial_velocity, double spacing = 1.0)
+{
+  const auto accel = -1.0 * initial_velocity * initial_velocity / (2.0 * length);
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = sqrt(initial_velocity * initial_velocity + 2.0 * accel * x);
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, accel));
+  }
+  return trajectory;
+}
+
+}  // namespace
+
+class VelocityModifierIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+    autoware::test_utils::updateNodeOptions(
+      node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<rclcpp::Node>("test_velocity_modifier_node", node_options);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
+
+    set_up_default_params();
+
+    // Create the context and the plugin once. Tests build per-frame InputData inline,
+    // and inject any required TF directly into context_->tf_buffer.
+    context_ = std::make_shared<TrajectoryModifierContext>(node_.get());
+    plugin_ = std::make_unique<VelocityModifier>();
+    plugin_->initialize("test_velocity_modifier", node_.get(), time_keeper_, context_, params_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    plugin_.reset();
+    context_.reset();
+    node_.reset();
+  }
+
+  void set_up_default_params()
+  {
+    params_.use_velocity_modifier = true;
+    params_.trajectory_time_step = 0.1;
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  std::unique_ptr<VelocityModifier> plugin_;
+  trajectory_modifier_params::Params params_;
+  std::shared_ptr<TrajectoryModifierContext> context_;
+};
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenDisabled)
+{
+  // Arrange
+  params_.use_velocity_modifier = false;
+  plugin_->update_params(params_);
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForEmptyTrajectory)
+{
+  // Arrange
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenNoStopPoint)
+{
+  // Arrange
+  auto trajectory = create_constant_velocity_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForSmoothStoppingTrajectory)
+{
+  // Arrange
+  auto trajectory = create_constant_deceleration_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryModifiedForStepChangeZeroVelocityTrajectory)
+{
+  // Arrange
+  auto trajectory = create_step_change_zero_velocity_trajectory(20.0, 10.0, 15.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_TRUE(modified);
+  EXPECT_NEAR(trajectory.back().longitudinal_velocity_mps, 0.0, 0.1);
+  EXPECT_NEAR(trajectory.back().acceleration_mps2, 0.0, 0.1);
+}

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
@@ -82,6 +82,7 @@ public:
     if (!status.is_valid_forward_trajectory_length) append_string("forward_traj_length");
     if (!status.is_valid_trajectory_shift) append_string("traj_shift");
     if (!status.is_valid_intersection_collision_check) append_string("collision");
+    if (!status.is_valid_boundary_departure) append_string("boundary_departure");
 
     if (ss.str().empty()) {
       return "";

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
@@ -266,6 +266,7 @@ struct PlanningValidatorContext
     s->is_valid_trajectory_shift = true;
     s->is_valid_intersection_collision_check = true;
     s->is_valid_rear_collision_check = true;
+    s->is_valid_boundary_departure = true;
   }
 
   void set_handling(const InvalidTrajectoryHandlingType handling_type)

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -9,6 +9,7 @@
   <arg name="launch_trajectory_checker" default="true"/>
   <arg name="launch_intersection_collision_checker" default="true"/>
   <arg name="launch_rear_collision_checker" default="true"/>
+  <arg name="launch_boundary_departure_checker" default="true"/>
   <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
   <arg name="planning_validator_launch_modules" default="["/>
   <let
@@ -31,6 +32,11 @@
     value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::RearCollisionChecker, '&quot;)"
     if="$(var launch_rear_collision_checker)"
   />
+  <let
+    name="planning_validator_launch_modules"
+    value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::BoundaryDepartureChecker, '&quot;)"
+    if="$(var launch_boundary_departure_checker)"
+  />
   <let name="planning_validator_launch_modules" value="$(eval &quot;'$(var planning_validator_launch_modules)' + '$(var launch_modules_list_end)'&quot;)"/>
 
   <arg name="planning_validator_param_path" default="$(find-pkg-share autoware_planning_validator)/config/planning_validator.param.yaml"/>
@@ -38,6 +44,7 @@
   <arg name="planning_validator_trajectory_checker_param_path"/>
   <arg name="planning_validator_intersection_collision_checker_param_path"/>
   <arg name="planning_validator_rear_collision_checker_param_path"/>
+  <arg name="planning_validator_boundary_departure_checker_param_path" default="$(find-pkg-share autoware_planning_validator_boundary_departure_checker)/config/boundary_departure_checker.param.yaml"/>
   <arg name="input_trajectory_topic_name" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
   <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
   <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
@@ -66,6 +73,7 @@
         <param from="$(var planning_validator_trajectory_checker_param_path)"/>
         <param from="$(var planning_validator_intersection_collision_checker_param_path)"/>
         <param from="$(var planning_validator_rear_collision_checker_param_path)"/>
+        <param from="$(var planning_validator_boundary_departure_checker_param_path)"/>
         <extra_arg name="use_intra_process_comms" value="false"/>
       </composable_node>
     </node_container>

--- a/planning/planning_validator/autoware_planning_validator/msg/PlanningValidatorStatus.msg
+++ b/planning/planning_validator/autoware_planning_validator/msg/PlanningValidatorStatus.msg
@@ -21,6 +21,7 @@ bool is_valid_yaw_deviation
 bool is_valid_trajectory_shift
 bool is_valid_intersection_collision_check
 bool is_valid_rear_collision_check
+bool is_valid_boundary_departure
 
 # values
 int64 trajectory_size

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -162,7 +162,8 @@ bool PlanningValidatorNode::isAllValid(const PlanningValidatorStatus & s) const
          s.is_valid_velocity_deviation && s.is_valid_distance_deviation &&
          s.is_valid_longitudinal_distance_deviation && s.is_valid_forward_trajectory_length &&
          s.is_valid_latency && s.is_valid_yaw_deviation && s.is_valid_trajectory_shift &&
-         s.is_valid_intersection_collision_check && s.is_valid_rear_collision_check;
+         s.is_valid_intersection_collision_check && s.is_valid_rear_collision_check &&
+         s.is_valid_boundary_departure;
 }
 
 void PlanningValidatorNode::publishTrajectory()
@@ -293,6 +294,9 @@ void PlanningValidatorNode::displayStatus()
     s->is_valid_intersection_collision_check,
     "planning trajectory leads to collision!! (intersection objects)");
   warn(s->is_valid_rear_collision_check, "planning trajectory leads to collision!! (rear objects)");
+  warn(
+    s->is_valid_boundary_departure,
+    "planning trajectory crosses an uncrossable boundary (CRITICAL)!!");
 }
 
 bool PlanningValidatorNode::infer_autonomous_control_state(

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_planning_validator_boundary_departure_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+pluginlib_export_plugin_description_file(autoware_planning_validator plugins.xml)
+
+include_directories(
+  ${autoware_planning_validator_INCLUDE_DIRS}
+)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  DIRECTORY src
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${autoware_planning_validator_LIBRARIES}
+)
+
+ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/config/boundary_departure_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/config/boundary_departure_checker.param.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    boundary_departure_checker:
+      enable: true
+      # 0: publish as-is, 1: last valid, 2: last valid with soft stop
+      handling_type: 2
+      boundary_types: ["road_border"]
+      lateral_margin_m: 0.1
+      longitudinal_margin_m: 1.0
+      max_deceleration_mps2: -4.0
+      max_jerk_mps3: -5.0
+      brake_delay_s: 1.0
+      time_to_departure_cutoff_s: 2.0
+      on_time_buffer_s: 0.20
+      off_time_buffer_s: 0.10

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/include/autoware/planning_validator_boundary_departure_checker/boundary_departure_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/include/autoware/planning_validator_boundary_departure_checker/boundary_departure_checker.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PLANNING_VALIDATOR_BOUNDARY_DEPARTURE_CHECKER__BOUNDARY_DEPARTURE_CHECKER_HPP_
+#define AUTOWARE__PLANNING_VALIDATOR_BOUNDARY_DEPARTURE_CHECKER__BOUNDARY_DEPARTURE_CHECKER_HPP_
+
+#include <autoware/boundary_departure_checker/parameters.hpp>
+#include <autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp>
+#include <autoware/planning_validator/plugin_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+
+namespace autoware::planning_validator
+{
+
+class BoundaryDepartureChecker : public PluginInterface
+{
+public:
+  void init(
+    rclcpp::Node & node, const std::string & name,
+    const std::shared_ptr<PlanningValidatorContext> & context) override;
+  void validate() override;
+  void setup_diag() override;
+  std::string get_module_name() const override { return module_name_; }
+
+private:
+  void set_diag_status(
+    DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const;
+
+  bool enable_{true};
+  InvalidTrajectoryHandlingType handling_type_{
+    InvalidTrajectoryHandlingType::USE_PREVIOUS_RESULT_WITH_SOFT_STOP};
+  autoware::boundary_departure_checker::UncrossableBoundaryDepartureParam params_;
+  std::unique_ptr<autoware::boundary_departure_checker::UncrossableBoundaryChecker> checker_;
+  bool is_valid_{true};
+};
+
+}  // namespace autoware::planning_validator
+
+#endif  // AUTOWARE__PLANNING_VALIDATOR_BOUNDARY_DEPARTURE_CHECKER__BOUNDARY_DEPARTURE_CHECKER_HPP_

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_planning_validator_boundary_departure_checker</name>
+  <version>0.51.0</version>
+  <description>Planning validator plugin that rejects trajectories crossing uncrossable boundaries</description>
+
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_boundary_departure_checker</depend>
+  <depend>autoware_planning_validator</depend>
+  <depend>autoware_utils</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/plugins.xml
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/plugins.xml
@@ -1,0 +1,4 @@
+<library path="autoware_planning_validator_boundary_departure_checker">
+  <class type="autoware::planning_validator::BoundaryDepartureChecker"
+         base_class_type="autoware::planning_validator::PluginInterface"/>
+</library>

--- a/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/src/boundary_departure_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_boundary_departure_checker/src/boundary_departure_checker.cpp
@@ -1,0 +1,153 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/planning_validator_boundary_departure_checker/boundary_departure_checker.hpp"
+
+#include <autoware_utils/ros/parameter.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::planning_validator
+{
+using autoware_utils::get_or_declare_parameter;
+
+void BoundaryDepartureChecker::init(
+  rclcpp::Node & node, const std::string & name,
+  const std::shared_ptr<PlanningValidatorContext> & context)
+{
+  module_name_ = name;
+  clock_ = node.get_clock();
+  logger_ = node.get_logger();
+  context_ = context;
+
+  enable_ = get_or_declare_parameter<bool>(node, "boundary_departure_checker.enable");
+  handling_type_ = get_handling_type(
+    get_or_declare_parameter<int>(node, "boundary_departure_checker.handling_type"));
+  params_.boundary_types_to_detect = get_or_declare_parameter<std::vector<std::string>>(
+    node, "boundary_departure_checker.boundary_types");
+  params_.lateral_margin_m =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.lateral_margin_m");
+  params_.longitudinal_margin_m =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.longitudinal_margin_m");
+  params_.max_deceleration_mps2 =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.max_deceleration_mps2");
+  params_.max_jerk_mps3 =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.max_jerk_mps3");
+  params_.brake_delay_s =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.brake_delay_s");
+  params_.time_to_departure_cutoff_s = get_or_declare_parameter<double>(
+    node, "boundary_departure_checker.time_to_departure_cutoff_s");
+  params_.on_time_buffer_s =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.on_time_buffer_s");
+  params_.off_time_buffer_s =
+    get_or_declare_parameter<double>(node, "boundary_departure_checker.off_time_buffer_s");
+
+  setup_diag();
+}
+
+void BoundaryDepartureChecker::validate()
+{
+  auto & status = context_->validation_status;
+  is_valid_ = true;
+  status->is_valid_boundary_departure = true;
+
+  if (!enable_) {
+    return;
+  }
+
+  const auto & data = context_->data;
+  if (!data->current_trajectory || !data->current_kinematics || !data->current_acceleration) {
+    return;
+  }
+  if (!data->route_handler || !data->route_handler->isHandlerReady()) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 3000, "[boundary_departure] map/route is not ready, skip check");
+    return;
+  }
+
+  const auto lanelet_map = data->route_handler->getLaneletMapPtr();
+  if (!lanelet_map || lanelet_map->lineStringLayer.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 3000, "[boundary_departure] lanelet map has no linestrings, skip check");
+    return;
+  }
+
+  if (!checker_) {
+    checker_ = std::make_unique<autoware::boundary_departure_checker::UncrossableBoundaryChecker>(
+      lanelet_map, params_, context_->vehicle_info);
+  }
+
+  autoware::boundary_departure_checker::EgoDynamicState ego_state;
+  ego_state.pose_with_cov = data->current_kinematics->pose;
+  ego_state.velocity = data->current_kinematics->twist.twist.linear.x;
+  ego_state.acceleration = data->current_acceleration->accel.accel.linear.x;
+  ego_state.current_time_s = rclcpp::Time(data->current_kinematics->header.stamp).seconds();
+
+  const auto result =
+    checker_->update_departure_status(data->current_trajectory->points, ego_state);
+  const bool is_critical =
+    result.status == autoware::boundary_departure_checker::DepartureType::CRITICAL;
+
+  is_valid_ = !is_critical;
+  status->is_valid_boundary_departure = is_valid_;
+
+  if (is_critical) {
+    context_->set_handling(handling_type_);
+    RCLCPP_ERROR_THROTTLE(
+      logger_, *clock_, 1000,
+      "[boundary_departure] CRITICAL uncrossable-boundary departure on planned trajectory");
+  }
+}
+
+void BoundaryDepartureChecker::setup_diag()
+{
+  if (!context_->diag_updater) {
+    return;
+  }
+
+  context_->diag_updater->add("boundary_departure", [this](auto & stat) {
+    const std::string msg = "planned trajectory crosses an uncrossable boundary";
+    set_diag_status(stat, is_valid_, msg);
+  });
+}
+
+void BoundaryDepartureChecker::set_diag_status(
+  DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
+{
+  if (is_ok) {
+    stat.summary(DiagnosticStatus::OK, "validated.");
+    return;
+  }
+
+  const auto invalid_count = context_->validation_status->invalid_count;
+  const auto count_threshold = context_->params.diag_error_count_threshold;
+  if (invalid_count < count_threshold) {
+    const auto warn_msg = msg + " (invalid count is less than error threshold: " +
+                          std::to_string(invalid_count) + " < " +
+                          std::to_string(count_threshold) + ")";
+    stat.summary(DiagnosticStatus::WARN, warn_msg);
+    return;
+  }
+
+  stat.summary(DiagnosticStatus::ERROR, msg);
+}
+
+}  // namespace autoware::planning_validator
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::planning_validator::BoundaryDepartureChecker,
+  autoware::planning_validator::PluginInterface)


### PR DESCRIPTION
## Summary
- New `autoware_planning_validator_boundary_departure_checker` plugin on the **single** planned trajectory (not candidate `trajectory_validator`).
- `CRITICAL` uncrossable-boundary → `is_valid_boundary_departure=false` → `USE_PREVIOUS_RESULT_WITH_SOFT_STOP`. Diagnostic name `boundary_departure`.

## Test plan
- [x] `colcon build --packages-up-to autoware_planning_validator_boundary_departure_checker autoware_planning_validator`
- [ ] CI on this PR
- [ ] Pair with launcher diag retarget PR — https://github.com/tier4/autoware_launch.xx1/pull/2189
- [ ] Vehicle/runtime — not in this pass

## Notes for reviewers
- Code-independent of TrafficLightStop; stacked only so the experiment reviews as one sequence.
- Source filter: X2 `uncrossable_boundary_departure` [tier4/autoware_universe#3358](https://github.com/tier4/autoware_universe/pull/3358). XX1 checker uses 2-arg `update_departure_status` and `lateral_margin_m`.

## Stack
1. Checker — https://github.com/tier4/autoware_universe/pull/3368
2. TrafficLightStop — https://github.com/tier4/autoware_universe/pull/3369
3. **this PR** — boundary-departure plugin
4. temporal controller — https://github.com/tier4/autoware_universe/pull/3371

Depends on #3369. Merge from the bottom.