### PR TITLE
feat(autoware_diffusion_planner): remap unsupported objects to pedestrian (#13352)

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -25,6 +25,7 @@
         start_time_s: 2.0
     planning_frequency_hz: 10.0
     ignore_neighbors: false
+    remap_unsupported_objects_to_pedestrian: false
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
     temperature: [0.0]

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -154,12 +154,15 @@ private:
 struct AgentData
 {
   // Legacy buffering: push unconditionally, fill new agents with copies, erase disappeared agents.
-  void update_histories(const TrackedObjects & objects);
+  void update_histories(
+    const TrackedObjects & objects, bool remap_unsupported_objects_to_pedestrian = false);
 
   // Resampled buffering: dedup on advancing header stamp, reset on a backward time jump, grow
   // histories without repeat-fill, and retain absent agents until their newest observation ages
   // out of the history window.
-  void update_histories(const TrackedObjects & objects, const HistoryResamplingParams & params);
+  void update_histories(
+    const TrackedObjects & objects, const HistoryResamplingParams & params,
+    bool remap_unsupported_objects_to_pedestrian = false);
 
   // Transform histories, trim to max_num_agent, and return the processed vector.
   std::vector<AgentHistory> transformed_and_trimmed_histories(

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -172,6 +172,7 @@ struct DiffusionPlannerParams
   double line_string_max_step_m;
   bool use_time_interpolation;
   HistoryResamplingParams object_motion_resampling;
+  bool remap_unsupported_objects_to_pedestrian;
   EgoSnapParams ego_snap_to_prev_trajectory;
   int dpm_solver_steps;
   double start_guidance_reference_distance_m;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -338,6 +338,11 @@
             }
           },
           "required": ["publish_debug_map", "publish_debug_route", "publish_debug_linestrings"]
+        },
+        "remap_unsupported_objects_to_pedestrian": {
+          "type": "boolean",
+          "default": false,
+          "description": "Treat UNKNOWN and HAZARD tracked objects as PEDESTRIAN, the most conservative supported class, so the planner reacts to them. Non-BOX shapes are replaced with a 0.5 m bounding box. ANIMAL, OVER_DRIVABLE and UNDER_DRIVABLE remain ignored."
         }
       },
       "required": [

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -98,29 +98,44 @@ std::vector<AgentHistory> transform_sort_trim(
   return histories;
 }
 
-// HAZARD objects are not supported by the model, so remap them to PEDESTRIAN
-// to make the planner consider them.
-TrackedObject remap_hazard_to_pedestrian(const TrackedObject & object)
+// UNKNOWN and HAZARD objects are not supported by the model, but they can still obstruct driving,
+// so remap them to PEDESTRIAN (the most conservative supported class) to make the planner consider
+// them. ANIMAL, OVER_DRIVABLE and UNDER_DRIVABLE remain ignored.
+bool is_unsupported_obstacle_label(const uint8_t label)
 {
-  const bool is_hazard = autoware::object_recognition_utils::getHighestProbLabel(
-                           object.classification) == ObjectClassification::HAZARD;
-  if (!is_hazard) {
+  return label == ObjectClassification::UNKNOWN || label == ObjectClassification::HAZARD;
+}
+
+TrackedObject remap_unsupported_to_pedestrian(const TrackedObject & object)
+{
+  // An empty classification also yields UNKNOWN from getHighestProbLabel(), but such an object
+  // carries no label to rewrite, so keep ignoring it.
+  if (object.classification.empty()) {
+    return object;
+  }
+
+  const uint8_t highest_prob_label =
+    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  if (!is_unsupported_obstacle_label(highest_prob_label)) {
     return object;
   }
 
   TrackedObject remapped = object;
   for (auto & classification : remapped.classification) {
-    if (classification.label == ObjectClassification::HAZARD) {
+    if (is_unsupported_obstacle_label(classification.label)) {
       classification.label = ObjectClassification::PEDESTRIAN;
     }
   }
 
+  // The POLYGON skip below would otherwise drop the object we just decided to keep.
   if (remapped.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     static rclcpp::Clock clock{RCL_ROS_TIME};
     RCLCPP_WARN_THROTTLE(
       rclcpp::get_logger("diffusion_planner"), clock, constants::LOG_THROTTLE_INTERVAL_MS,
-      "HAZARD object %s has a non-BOX shape (type=%u). Replacing it with a 0.5 m bounding box.",
-      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), remapped.shape.type);
+      "Unsupported-class object %s (label=%u) has a non-BOX shape (type=%u). Replacing it with a "
+      "0.5 m bounding box.",
+      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), highest_prob_label,
+      remapped.shape.type);
     remapped.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
     remapped.shape.footprint.points.clear();
     remapped.shape.dimensions.x = 0.5;
@@ -129,7 +144,6 @@ TrackedObject remap_hazard_to_pedestrian(const TrackedObject & object)
   }
   return remapped;
 }
-
 }  // namespace
 
 AgentState::AgentState(const TrackedObject & object, const rclcpp::Time & timestamp)
@@ -206,12 +220,15 @@ void AgentHistory::update(const TrackedObject & object, const rclcpp::Time & tim
   push_back(state);
 }
 
-void AgentData::update_histories(const TrackedObjects & objects)
+void AgentData::update_histories(
+  const TrackedObjects & objects, const bool remap_unsupported_objects_to_pedestrian)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
   for (const TrackedObject & input_object : objects.objects) {
-    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
+    const TrackedObject object = remap_unsupported_objects_to_pedestrian
+                                   ? remap_unsupported_to_pedestrian(input_object)
+                                   : input_object;
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }
@@ -250,7 +267,8 @@ std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
 }
 
 void AgentData::update_histories(
-  const TrackedObjects & objects, [[maybe_unused]] const HistoryResamplingParams & params)
+  const TrackedObjects & objects, [[maybe_unused]] const HistoryResamplingParams & params,
+  const bool remap_unsupported_objects_to_pedestrian)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
 
@@ -277,7 +295,9 @@ void AgentData::update_histories(
 
   latest_ids_.clear();
   for (const TrackedObject & input_object : objects.objects) {
-    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
+    const TrackedObject object = remap_unsupported_objects_to_pedestrian
+                                   ? remap_unsupported_to_pedestrian(input_object)
+                                   : input_object;
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -21,7 +21,11 @@
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logging.hpp>
+
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
@@ -92,6 +96,38 @@ std::vector<AgentHistory> transform_sort_trim(
       histories.begin() + static_cast<std::ptrdiff_t>(max_num_agent), histories.end());
   }
   return histories;
+}
+
+// HAZARD objects are not supported by the model, so remap them to PEDESTRIAN
+// to make the planner consider them.
+TrackedObject remap_hazard_to_pedestrian(const TrackedObject & object)
+{
+  const bool is_hazard = autoware::object_recognition_utils::getHighestProbLabel(
+                           object.classification) == ObjectClassification::HAZARD;
+  if (!is_hazard) {
+    return object;
+  }
+
+  TrackedObject remapped = object;
+  for (auto & classification : remapped.classification) {
+    if (classification.label == ObjectClassification::HAZARD) {
+      classification.label = ObjectClassification::PEDESTRIAN;
+    }
+  }
+
+  if (remapped.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    static rclcpp::Clock clock{RCL_ROS_TIME};
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("diffusion_planner"), clock, constants::LOG_THROTTLE_INTERVAL_MS,
+      "HAZARD object %s has a non-BOX shape (type=%u). Replacing it with a 0.5 m bounding box.",
+      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), remapped.shape.type);
+    remapped.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+    remapped.shape.footprint.points.clear();
+    remapped.shape.dimensions.x = 0.5;
+    remapped.shape.dimensions.y = 0.5;
+    remapped.shape.dimensions.z = 0.5;
+  }
+  return remapped;
 }
 
 }  // namespace
@@ -174,7 +210,8 @@ void AgentData::update_histories(const TrackedObjects & objects)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
-  for (const TrackedObject & object : objects.objects) {
+  for (const TrackedObject & input_object : objects.objects) {
+    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }
@@ -239,7 +276,8 @@ void AgentData::update_histories(
   last_processed_stamp_ = objects_timestamp;
 
   latest_ids_.clear();
-  for (const TrackedObject & object : objects.objects) {
+  for (const TrackedObject & input_object : objects.objects) {
+    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -377,11 +377,14 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   // frame time); otherwise the legacy buffered histories are used directly.
   std::vector<AgentHistory> processed_neighbor_histories;
   if (params_.object_motion_resampling.enable) {
-    agent_data_.update_histories(*effective_objects, params_.object_motion_resampling);
+    agent_data_.update_histories(
+      *effective_objects, params_.object_motion_resampling,
+      params_.remap_unsupported_objects_to_pedestrian);
     processed_neighbor_histories = agent_data_.resampled_transformed_and_trimmed_histories(
       frame_time, map_to_ego_transform, NEIGHBOR_SHAPE[1], params_.object_motion_resampling);
   } else {
-    agent_data_.update_histories(*effective_objects);
+    agent_data_.update_histories(
+      *effective_objects, params_.remap_unsupported_objects_to_pedestrian);
     processed_neighbor_histories =
       agent_data_.transformed_and_trimmed_histories(map_to_ego_transform, NEIGHBOR_SHAPE[1]);
   }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -193,6 +193,8 @@ void DiffusionPlanner::set_up_params()
   params_.build_only = this->declare_parameter<bool>("build_only", false);
   params_.planning_frequency_hz = this->declare_parameter<double>("planning_frequency_hz", 10.0);
   params_.ignore_neighbors = this->declare_parameter<bool>("ignore_neighbors", false);
+  params_.remap_unsupported_objects_to_pedestrian =
+    this->declare_parameter<bool>("remap_unsupported_objects_to_pedestrian", false);
   params_.traffic_light_group_msg_timeout_seconds =
     this->declare_parameter<double>("traffic_light_group_msg_timeout_seconds", 0.2);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
@@ -331,6 +333,9 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<std::string>(parameters, "model.precision", temp_params.trt_precision);
     update_param<bool>(parameters, "model.use_cuda_graph", temp_params.use_cuda_graph);
     update_param<bool>(parameters, "ignore_neighbors", temp_params.ignore_neighbors);
+    update_param<bool>(
+      parameters, "remap_unsupported_objects_to_pedestrian",
+      temp_params.remap_unsupported_objects_to_pedestrian);
     update_param<double>(
       parameters, "traffic_light_group_msg_timeout_seconds",
       temp_params.traffic_light_group_msg_timeout_seconds);

--- a/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
@@ -75,7 +75,7 @@ TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
   objects.objects.push_back(tracked_object_);
 
   AgentData agent_data;
-  agent_data.update_histories(objects);
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
   const auto histories =
     agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
 
@@ -85,6 +85,11 @@ TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
   EXPECT_EQ(
     state.original_info.classification.front().label,
     autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
+  // The remap lands in the PEDESTRIAN slot.
+  const auto array = state.as_array();
+  EXPECT_FLOAT_EQ(array[8], 0.0F);
+  EXPECT_FLOAT_EQ(array[9], 1.0F);
+  EXPECT_FLOAT_EQ(array[10], 0.0F);
   // BOX shape is kept as is
   EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 5.0);
   EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 2.0);
@@ -101,7 +106,7 @@ TEST_F(AgentEdgeCaseTest, HazardObjectWithNonBoxShapeGetsDefaultBox)
   objects.objects.push_back(tracked_object_);
 
   AgentData agent_data;
-  agent_data.update_histories(objects);
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
   const auto histories =
     agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
 
@@ -124,7 +129,100 @@ TEST_F(AgentEdgeCaseTest, NonHazardPolygonObjectIsStillSkipped)
   objects.objects.push_back(tracked_object_);
 
   AgentData agent_data;
-  agent_data.update_histories(objects);
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  EXPECT_TRUE(histories.empty());
+}
+
+TEST_F(AgentEdgeCaseTest, UnknownObjectIsRemappedToPedestrian)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  // The UNKNOWN object is included, not dropped.
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  // The remap is reflected in the republished classification.
+  EXPECT_EQ(
+    state.original_info.classification.front().label,
+    autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
+  const auto array = state.as_array();
+  EXPECT_FLOAT_EQ(array[8], 0.0F);
+  EXPECT_FLOAT_EQ(array[9], 1.0F);
+  EXPECT_FLOAT_EQ(array[10], 0.0F);
+  // BOX shape is kept as is.
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 5.0);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 2.0);
+}
+
+TEST_F(AgentEdgeCaseTest, UnknownObjectWithNonBoxShapeGetsDefaultBox)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  // The polygon unknown object is not skipped because its shape is replaced with a bounding box
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  EXPECT_EQ(state.original_info.shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.z, 0.5);
+}
+
+// With the parameter off, both unsupported classes keep the pre-existing behavior of being dropped.
+TEST_F(AgentEdgeCaseTest, UnsupportedObjectsAreIgnoredWhenRemapDisabled)
+{
+  for (const auto label :
+       {autoware_perception_msgs::msg::ObjectClassification::UNKNOWN,
+        autoware_perception_msgs::msg::ObjectClassification::HAZARD}) {
+    tracked_object_.classification.front().label = label;
+
+    TrackedObjects objects;
+    objects.header.stamp.sec = 100;
+    objects.objects.push_back(tracked_object_);
+
+    AgentData agent_data;
+    agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/false);
+    const auto histories =
+      agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+    EXPECT_TRUE(histories.empty()) << "label " << static_cast<int>(label) << " was not ignored";
+  }
+}
+
+TEST_F(AgentEdgeCaseTest, EmptyClassificationObjectIsStillIgnored)
+{
+  tracked_object_.classification.clear();
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects, /*remap_unsupported_objects_to_pedestrian=*/true);
   const auto histories =
     agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
 

--- a/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
@@ -65,4 +65,70 @@ protected:
   TrackedObject tracked_object_;
 };
 
+TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  EXPECT_EQ(
+    state.original_info.classification.front().label,
+    autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
+  // BOX shape is kept as is
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 5.0);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 2.0);
+}
+
+TEST_F(AgentEdgeCaseTest, HazardObjectWithNonBoxShapeGetsDefaultBox)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  // The polygon hazard object is not skipped because its shape is replaced with a bounding box
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  EXPECT_EQ(state.original_info.shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.z, 0.5);
+}
+
+TEST_F(AgentEdgeCaseTest, NonHazardPolygonObjectIsStillSkipped)
+{
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  EXPECT_TRUE(histories.empty());
+}
+
 }  // namespace autoware::diffusion_planner::test

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
@@ -46,6 +46,8 @@
 
 #include <rviz_common/display_context.hpp>
 
+#include <geometry_msgs/msg/point32.hpp>
+
 #include <algorithm>
 #include <random>
 #include <string>
@@ -121,6 +123,21 @@ DummyObject UnknownInitialPoseTool::createObjectMsg() const
   object.shape.dimensions.x = length;
   object.shape.dimensions.y = width;
   object.shape.dimensions.z = 2.0;
+
+  // A POLYGON shape is defined by its footprint, not by `dimensions`. Leaving the footprint empty
+  // yields a zero-area object, which the tracker can never confirm, so the dummy object would never
+  // be published on the tracking topic. Emit the rectangle implied by length/width instead.
+  const auto add_footprint_point = [&object](const double x, const double y) {
+    geometry_msgs::msg::Point32 point;
+    point.x = static_cast<float>(x);
+    point.y = static_cast<float>(y);
+    point.z = 0.0F;
+    object.shape.footprint.points.push_back(point);
+  };
+  add_footprint_point(length / 2.0, width / 2.0);
+  add_footprint_point(-length / 2.0, width / 2.0);
+  add_footprint_point(-length / 2.0, -width / 2.0);
+  add_footprint_point(length / 2.0, -width / 2.0);
 
   // initial state
   object.initial_state.pose_covariance.pose.position.z = position_z_->getFloat();


### PR DESCRIPTION
## Description

Cherry-pick of autowarefoundation/autoware_universe#13352 (squash commit `eabc796`).

UNKNOWN and HAZARD tracked objects have no matching class in the diffusion planner model,
so they hit `get_model_label()`'s `IGNORE` default and were dropped before the planner saw
them, even though they can obstruct driving.

This adds a `remap_unsupported_objects_to_pedestrian` parameter. When it is on, an object
whose label the model does not support is rewritten to PEDESTRIAN — the most conservative
supported class — before agent history is built. `ANIMAL`, `OVER_DRIVABLE` and
`UNDER_DRIVABLE` stay ignored on purpose. A non-BOX shape is replaced with a 0.5 m bounding
box, because perception reports these classes as polygons while the model reads
`dimensions.x/y` as length and width.

The default is `false`, so nothing changes unless the parameter is turned on.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_universe#13352

## How was this PR tested?

- `colcon build` of `autoware_diffusion_planner` and `tier4_dummy_object_rviz_plugin`: passes.
- `test_diffusion_planner`: **118 tests, 118 passed**, including all 8 `AgentEdgeCaseTest`
  remap cases.
- Behaviour measured across all 12 `ObjectClassification` labels, in BOX and POLYGON shape,
  with the parameter off and on. Only label 0 (UNKNOWN) and label 9 (HAZARD) change: dropped
  when off, kept as PEDESTRIAN when on. Every other label is unchanged.
- Planning simulator on the odaiba map: with the parameter on, dummy UNKNOWN objects appear
  as agents with predicted paths.

## Notes for reviewers

This is a faithful cherry-pick. The change is byte-identical to the upstream PR's diff; the
only textual differences are context lines, because this branch uses `DummyObject` where AWF
main uses `SimulatedObject`.

The branch also carries a merge of `feat/v0.64/e2e` and a revert commit that drops the
earlier hand-written version of this change, so that the final commit is a clean
`git cherry-pick -x` of the upstream squash commit.

**At squash-merge time, please trim the squash message down to the cherry-pick commit
message**, so the `(cherry picked from commit eabc7966899e42dd16dac5ca498f937981dd7426)`
line is kept in `feat/v0.64/e2e`.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Added | `remap_unsupported_objects_to_pedestrian` | `bool` | `false` | Treat UNKNOWN and HAZARD tracked objects as PEDESTRIAN so the planner reacts to them. Non-BOX shapes are replaced with a 0.5 m bounding box. ANIMAL, OVER_DRIVABLE and UNDER_DRIVABLE remain ignored. |

## Effects on system behavior

None by default, because `remap_unsupported_objects_to_pedestrian` is `false`.

When enabled, UNKNOWN and HAZARD objects become PEDESTRIAN agents in the planner input, so
the planner reacts to them instead of ignoring them.
