### PR TITLE
chore(crosswalk_filter): relieve lon_detection_margin to 2.5

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -114,7 +114,7 @@
 
     crosswalk:
       object_types: ["pedestrian", "bicycle"]
-      lon_detection_margin: 2.0 # [m] longitudinal extrusion length from crosswalk edge
+      lon_detection_margin: 2.5 # [m] longitudinal extrusion length from crosswalk edge
       lat_detection_margin: 1.0 # [m] lateral extrusion length from crosswalk edge
       object_clear_time_th: 0.3 # [s] duration threshold to clear target object when no longer seen
       overshoot_tolerance: 0.1  # [m] maximum overshoot distance allowed to consider the trajectory feasible


### PR DESCRIPTION
## Description

Relieve `lon_detection_margin` to 2.5 for crosswalk filter to capture pedestrians in a larger range. 

## How was this PR tested?

Tested that the scenario test results improve from 

## Notes for reviewers

None.

## Effects on system behavior

None.
