### PR TITLE
fix: find nearest index

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -112,6 +112,47 @@ size_t findNearestIndex(const T & points, const geometry_msgs::msg::Point & poin
 }
 
 template <class T>
+size_t findFirstNearestIndex(
+  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 9.0)
+{
+  validateNonEmpty(points);
+
+  const double squared_distance_thresh = distance_thresh * distance_thresh;
+
+  bool min_idx_found = false;
+  bool max_idx_found = false;
+  size_t range_min_idx = 0;
+  size_t range_max_idx = points.size() - 1;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    const auto dist = calcSquaredDistance2d(points.at(i), point);
+    if (dist < squared_distance_thresh) {
+      if (!min_idx_found) {
+        range_min_idx = i;
+        min_idx_found = true;
+      }
+      if (!max_idx_found) {
+        range_max_idx = i;
+      }
+    } else if (min_idx_found) {
+      max_idx_found = true;
+    }
+  }
+
+  double min_dist = std::numeric_limits<double>::max();
+  size_t min_idx = 0;
+
+  for (size_t i = range_min_idx; i <= range_max_idx; ++i) {
+    const auto dist = calcSquaredDistance2d(points.at(i), point);
+    if (dist < min_dist) {
+      min_dist = dist;
+      min_idx = i;
+    }
+  }
+  return min_idx;
+}
+
+template <class T>
 boost::optional<size_t> findNearestIndex(
   const T & points, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
@@ -131,6 +172,70 @@ boost::optional<size_t> findNearestIndex(
   size_t min_idx = 0;
 
   for (size_t i = 0; i < points.size(); ++i) {
+    const auto squared_dist = calcSquaredDistance2d(points.at(i), pose);
+    if (squared_dist > max_squared_dist) {
+      continue;
+    }
+
+    const auto yaw = calcYawDeviation(getPose(points.at(i)), pose);
+    if (std::fabs(yaw) > max_yaw) {
+      continue;
+    }
+
+    if (squared_dist >= min_squared_dist) {
+      continue;
+    }
+
+    min_squared_dist = squared_dist;
+    min_idx = i;
+    is_nearest_found = true;
+  }
+  return is_nearest_found ? boost::optional<size_t>(min_idx) : boost::none;
+}
+
+template <class T>
+boost::optional<size_t> findFirstNearestIndex(
+  const T & points, const geometry_msgs::msg::Pose & pose,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_yaw = std::numeric_limits<double>::max(),
+  const double distance_thresh = 9.0)
+{
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
+
+  const double squared_distance_thresh = distance_thresh * distance_thresh;
+
+  bool min_idx_found = false;
+  bool max_idx_found = false;
+  size_t range_min_idx = 0;
+  size_t range_max_idx = points.size() - 1;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    const auto squared_dist = calcSquaredDistance2d(points.at(i), pose);
+    if (squared_dist < squared_distance_thresh) {
+      if (!min_idx_found) {
+        range_min_idx = i;
+        min_idx_found = true;
+      }
+      if (!max_idx_found) {
+        range_max_idx = i;
+      }
+    } else if (min_idx_found) {
+      max_idx_found = true;
+    }
+  }
+
+  const double max_squared_dist = max_dist * max_dist;
+
+  double min_squared_dist = std::numeric_limits<double>::max();
+  bool is_nearest_found = false;
+  size_t min_idx = 0;
+
+  for (size_t i = range_min_idx; i <= range_max_idx; ++i) {
     const auto squared_dist = calcSquaredDistance2d(points.at(i), pose);
     if (squared_dist > max_squared_dist) {
       continue;
@@ -235,6 +340,37 @@ size_t findNearestSegmentIndex(const T & points, const geometry_msgs::msg::Point
 }
 
 /**
+ * @brief find first nearest segment index to point
+ *        segment is straight path between two continuous points of trajectory
+ *        When point is on a trajectory point whose index is nearest_idx, return nearest_idx - 1
+ * @param points points of trajectory
+ * @param point point to which to find nearest segment index
+ * @param distance_thresh distance threshold for the first-near range
+ * @return nearest index
+ */
+template <class T>
+size_t findFirstNearestSegmentIndex(
+  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 9.0)
+{
+  const size_t nearest_idx = findFirstNearestIndex(points, point, distance_thresh);
+
+  if (nearest_idx == 0) {
+    return 0;
+  }
+  if (nearest_idx == points.size() - 1) {
+    return points.size() - 2;
+  }
+
+  const double signed_length = calcLongitudinalOffsetToSegment(points, nearest_idx, point);
+
+  if (signed_length <= 0) {
+    return nearest_idx - 1;
+  }
+
+  return nearest_idx;
+}
+
+/**
  * @brief find nearest segment index to pose
  *        segment is straight path between two continuous points of trajectory
  *        When pose is on a trajectory point whose index is nearest_idx, return nearest_idx - 1
@@ -251,6 +387,46 @@ boost::optional<size_t> findNearestSegmentIndex(
   const double max_yaw = std::numeric_limits<double>::max())
 {
   const auto nearest_idx = findNearestIndex(points, pose, max_dist, max_yaw);
+
+  if (!nearest_idx) {
+    return boost::none;
+  }
+
+  if (*nearest_idx == 0) {
+    return 0;
+  }
+  if (*nearest_idx == points.size() - 1) {
+    return points.size() - 2;
+  }
+
+  const double signed_length = calcLongitudinalOffsetToSegment(points, *nearest_idx, pose.position);
+
+  if (signed_length <= 0) {
+    return *nearest_idx - 1;
+  }
+
+  return *nearest_idx;
+}
+
+/**
+ * @brief find first nearest segment index to pose
+ *        segment is straight path between two continuous points of trajectory
+ *        When pose is on a trajectory point whose index is nearest_idx, return nearest_idx - 1
+ * @param points points of trajectory
+ * @param pose pose to which to find nearest segment index
+ * @param max_dist max distance to search
+ * @param max_yaw max yaw to search
+ * @param distance_thresh distance threshold for the first-near range
+ * @return nearest index
+ */
+template <class T>
+boost::optional<size_t> findFirstNearestSegmentIndex(
+  const T & points, const geometry_msgs::msg::Pose & pose,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_yaw = std::numeric_limits<double>::max(),
+  const double distance_thresh = 9.0)
+{
+  const auto nearest_idx = findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh);
 
   if (!nearest_idx) {
     return boost::none;
@@ -431,6 +607,41 @@ boost::optional<double> calcSignedArcLength(
   }
 
   const size_t dst_seg_idx = findNearestSegmentIndex(points, dst_point);
+
+  const double signed_length_on_traj = calcSignedArcLength(points, *src_seg_idx, dst_seg_idx);
+  const double signed_length_src_offset =
+    calcLongitudinalOffsetToSegment(points, *src_seg_idx, src_pose.position);
+  const double signed_length_dst_offset =
+    calcLongitudinalOffsetToSegment(points, dst_seg_idx, dst_point);
+
+  return signed_length_on_traj - signed_length_src_offset + signed_length_dst_offset;
+}
+
+/**
+ * @brief calcFirstSignedArcLength from pose to point
+ */
+template <class T>
+boost::optional<double> calcFirstSignedArcLength(
+  const T & points, const geometry_msgs::msg::Pose & src_pose,
+  const geometry_msgs::msg::Point & dst_point,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_yaw = std::numeric_limits<double>::max(),
+  const double distance_thresh = 9.0)
+{
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
+
+  const auto src_seg_idx =
+    findFirstNearestSegmentIndex(points, src_pose, max_dist, max_yaw, distance_thresh);
+  if (!src_seg_idx) {
+    return boost::none;
+  }
+
+  const size_t dst_seg_idx = findFirstNearestSegmentIndex(points, dst_point, distance_thresh);
 
   const double signed_length_on_traj = calcSignedArcLength(points, *src_seg_idx, dst_seg_idx);
   const double signed_length_src_offset =

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -113,7 +113,7 @@ size_t findNearestIndex(const T & points, const geometry_msgs::msg::Point & poin
 
 template <class T>
 size_t findFirstNearestIndex(
-  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 9.0)
+  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 5.0)
 {
   validateNonEmpty(points);
 
@@ -198,7 +198,7 @@ boost::optional<size_t> findFirstNearestIndex(
   const T & points, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(),
-  const double distance_thresh = 9.0)
+  const double distance_thresh = 5.0)
 {
   try {
     validateNonEmpty(points);
@@ -350,7 +350,7 @@ size_t findNearestSegmentIndex(const T & points, const geometry_msgs::msg::Point
  */
 template <class T>
 size_t findFirstNearestSegmentIndex(
-  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 9.0)
+  const T & points, const geometry_msgs::msg::Point & point, const double distance_thresh = 5.0)
 {
   const size_t nearest_idx = findFirstNearestIndex(points, point, distance_thresh);
 
@@ -424,7 +424,7 @@ boost::optional<size_t> findFirstNearestSegmentIndex(
   const T & points, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(),
-  const double distance_thresh = 9.0)
+  const double distance_thresh = 5.0)
 {
   const auto nearest_idx = findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh);
 
@@ -626,7 +626,7 @@ boost::optional<double> calcFirstSignedArcLength(
   const geometry_msgs::msg::Point & dst_point,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(),
-  const double distance_thresh = 9.0)
+  const double distance_thresh = 5.0)
 {
   try {
     validateNonEmpty(points);

--- a/common/tier4_autoware_utils/test/src/trajectory/test_calc_first_signed_arc_length.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_calc_first_signed_arc_length.cpp
@@ -1,0 +1,267 @@
+#include "test_first_nearest_inputs.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double epsilon = 1e-6;
+constexpr double epsilon_diff = 1e-2;
+}  // namespace
+
+TEST(trajectory, calcFirstSignedArcLength_01)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_n_point;
+  using first_nearest_inputs::plain_n_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_plain();
+  const auto src = plain_n_pose();
+  const auto dst = plain_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NEAR(*first, *baseline, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_02)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap1_n_point;
+  using first_nearest_inputs::overlap1_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap1_n_pose();
+  const auto dst = overlap1_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NEAR(*first, *baseline, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_03)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_n_point;
+  using first_nearest_inputs::overlap2_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap2_n_pose();
+  const auto dst = overlap2_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_GT(std::fabs(*first - *baseline), epsilon_diff);
+
+  constexpr double expected = 0.1;
+  EXPECT_NEAR(*first, expected, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_04)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap1_n_pose;
+  using first_nearest_inputs::overlap2_n_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap1_n_pose();
+  const auto dst = overlap2_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_GT(std::fabs(*first - *baseline), epsilon_diff);
+
+  constexpr double expected = 0.34;
+  EXPECT_NEAR(*first, expected, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_05)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap1_n_point;
+  using first_nearest_inputs::overlap2_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap2_n_pose();
+  const auto dst = overlap1_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_GT(std::fabs(*first - *baseline), epsilon_diff);
+
+  constexpr double expected = 0.36;
+  EXPECT_NEAR(*first, expected, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_06)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_f_point;
+  using first_nearest_inputs::overlap2_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap2_n_pose();
+  const auto dst = overlap2_f_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_GT(std::fabs(*first - *baseline), epsilon_diff);
+
+  constexpr double expected = 24.76;
+  EXPECT_NEAR(*first, expected, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_07)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_f_pose;
+  using first_nearest_inputs::overlap2_n_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap2_f_pose();
+  const auto dst = overlap2_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_GT(std::fabs(*first - *baseline), epsilon_diff);
+
+  constexpr double expected = -23.26;
+  EXPECT_NEAR(*first, expected, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_08)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_f_point;
+  using first_nearest_inputs::plain_n_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_plain();
+  const auto src = plain_n_pose();
+  const auto dst = plain_f_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NEAR(*first, *baseline, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_09)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_f_pose;
+  using first_nearest_inputs::plain_n_point;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_plain();
+  const auto src = plain_f_pose();
+  const auto dst = plain_n_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NEAR(*first, *baseline, epsilon);
+}
+
+TEST(trajectory, calcFirstSignedArcLength_10)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_f_point;
+  using first_nearest_inputs::overlap2_f_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::calcFirstSignedArcLength;
+  using tier4_autoware_utils::calcSignedArcLength;
+
+  const auto points = traj_overlap();
+  const auto src = overlap2_f_pose();
+  const auto dst = overlap2_f_point();
+
+  const auto first =
+    calcFirstSignedArcLength(points, src, dst, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = calcSignedArcLength(points, src, dst, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NEAR(*first, *baseline, epsilon);
+}

--- a/common/tier4_autoware_utils/test/src/trajectory/test_find_first_nearest_index.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_find_first_nearest_index.cpp
@@ -1,0 +1,180 @@
+#include "test_first_nearest_inputs.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(trajectory, findFirstNearestIndex_19)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_n_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_plain();
+  const auto pose = plain_n_pose();
+
+  const auto first =
+    findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_20)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_overlap();
+  const auto pose = overlap2_n_pose();
+
+  const auto first =
+    findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NE(*first, *baseline);
+
+  constexpr size_t expected = 49;
+  EXPECT_EQ(*first, expected);
+}
+
+TEST(trajectory, findFirstNearestIndex_21)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_f_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_plain();
+  const auto pose = plain_f_pose();
+
+  const auto first = findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_22)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_y_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_plain();
+  const auto pose = plain_y_pose();
+
+  const auto first = findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh_small);
+  const auto baseline = findNearestIndex(points, pose, max_dist, max_yaw);
+
+  EXPECT_FALSE(first);
+  ASSERT_TRUE(baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_23)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_f_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_overlap();
+  const auto pose = overlap2_f_pose();
+
+  const auto first = findFirstNearestIndex(points, pose, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_24)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::plain_n_point;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_plain();
+  const auto point = plain_n_point();
+
+  const auto first = findFirstNearestIndex(points, point, distance_thresh_default);
+  const auto baseline = findNearestIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_25)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::overlap2_n_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_overlap();
+  const auto point = overlap2_n_point();
+
+  const auto first = findFirstNearestIndex(points, point, distance_thresh_default);
+  const auto baseline = findNearestIndex(points, point);
+  EXPECT_NE(first, baseline);
+
+  constexpr size_t expected = 50;
+  EXPECT_EQ(first, expected);
+}
+
+TEST(trajectory, findFirstNearestIndex_26)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::plain_f_point;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_plain();
+  const auto point = plain_f_point();
+
+  const auto first = findFirstNearestIndex(points, point, distance_thresh_small);
+  const auto baseline = findNearestIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}
+
+TEST(trajectory, findFirstNearestIndex_27)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::overlap2_f_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestIndex;
+  using tier4_autoware_utils::findNearestIndex;
+
+  const auto points = traj_overlap();
+  const auto point = overlap2_f_point();
+
+  const auto first = findFirstNearestIndex(points, point, distance_thresh_small);
+  const auto baseline = findNearestIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}

--- a/common/tier4_autoware_utils/test/src/trajectory/test_find_first_nearest_segment_index.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_find_first_nearest_segment_index.cpp
@@ -1,0 +1,162 @@
+#include "test_first_nearest_inputs.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(trajectory, findFirstNearestSegmentIndex_11)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_n_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_plain();
+  const auto pose = plain_n_pose();
+
+  const auto first =
+    findFirstNearestSegmentIndex(points, pose, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestSegmentIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_12)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_n_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_overlap();
+  const auto pose = overlap2_n_pose();
+
+  const auto first =
+    findFirstNearestSegmentIndex(points, pose, max_dist, max_yaw, distance_thresh_default);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestSegmentIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_NE(*first, *baseline);
+
+  constexpr size_t expected = 49;
+  EXPECT_EQ(*first, expected);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_13)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::plain_f_pose;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_plain();
+  const auto pose = plain_f_pose();
+
+  const auto first =
+    findFirstNearestSegmentIndex(points, pose, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestSegmentIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_14)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::max_dist;
+  using first_nearest_inputs::max_yaw;
+  using first_nearest_inputs::overlap2_f_pose;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_overlap();
+  const auto pose = overlap2_f_pose();
+
+  const auto first =
+    findFirstNearestSegmentIndex(points, pose, max_dist, max_yaw, distance_thresh_small);
+  ASSERT_TRUE(first);
+
+  const auto baseline = findNearestSegmentIndex(points, pose, max_dist, max_yaw);
+  ASSERT_TRUE(baseline);
+  EXPECT_EQ(*first, *baseline);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_15)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::plain_n_point;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_plain();
+  const auto point = plain_n_point();
+
+  const auto first = findFirstNearestSegmentIndex(points, point, distance_thresh_default);
+  const auto baseline = findNearestSegmentIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_16)
+{
+  using first_nearest_inputs::distance_thresh_default;
+  using first_nearest_inputs::overlap2_n_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_overlap();
+  const auto point = overlap2_n_point();
+
+  const auto first = findFirstNearestSegmentIndex(points, point, distance_thresh_default);
+  const auto baseline = findNearestSegmentIndex(points, point);
+  EXPECT_NE(first, baseline);
+
+  constexpr size_t expected = 50;
+  EXPECT_EQ(first, expected);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_17)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::plain_f_point;
+  using first_nearest_inputs::traj_plain;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_plain();
+  const auto point = plain_f_point();
+
+  const auto first = findFirstNearestSegmentIndex(points, point, distance_thresh_small);
+  const auto baseline = findNearestSegmentIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}
+
+TEST(trajectory, findFirstNearestSegmentIndex_18)
+{
+  using first_nearest_inputs::distance_thresh_small;
+  using first_nearest_inputs::overlap2_f_point;
+  using first_nearest_inputs::traj_overlap;
+  using tier4_autoware_utils::findFirstNearestSegmentIndex;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+
+  const auto points = traj_overlap();
+  const auto point = overlap2_f_point();
+
+  const auto first = findFirstNearestSegmentIndex(points, point, distance_thresh_small);
+  const auto baseline = findNearestSegmentIndex(points, point);
+  EXPECT_EQ(first, baseline);
+}

--- a/common/tier4_autoware_utils/test/src/trajectory/test_first_nearest_inputs.hpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_first_nearest_inputs.hpp
@@ -1,0 +1,150 @@
+#ifndef TIER4_AUTOWARE_UTILS__TEST_FIRST_NEAREST_INPUTS_HPP_
+#define TIER4_AUTOWARE_UTILS__TEST_FIRST_NEAREST_INPUTS_HPP_
+
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/math/unit_conversion.hpp"
+
+#include <autoware_auto_planning_msgs/msg/trajectory_point.hpp>
+
+#include <vector>
+
+namespace first_nearest_inputs
+{
+using TrajectoryPoints = std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>;
+
+constexpr double distance_thresh_default = 9.0;
+constexpr double distance_thresh_small = 0.5;  // overlap2_n が折返し前も窓に入る下限
+constexpr double max_dist = 9.0;
+constexpr double max_yaw = tier4_autoware_utils::deg2rad(60.0);
+
+inline geometry_msgs::msg::Pose makePose(const double x, const double y, const double yaw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position = tier4_autoware_utils::createPoint(x, y, 0.0);
+  pose.orientation = tier4_autoware_utils::createQuaternionFromRPY(0.0, 0.0, yaw);
+  return pose;
+}
+
+inline geometry_msgs::msg::Point makePoint(const double x, const double y)
+{
+  return tier4_autoware_utils::createPoint(x, y, 0.0);
+}
+
+inline autoware_auto_planning_msgs::msg::TrajectoryPoint makeTrajPoint(
+  const double x, const double y, const double yaw)
+{
+  autoware_auto_planning_msgs::msg::TrajectoryPoint p;
+  p.pose = makePose(x, y, yaw);
+  return p;
+}
+
+// --- trajectories ---
+
+// 折線 S: (0,0)->(10,0)->(10,10)->(20,10)、点間隔 0.1 m
+inline TrajectoryPoints traj_plain()
+{
+  TrajectoryPoints points;
+  points.reserve(301);
+  constexpr double yaw_x = 0.0;
+  constexpr double yaw_y = tier4_autoware_utils::deg2rad(90.0);
+
+  for (int i = 0; i < 100; ++i) {
+    points.push_back(makeTrajPoint(0.1 * i, 0.0, yaw_x));
+  }
+  points.push_back(makeTrajPoint(10.0, 0.0, yaw_y));
+  for (int i = 1; i < 100; ++i) {
+    points.push_back(makeTrajPoint(10.0, 0.1 * i, yaw_y));
+  }
+  points.push_back(makeTrajPoint(10.0, 10.0, yaw_x));
+  for (int i = 1; i <= 100; ++i) {
+    points.push_back(makeTrajPoint(10.0 + 0.1 * i, 10.0, yaw_x));
+  }
+  return points;
+}
+
+inline TrajectoryPoints traj_overlap()
+{
+  // 15+2+10+3、全て直角右折: (0,0)->(15,0)->(15,-2)->(5,-2)->(5,1)、点間隔 0.1 m
+  TrajectoryPoints points;
+  points.reserve(301);
+  constexpr double yaw_px = 0.0;
+  constexpr double yaw_my = tier4_autoware_utils::deg2rad(-90.0);
+  constexpr double yaw_mx = tier4_autoware_utils::deg2rad(180.0);
+  constexpr double yaw_py = tier4_autoware_utils::deg2rad(90.0);
+
+  for (int i = 0; i < 150; ++i) {
+    points.push_back(makeTrajPoint(0.1 * i, 0.0, yaw_px));
+  }
+  points.push_back(makeTrajPoint(15.0, 0.0, yaw_my));
+  for (int i = 1; i < 20; ++i) {
+    points.push_back(makeTrajPoint(15.0, -0.1 * i, yaw_my));
+  }
+  points.push_back(makeTrajPoint(15.0, -2.0, yaw_mx));
+  for (int i = 1; i < 100; ++i) {
+    points.push_back(makeTrajPoint(15.0 - 0.1 * i, -2.0, yaw_mx));
+  }
+  points.push_back(makeTrajPoint(5.0, -2.0, yaw_py));
+  for (int i = 1; i <= 30; ++i) {
+    points.push_back(makeTrajPoint(5.0, -2.0 + 0.1 * i, yaw_py));
+  }
+  return points;
+}
+
+inline geometry_msgs::msg::Pose plain_n_pose()
+{
+  return makePose(2.0, 0.05, 0.0);
+}
+
+inline geometry_msgs::msg::Point plain_n_point()
+{
+  return makePoint(5.0, 0.05);
+}
+
+inline geometry_msgs::msg::Pose plain_f_pose()
+{
+  return makePose(3.5, 0.6, 0.0);
+}
+
+inline geometry_msgs::msg::Point plain_f_point()
+{
+  return makePoint(6.5, 0.6);
+}
+
+inline geometry_msgs::msg::Pose plain_y_pose()
+{
+  return makePose(7.5, 0.05, tier4_autoware_utils::deg2rad(70.0));
+}
+
+inline geometry_msgs::msg::Pose overlap1_n_pose()
+{
+  return makePose(4.7, 0.05, 0.0);
+}
+
+inline geometry_msgs::msg::Point overlap1_n_point()
+{
+  return makePoint(5.3, 0.05);
+}
+
+inline geometry_msgs::msg::Pose overlap2_n_pose()
+{
+  return makePose(4.94, -0.4, tier4_autoware_utils::deg2rad(45.0));
+}
+
+inline geometry_msgs::msg::Point overlap2_n_point()
+{
+  return makePoint(5.04, 0.3);
+}
+
+inline geometry_msgs::msg::Pose overlap2_f_pose()
+{
+  return makePose(4.4, -0.7, tier4_autoware_utils::deg2rad(45.0));
+}
+
+inline geometry_msgs::msg::Point overlap2_f_point()
+{
+  return makePoint(4.4, 0.7);
+}
+
+}  // namespace first_nearest_inputs
+
+#endif  // TIER4_AUTOWARE_UTILS__TEST_FIRST_NEAREST_INPUTS_HPP_

--- a/planning/behavior_velocity_planner/config/virtual_traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/config/virtual_traffic_light.param.yaml
@@ -5,5 +5,5 @@
       near_line_distance: 1.0
       dead_line_margin: 1.0
       max_yaw_deviation_deg: 90.0
-      distance_thresh: 9.0
+      distance_thresh: 5.0
       check_timeout_after_stop_line: true

--- a/planning/behavior_velocity_planner/config/virtual_traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/config/virtual_traffic_light.param.yaml
@@ -5,4 +5,5 @@
       near_line_distance: 1.0
       dead_line_margin: 1.0
       max_yaw_deviation_deg: 90.0
+      distance_thresh: 9.0
       check_timeout_after_stop_line: true

--- a/planning/behavior_velocity_planner/include/scene_module/virtual_traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/virtual_traffic_light/scene.hpp
@@ -69,6 +69,7 @@ public:
     double near_line_distance;
     double dead_line_margin;
     double max_yaw_deviation_rad;
+    double distance_thresh;
     bool check_timeout_after_stop_line;
   };
 

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
@@ -76,6 +76,7 @@ VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node 
     p.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 1.0);
     p.max_yaw_deviation_rad =
       tier4_autoware_utils::deg2rad(node.declare_parameter(ns + ".max_yaw_deviation_deg", 90.0));
+    p.distance_thresh = node.declare_parameter(ns + ".distance_thresh", 9.0);
     p.check_timeout_after_stop_line =
       node.declare_parameter(ns + ".check_timeout_after_stop_line", true);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
@@ -76,7 +76,7 @@ VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node 
     p.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 1.0);
     p.max_yaw_deviation_rad =
       tier4_autoware_utils::deg2rad(node.declare_parameter(ns + ".max_yaw_deviation_deg", 90.0));
-    p.distance_thresh = node.declare_parameter(ns + ".distance_thresh", 9.0);
+    p.distance_thresh = node.declare_parameter(ns + ".distance_thresh", 5.0);
     p.check_timeout_after_stop_line =
       node.declare_parameter(ns + ".check_timeout_after_stop_line", true);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
@@ -471,9 +471,9 @@ bool VirtualTrafficLightModule::isBeforeStartLine()
   }
 
   const double max_dist = std::numeric_limits<double>::max();
-  const auto signed_arc_length = tier4_autoware_utils::calcSignedArcLength(
+  const auto signed_arc_length = tier4_autoware_utils::calcFirstSignedArcLength(
     module_data_.path.points, module_data_.head_pose, collision->point, max_dist,
-    planner_param_.max_yaw_deviation_rad);
+    planner_param_.max_yaw_deviation_rad, planner_param_.distance_thresh);
 
   return *signed_arc_length > 0;
 }
@@ -489,9 +489,9 @@ bool VirtualTrafficLightModule::isBeforeStopLine()
   }
 
   const double max_dist = std::numeric_limits<double>::max();
-  const auto signed_arc_length = tier4_autoware_utils::calcSignedArcLength(
+  const auto signed_arc_length = tier4_autoware_utils::calcFirstSignedArcLength(
     module_data_.path.points, module_data_.head_pose, collision->point, max_dist,
-    planner_param_.max_yaw_deviation_rad);
+    planner_param_.max_yaw_deviation_rad, planner_param_.distance_thresh);
 
   return *signed_arc_length > -planner_param_.dead_line_margin;
 }
@@ -512,9 +512,9 @@ bool VirtualTrafficLightModule::isAfterAnyEndLine()
   }
 
   const double max_dist = std::numeric_limits<double>::max();
-  const auto signed_arc_length = tier4_autoware_utils::calcSignedArcLength(
+  const auto signed_arc_length = tier4_autoware_utils::calcFirstSignedArcLength(
     module_data_.path.points, module_data_.head_pose, collision->point, max_dist,
-    planner_param_.max_yaw_deviation_rad);
+    planner_param_.max_yaw_deviation_rad, planner_param_.distance_thresh);
 
   return *signed_arc_length < -planner_param_.dead_line_margin;
 }
@@ -528,9 +528,9 @@ bool VirtualTrafficLightModule::isNearAnyEndLine()
   }
 
   const double max_dist = std::numeric_limits<double>::max();
-  const auto signed_arc_length = tier4_autoware_utils::calcSignedArcLength(
+  const auto signed_arc_length = tier4_autoware_utils::calcFirstSignedArcLength(
     module_data_.path.points, module_data_.head_pose, collision->point, max_dist,
-    planner_param_.max_yaw_deviation_rad);
+    planner_param_.max_yaw_deviation_rad, planner_param_.distance_thresh);
 
   return std::abs(*signed_arc_length) < planner_param_.near_line_distance;
 }

--- a/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
+++ b/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
@@ -28,7 +28,7 @@
     extract_ahead_dist: 200.0         # forward trajectory distance used for planning [m]
     extract_behind_dist: 5.0          # backward trajectory distance used for planning [m]
     delta_yaw_threshold: 1.0472       # Allowed delta yaw between ego pose and trajectory pose [radian]
-    distance_thresh: 9.0
+    distance_thresh: 5.0
 
     # resampling parameters for optimization
     max_trajectory_length: 200.0        # max trajectory length for resampling [m]

--- a/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
+++ b/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
@@ -28,6 +28,7 @@
     extract_ahead_dist: 200.0         # forward trajectory distance used for planning [m]
     extract_behind_dist: 5.0          # backward trajectory distance used for planning [m]
     delta_yaw_threshold: 1.0472       # Allowed delta yaw between ego pose and trajectory pose [radian]
+    distance_thresh: 9.0
 
     # resampling parameters for optimization
     max_trajectory_length: 200.0        # max trajectory length for resampling [m]

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -120,6 +120,7 @@ private:
     double extract_behind_dist;           // backward waypoints distance from current position [m]
     double stop_dist_to_prohibit_engage;  // prevent to move toward close stop point
     double delta_yaw_threshold;           // for closest index calculation
+    double distance_thresh;
     resampling::ResampleParam post_resample_param;
     AlgorithmType algorithm_type;  // Option : JerkFiltered, Linf, L2
   } node_param_{};

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -147,6 +147,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
     update_param("extract_behind_dist", p.extract_behind_dist);
     update_param("stop_dist_to_prohibit_engage", p.stop_dist_to_prohibit_engage);
     update_param("delta_yaw_threshold", p.delta_yaw_threshold);
+    update_param("distance_thresh", p.distance_thresh);
   }
 
   {
@@ -244,6 +245,7 @@ void MotionVelocitySmootherNode::initCommonParam()
   p.extract_behind_dist = declare_parameter("extract_behind_dist", 3.0);
   p.stop_dist_to_prohibit_engage = declare_parameter("stop_dist_to_prohibit_engage", 1.5);
   p.delta_yaw_threshold = declare_parameter("delta_yaw_threshold", M_PI / 3.0);
+  p.distance_thresh = declare_parameter("distance_thresh", 9.0);
   p.post_resample_param.max_trajectory_length =
     declare_parameter("post_max_trajectory_length", 300.0);
   p.post_resample_param.min_trajectory_length =
@@ -720,9 +722,9 @@ void MotionVelocitySmootherNode::overwriteStopPoint(
   }
 
   // Get Closest Point from Output
-  const auto nearest_output_point_idx = tier4_autoware_utils::findNearestIndex(
+  const auto nearest_output_point_idx = tier4_autoware_utils::findFirstNearestIndex(
     output, input.at(*stop_idx).pose, std::numeric_limits<double>::max(),
-    node_param_.delta_yaw_threshold);
+    node_param_.delta_yaw_threshold, node_param_.distance_thresh);
 
   // check over velocity
   bool is_stop_velocity_exceeded{false};

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -245,7 +245,7 @@ void MotionVelocitySmootherNode::initCommonParam()
   p.extract_behind_dist = declare_parameter("extract_behind_dist", 3.0);
   p.stop_dist_to_prohibit_engage = declare_parameter("stop_dist_to_prohibit_engage", 1.5);
   p.delta_yaw_threshold = declare_parameter("delta_yaw_threshold", M_PI / 3.0);
-  p.distance_thresh = declare_parameter("distance_thresh", 9.0);
+  p.distance_thresh = declare_parameter("distance_thresh", 5.0);
   p.post_resample_param.max_trajectory_length =
     declare_parameter("post_max_trajectory_length", 300.0);
   p.post_resample_param.min_trajectory_length =

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -34,6 +34,7 @@
 
       delta_dist_threshold_for_closest_point: 3.0 # delta dist thres for closest point [m]
       delta_yaw_threshold_for_closest_point: 1.046 #M_PI/3.0, delta yaw thres for closest point
+      distance_thresh: 9.0
       delta_yaw_threshold_for_straight: 0.02 # delta dist thres for straight point
 
       num_fix_points_for_extending: 50 # number of fixing points when extending

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -34,7 +34,7 @@
 
       delta_dist_threshold_for_closest_point: 3.0 # delta dist thres for closest point [m]
       delta_yaw_threshold_for_closest_point: 1.046 #M_PI/3.0, delta yaw thres for closest point
-      distance_thresh: 9.0
+      distance_thresh: 5.0
       delta_yaw_threshold_for_straight: 0.02 # delta dist thres for straight point
 
       num_fix_points_for_extending: 50 # number of fixing points when extending

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
@@ -193,6 +193,7 @@ struct TrajectoryParam
   double delta_arc_length_for_trajectory;
   double delta_dist_threshold_for_closest_point;
   double delta_yaw_threshold_for_closest_point;
+  double distance_thresh;
   double delta_yaw_threshold_for_straight;
   double trajectory_length;
   double forward_fixing_min_distance;

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -40,12 +40,13 @@ namespace
 {
 template <typename T1, typename T2>
 size_t searchExtendedZeroVelocityIndex(
-  const std::vector<T1> & fine_points, const std::vector<T2> & vel_points)
+  const std::vector<T1> & fine_points, const std::vector<T2> & vel_points,
+  const double distance_thresh)
 {
   const auto opt_zero_vel_idx = tier4_autoware_utils::searchZeroVelocityIndex(vel_points);
   const size_t zero_vel_idx = opt_zero_vel_idx ? opt_zero_vel_idx.get() : vel_points.size() - 1;
-  return tier4_autoware_utils::findNearestIndex(
-    fine_points, vel_points.at(zero_vel_idx).pose.position);
+  return tier4_autoware_utils::findFirstNearestIndex(
+    fine_points, vel_points.at(zero_vel_idx).pose.position, distance_thresh);
 }
 
 bool isPathShapeChanged(
@@ -319,6 +320,7 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       declare_parameter<double>("common.delta_dist_threshold_for_closest_point");
     traj_param_.delta_yaw_threshold_for_closest_point =
       declare_parameter<double>("common.delta_yaw_threshold_for_closest_point");
+    traj_param_.distance_thresh = declare_parameter<double>("common.distance_thresh", 9.0);
     traj_param_.delta_yaw_threshold_for_straight =
       declare_parameter<double>("common.delta_yaw_threshold_for_straight");
 
@@ -581,6 +583,7 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::paramCallback
     updateParam<double>(
       parameters, "common.delta_yaw_threshold_for_closest_point",
       traj_param_.delta_yaw_threshold_for_closest_point);
+    updateParam<double>(parameters, "common.distance_thresh", traj_param_.distance_thresh);
     updateParam<double>(
       parameters, "common.delta_yaw_threshold_for_straight",
       traj_param_.delta_yaw_threshold_for_straight);
@@ -1417,9 +1420,9 @@ ObstacleAvoidancePlanner::alignVelocity(
     const auto opt_path_zero_vel_idx = tier4_autoware_utils::searchZeroVelocityIndex(path_points);
     if (opt_path_zero_vel_idx && 1 < fine_traj_points.size()) {
       const auto & zero_vel_path_point = path_points.at(opt_path_zero_vel_idx.get());
-      const auto opt_traj_seg_idx = tier4_autoware_utils::findNearestSegmentIndex(
+      const auto opt_traj_seg_idx = tier4_autoware_utils::findFirstNearestSegmentIndex(
         fine_traj_points, zero_vel_path_point.pose, std::numeric_limits<double>::max(),
-        traj_param_.delta_yaw_threshold_for_closest_point);
+        traj_param_.delta_yaw_threshold_for_closest_point, traj_param_.distance_thresh);
       if (opt_traj_seg_idx) {
         const auto interpolated_pose =
           lerpPose(fine_traj_points, zero_vel_path_point.pose.position, opt_traj_seg_idx.get());
@@ -1458,7 +1461,8 @@ ObstacleAvoidancePlanner::alignVelocity(
   const size_t zero_vel_fine_traj_idx = [&]() {
     // zero velocity for being outside drivable area
     const size_t zero_vel_traj_idx =
-      searchExtendedZeroVelocityIndex(fine_traj_points_with_path_zero_vel, traj_points);
+      searchExtendedZeroVelocityIndex(
+        fine_traj_points_with_path_zero_vel, traj_points, traj_param_.distance_thresh);
 
     // zero velocity in path points
     if (opt_zero_vel_path_idx) {

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -320,7 +320,7 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       declare_parameter<double>("common.delta_dist_threshold_for_closest_point");
     traj_param_.delta_yaw_threshold_for_closest_point =
       declare_parameter<double>("common.delta_yaw_threshold_for_closest_point");
-    traj_param_.distance_thresh = declare_parameter<double>("common.distance_thresh", 9.0);
+    traj_param_.distance_thresh = declare_parameter<double>("common.distance_thresh", 5.0);
     traj_param_.delta_yaw_threshold_for_straight =
       declare_parameter<double>("common.delta_yaw_threshold_for_straight");
 

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    distance_thresh: 9.0
+
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
       min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    distance_thresh: 9.0
+    distance_thresh: 5.0
 
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -104,6 +104,7 @@ public:
     double hunting_threshold;      // keep slow down or stop state if obstacle vanished [s]
     double max_yaw_deviation_rad;  // maximum ego yaw deviation from trajectory [rad] (measures
                                    // against overlapping lanes)
+    double distance_thresh;
   };
 
   struct StopParam

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -39,7 +39,6 @@ using tier4_autoware_utils::calcAzimuthAngle;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcSignedArcLength;
 using tier4_autoware_utils::createPoint;
-using tier4_autoware_utils::findNearestIndex;
 using tier4_autoware_utils::getRPY;
 
 namespace
@@ -448,6 +447,7 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     lpf_acc_ = std::make_shared<LowpassFilter1d>(0.0, p.lowpass_gain);
     const double max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 90.0);
     p.max_yaw_deviation_rad = tier4_autoware_utils::deg2rad(max_yaw_deviation_deg);
+    p.distance_thresh = declare_parameter("distance_thresh", 9.0);
   }
 
   {
@@ -1234,10 +1234,11 @@ TrajectoryPoints ObstacleStopPlannerNode::trimTrajectoryWithIndexFromSelfPose(
   TrajectoryPoints output{};
 
   size_t min_distance_index = 0;
-  const auto nearest_index = tier4_autoware_utils::findNearestIndex(
-    input, self_pose, 10.0, node_param_.max_yaw_deviation_rad);
+  const auto nearest_index = tier4_autoware_utils::findFirstNearestIndex(
+    input, self_pose, 10.0, node_param_.max_yaw_deviation_rad, node_param_.distance_thresh);
   if (!nearest_index) {
-    min_distance_index = tier4_autoware_utils::findNearestIndex(input, self_pose.position);
+    min_distance_index = tier4_autoware_utils::findFirstNearestIndex(
+      input, self_pose.position, node_param_.distance_thresh);
   } else {
     min_distance_index = nearest_index.value();
   }

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -447,7 +447,7 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     lpf_acc_ = std::make_shared<LowpassFilter1d>(0.0, p.lowpass_gain);
     const double max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 90.0);
     p.max_yaw_deviation_rad = tier4_autoware_utils::deg2rad(max_yaw_deviation_deg);
-    p.distance_thresh = declare_parameter("distance_thresh", 9.0);
+    p.distance_thresh = declare_parameter("distance_thresh", 5.0);
   }
 
   {

--- a/planning/surround_obstacle_checker/CMakeLists.txt
+++ b/planning/surround_obstacle_checker/CMakeLists.txt
@@ -22,6 +22,16 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_get_first_closest_index
+    test/src/test_get_first_closest_index.cpp
+  )
+  target_link_libraries(test_get_first_closest_index
+    ${PROJECT_NAME}
+  )
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   config

--- a/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
+++ b/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
@@ -9,3 +9,4 @@
 
     # ego stop state
     stop_state_ego_speed: 0.1 #[m/s]
+    distance_thresh: 9.0

--- a/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
+++ b/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
@@ -9,4 +9,4 @@
 
     # ego stop state
     stop_state_ego_speed: 0.1 #[m/s]
-    distance_thresh: 9.0
+    distance_thresh: 5.0

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -85,7 +85,7 @@ private:
   size_t getClosestIdx(const TrajectoryPoints & traj, const geometry_msgs::msg::Pose current_pose);
   size_t getFirstClosestIndex(
     const TrajectoryPoints & traj, const geometry_msgs::msg::Pose current_pose,
-    const double distance_thresh = 9.0);
+    const double distance_thresh = 5.0);
   bool checkStop(const TrajectoryPoint & closest_point);
   Polygon2d createSelfPolygon();
   Polygon2d createObjPolygon(

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -54,8 +54,12 @@ using TrajectoryPoints = std::vector<TrajectoryPoint>;
 
 enum class State { PASS, STOP };
 
+class SurroundObstacleCheckerNodeTest;
+
 class SurroundObstacleCheckerNode : public rclcpp::Node
 {
+  friend class SurroundObstacleCheckerNodeTest;
+
 public:
   explicit SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options);
 
@@ -79,6 +83,9 @@ private:
   bool isObstacleFound(const double min_dist_to_obj);
   bool isStopRequired(const bool is_obstacle_found, const bool is_stopped);
   size_t getClosestIdx(const TrajectoryPoints & traj, const geometry_msgs::msg::Pose current_pose);
+  size_t getFirstClosestIndex(
+    const TrajectoryPoints & traj, const geometry_msgs::msg::Pose current_pose,
+    const double distance_thresh = 9.0);
   bool checkStop(const TrajectoryPoint & closest_point);
   Polygon2d createSelfPolygon();
   Polygon2d createObjPolygon(
@@ -118,6 +125,7 @@ private:
   double surround_check_recover_distance_;
   double state_clear_time_;
   double stop_state_ego_speed_;
+  double distance_thresh_;
   bool is_surround_obstacle_;
 
   // State Machine

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -32,6 +32,7 @@
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -75,7 +75,7 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     this->declare_parameter("surround_check_recover_distance", 2.5);
   state_clear_time_ = this->declare_parameter("state_clear_time", 2.0);
   stop_state_ego_speed_ = this->declare_parameter("stop_state_ego_speed", 0.1);
-  distance_thresh_ = this->declare_parameter("distance_thresh", 9.0);
+  distance_thresh_ = this->declare_parameter("distance_thresh", 5.0);
   debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
     vehicle_info_.max_longitudinal_offset_m, this->get_clock(), *this);
   self_poly_ = createSelfPolygon();

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -29,6 +29,7 @@
 
 #define EIGEN_MPL2_ONLY
 #include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -74,6 +75,7 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     this->declare_parameter("surround_check_recover_distance", 2.5);
   state_clear_time_ = this->declare_parameter("state_clear_time", 2.0);
   stop_state_ego_speed_ = this->declare_parameter("stop_state_ego_speed", 0.1);
+  distance_thresh_ = this->declare_parameter("distance_thresh", 9.0);
   debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
     vehicle_info_.max_longitudinal_offset_m, this->get_clock(), *this);
   self_poly_ = createSelfPolygon();
@@ -134,7 +136,8 @@ void SurroundObstacleCheckerNode::pathCallback(
   }
 
   // get closest idx
-  const size_t closest_idx = getClosestIdx(output_trajectory_points, current_pose);
+  const size_t closest_idx =
+    getFirstClosestIndex(output_trajectory_points, current_pose, distance_thresh_);
 
   // get nearest object
   double min_dist_to_obj = std::numeric_limits<double>::max();
@@ -263,6 +266,16 @@ size_t SurroundObstacleCheckerNode::getClosestIdx(
     }
   }
   return min_dist_idx;
+}
+
+size_t SurroundObstacleCheckerNode::getFirstClosestIndex(
+  const TrajectoryPoints & traj, const geometry_msgs::msg::Pose current_pose,
+  const double distance_thresh)
+{
+  if (traj.empty()) {
+    return 0;
+  }
+  return tier4_autoware_utils::findFirstNearestIndex(traj, current_pose.position, distance_thresh);
 }
 
 void SurroundObstacleCheckerNode::getNearestObstacle(

--- a/planning/surround_obstacle_checker/test/src/test_get_first_closest_index.cpp
+++ b/planning/surround_obstacle_checker/test/src/test_get_first_closest_index.cpp
@@ -1,0 +1,106 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "surround_obstacle_checker/node.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+geometry_msgs::msg::Pose makePose(const double x, const double y)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position = tier4_autoware_utils::createPoint(x, y, 0.0);
+  pose.orientation = tier4_autoware_utils::createQuaternionFromRPY(0.0, 0.0, 0.0);
+  return pose;
+}
+
+TrajectoryPoint makeTrajPoint(const double x, const double y)
+{
+  TrajectoryPoint p;
+  p.pose = makePose(x, y);
+  return p;
+}
+
+TrajectoryPoints traj_line()
+{
+  return {
+    makeTrajPoint(0.0, 0.0), makeTrajPoint(1.0, 1.0), makeTrajPoint(2.0, 2.0),
+    makeTrajPoint(3.0, 3.0), makeTrajPoint(4.0, 4.0),
+  };
+}
+
+rclcpp::NodeOptions makeNodeOptions()
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("wheel_radius", 0.5);
+  options.append_parameter_override("wheel_width", 0.2);
+  options.append_parameter_override("wheel_base", 3.0);
+  options.append_parameter_override("wheel_tread", 2.0);
+  options.append_parameter_override("front_overhang", 1.0);
+  options.append_parameter_override("rear_overhang", 1.0);
+  options.append_parameter_override("left_overhang", 0.5);
+  options.append_parameter_override("right_overhang", 0.5);
+  options.append_parameter_override("vehicle_height", 1.5);
+  return options;
+}
+}  // namespace
+
+class SurroundObstacleCheckerNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    node_ = std::make_unique<SurroundObstacleCheckerNode>(makeNodeOptions());
+  }
+
+  void TearDown() override { node_.reset(); }
+
+  size_t getFirstClosestIndex(
+    const TrajectoryPoints & traj, const geometry_msgs::msg::Pose & pose,
+    const double distance_thresh)
+  {
+    return node_->getFirstClosestIndex(traj, pose, distance_thresh);
+  }
+
+  std::unique_ptr<SurroundObstacleCheckerNode> node_;
+};
+
+TEST_F(SurroundObstacleCheckerNodeTest, getFirstClosestIndex_01)
+{
+  const auto traj = traj_line();
+  const auto pose = makePose(2.0, 2.0);
+  EXPECT_EQ(getFirstClosestIndex(traj, pose, 9.0), 2u);
+}
+
+TEST_F(SurroundObstacleCheckerNodeTest, getFirstClosestIndex_02)
+{
+  const TrajectoryPoints traj;
+  const auto pose = makePose(2.0, 2.0);
+  EXPECT_EQ(getFirstClosestIndex(traj, pose, 9.0), 0u);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
## Description

本件は、経路上の最近傍点探索における不具合の修正である。
ループ経路の重複箇所で、最初に到達する区間ではなく、ループ後の区間を誤検出してしまう不具合を修正する。
例→[internal link](https://tier4.atlassian.net/wiki/spaces/EVA/pages/5366612169)

具体的な変更点は以下である。
- tier4_autoware_utilsにある最近傍探索機能を持った共通関数について、対策版を新規作成
- 影響が大きい箇所について、呼び出し先を対策版に置き換える
- ユニットテスト追加

## Related Links
- [不具合リスクの洗い出し](https://tier4.atlassian.net/wiki/spaces/EVA/pages/5412880720/Index)
- [修正範囲の決定](https://tier4.atlassian.net/browse/AEAP-3961)
- [外部設計チケット](https://tier4.atlassian.net/browse/AEAP-3962)
- [内部設計チケット](https://tier4.atlassian.net/browse/AEAP-3922)

## Test Performed
- 外部設計テストについては[外部設計書](https://tier4.atlassian.net/wiki/spaces/EVA/pages/5440241840/_)に記載
- 内部設計テストについては[内部設計書](https://tier4.atlassian.net/wiki/spaces/EVA/pages/5469602029/_)に記載
- 内部テスト結果は[内部設計チケット](https://tier4.atlassian.net/browse/AEAP-3922)に記載

## Notes for Reviewers
None.
## Interface Changes
None.
## Effects on System Behavior
No Description.