### PR TITLE
feat(trajectory_modifier): port velocity modifier from X2

### DIFF
--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp
   src/trajectory_modifier_plugins/obstacle_stop.cpp
   src/trajectory_modifier_plugins/traffic_light_stop.cpp
+  src/trajectory_modifier_plugins/velocity_modifier.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -3,10 +3,12 @@
     plugin_names:
       - "autoware::trajectory_modifier::plugin::ObstacleStop"
       - "autoware::trajectory_modifier::plugin::TrafficLightStop"
+      - "autoware::trajectory_modifier::plugin::VelocityModifier"
       - "autoware::trajectory_modifier::plugin::StopPointFixer"
     use_stop_point_fixer: true
     use_obstacle_stop: true
     use_traffic_light_stop: true
+    use_velocity_modifier: true
     trajectory_time_step: 0.1 # [s]
 
     # Stop Point Fixer Plugin Parameters
@@ -30,9 +32,6 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
-      nominal_stopping_decel: 1.0 # [m/s^2]
-      maximum_stopping_decel: 4.0 # [m/s^2]
-      stopping_jerk: 3.0 # [m/s^3]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -62,6 +62,7 @@ protected:
 
 private:
   TrajectoryModifierParams::ObstacleStop params_;
+  TrajectoryModifierParams::StoppingConstraints stopping_params_;
 
   std::optional<CollisionPoint> nearest_collision_point_;
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
@@ -1,0 +1,55 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+class VelocityModifier : public TrajectoryModifierPluginBase
+{
+public:
+  VelocityModifier() = default;
+
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override
+  {
+    enabled_ = params.use_velocity_modifier;
+    trajectory_time_step_ = params.trajectory_time_step;
+    params_ = params.stopping_constraints;
+  };
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  TrajectoryModifierParams::StoppingConstraints params_;
+
+  size_t update_velocities(
+    TrajectoryPoints & trajectory, const double jerk, const double decel) const;
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -6,6 +6,7 @@ trajectory_modifier_params:
         autoware::trajectory_modifier::plugin::ObstacleStop,
         autoware::trajectory_modifier::plugin::TrafficLightStop,
         autoware::trajectory_modifier::plugin::StopPointFixer,
+        autoware::trajectory_modifier::plugin::VelocityModifier,
       ]
     description: List of trajectory modifier plugins to load
     read_only: false
@@ -23,6 +24,11 @@ trajectory_modifier_params:
     type: bool
     default_value: true
     description: Enable the use of traffic light stop
+    read_only: false
+  use_velocity_modifier:
+    type: bool
+    default_value: true
+    description: Enable the use of velocity modifier
     read_only: false
   trajectory_time_step:
     type: double
@@ -122,27 +128,6 @@ trajectory_modifier_params:
       description: Distance to maintain from an obstacle when stopped [m]
       validation:
         bounds<>: [0.0, 100.0]
-      read_only: false
-    nominal_stopping_decel:
-      type: double
-      default_value: 1.0
-      description: Nominal deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    maximum_stopping_decel:
-      type: double
-      default_value: 4.0
-      description: Maximum deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    stopping_jerk:
-      type: double
-      default_value: 3.0
-      description: Jerk during stopping [m/s^3]
-      validation:
-        bounds<>: [0.0, 10.0]
       read_only: false
     lateral_margin:
       type: double

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -18,4 +18,10 @@
       Inserts a stop before a traffic-light stop line on red or amber
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::VelocityModifier"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Modifies the velocity of a trajectory to smooth the motion
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -11,7 +11,8 @@
           "description": "List of trajectory modifier plugins to load",
           "default": [
             "autoware::trajectory_modifier::plugin::ObstacleStop",
-            "autoware::trajectory_modifier::plugin::StopPointFixer"
+            "autoware::trajectory_modifier::plugin::StopPointFixer",
+            "autoware::trajectory_modifier::plugin::VelocityModifier"
           ],
           "items": {
             "type": "string"
@@ -25,6 +26,11 @@
         "use_obstacle_stop": {
           "type": "boolean",
           "description": "Enable the obstacle stop modifier plugin",
+          "default": true
+        },
+        "use_velocity_modifier": {
+          "type": "boolean",
+          "description": "Enable the velocity modifier plugin",
           "default": true
         },
         "trajectory_time_step": {
@@ -68,6 +74,31 @@
           "required": [],
           "additionalProperties": false
         },
+        "stopping_constraints": {
+          "type": "object",
+          "properties": {
+            "nominal_deceleration": {
+              "type": "number",
+              "description": "Nominal deceleration during stopping [m/s^2]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "maximum_deceleration": {
+              "type": "number",
+              "description": "Maximum deceleration during stopping [m/s^2]",
+              "default": 4.0,
+              "minimum": 0.0
+            },
+            "jerk_limit": {
+              "type": "number",
+              "description": "Jerk limit during stopping [m/s^3]",
+              "default": 3.0,
+              "minimum": 0.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
         "obstacle_stop": {
           "type": "object",
           "properties": {
@@ -96,21 +127,6 @@
               "description": "Distance to maintain from an obstacle when stopped [m]",
               "default": 6.0,
               "minimum": 0.0
-            },
-            "nominal_stopping_decel": {
-              "type": "number",
-              "description": "Nominal deceleration during stopping [m/s^2]",
-              "default": 1.0
-            },
-            "maximum_stopping_decel": {
-              "type": "number",
-              "description": "Maximum deceleration during stopping [m/s^2]",
-              "default": 4.0
-            },
-            "stopping_jerk": {
-              "type": "number",
-              "description": "Jerk during stopping [m/s^3]",
-              "default": 3.0
             },
             "lateral_margin": {
               "type": "number",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -18,8 +18,7 @@
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
-#include <autoware/trajectory/interpolator/akima_spline.hpp>
-#include <autoware/trajectory/interpolator/interpolator.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
@@ -42,10 +41,6 @@ using utils::obstacle_stop::get_trajectory_shape;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
 
-using autoware::experimental::trajectory::interpolator::AkimaSpline;
-using InterpolationTrajectory =
-  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
-
 void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 {
   const auto node_ptr = get_node_ptr();
@@ -59,6 +54,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
     "~/obstacle_stop/debug/marker", 1);
 
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
@@ -99,6 +95,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 {
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
@@ -153,8 +150,8 @@ bool ObstacleStop::is_trajectory_modification_required(
     debug_data_.trajectory_shape = get_trajectory_shape(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.nominal_stopping_decel,
-      params_.stopping_jerk, params_.stop_margin, params_.lateral_margin);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
+      stopping_params_.jerk_limit, params_.stop_margin, params_.lateral_margin);
   }
 
   check_obstacles(traj_points, input);
@@ -192,8 +189,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
     auto min_stopping_distance = motion_utils::calculate_stop_distance(
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.maximum_stopping_decel,
-      params_.stopping_jerk, 0.0);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
+      stopping_params_.jerk_limit, 0.0);
     if (!min_stopping_distance) min_stopping_distance = 0.0;
     return std::clamp(
       nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
@@ -238,39 +235,6 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   return true;
 }
 
-size_t update_velocities(TrajectoryPoints & trajectory, const double jerk, const double decel)
-{
-  if (trajectory.size() < 2) return 0;
-
-  auto get_vel_accel = [&](
-                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
-    const auto v_ref = ref_point.longitudinal_velocity_mps;
-    const auto a_ref = std::abs(ref_point.acceleration_mps2);
-
-    const auto ds =
-      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
-    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
-    const auto a_curr = std::min(a_ref + da, decel);
-    const auto a_avg = (a_ref + a_curr) / 2.0;
-    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
-    return {v_curr, -1.0 * a_curr};
-  };
-
-  const auto stop_index = trajectory.size() - 1;
-  auto vel_update_start_index = stop_index;
-  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
-    auto & curr = trajectory.at(i);
-    auto & next = trajectory.at(i + 1);
-    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
-
-    if (v_curr >= curr.longitudinal_velocity_mps) break;
-    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
-    curr.acceleration_mps2 = static_cast<float>(a_curr);
-    vel_update_start_index = i;
-  }
-  return vel_update_start_index;
-}
-
 size_t insert_stop_point(
   TrajectoryPoints & trajectory, const double target_stop_point_arc_length,
   const double traj_length)
@@ -304,71 +268,12 @@ bool ObstacleStop::apply_stopping(
 {
   if (target_stop_point_arc_length < 1e-3) return false;
 
-  auto trajectory = traj_points;
-
   const auto stop_index = insert_stop_point(
-    trajectory, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
+    traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
 
-  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
-  trajectory.back().longitudinal_velocity_mps = 0.0;
-  trajectory.back().acceleration_mps2 = 0.0;
-
-  constexpr double min_v_ref = 1.0;
-  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
-  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * target_stop_point_arc_length));
-  const auto jerk = std::abs(params_.stopping_jerk);
-  const auto decel = std::clamp(
-    required_decel, std::abs(params_.nominal_stopping_decel),
-    std::abs(params_.maximum_stopping_decel));
-
-  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
-  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
-
-  auto trajectory_interpolation_util =
-    InterpolationTrajectory::Builder{}
-      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
-      .set_longitudinal_velocity_interpolator<AkimaSpline>()
-      .build(trajectory);
-  if (!trajectory_interpolation_util) {
-    RCLCPP_WARN_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Failed to build interpolation trajectory");
-    return false;
-  }
-
-  const auto dt = trajectory_time_step_;
-
-  if (dt < 1e-3) {
-    RCLCPP_ERROR_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Invalid trajectory time step: %f, unable to interpolate trajectory", dt);
-    traj_points = std::move(trajectory);
-    return true;
-  }
-
-  const auto s_max = trajectory_interpolation_util->length();
-  const auto interpolate_start_arc_length =
-    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
-  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
-  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
-  double s_curr{interpolate_start_arc_length};
-  while (s_curr <= s_max) {
-    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
-    const auto a_curr = traj_points.back().acceleration_mps2;
-    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
-    if (v_curr < 1e-3) break;
-
-    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
-    if (ds < 1e-3) break;
-
-    s_curr += ds;
-    const auto s_clamped = std::min(s_curr, s_max);
-
-    auto p = trajectory_interpolation_util->compute(s_clamped);
-    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
-    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
-    traj_points.push_back(p);
-  }
+  traj_points.erase(traj_points.begin() + stop_index + 1, traj_points.end());
+  traj_points.back().longitudinal_velocity_mps = 0.0;
+  traj_points.back().acceleration_mps2 = 0.0;
 
   return true;
 }
@@ -449,7 +354,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, context_->vehicle_info, active_objects,
       object_decel_map_, input.current_odometry->twist.twist.linear.x,
-      params_.nominal_stopping_decel, params_.rss_params.reaction_time,
+      stopping_params_.nominal_deceleration, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.rss_params.min_vel_th, debug_data_.target_polygons,
       colliding_object);
   });

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <autoware/trajectory/interpolator/akima_spline.hpp>
+#include <autoware/trajectory/interpolator/interpolator.hpp>
+#include <autoware/trajectory/trajectory_point.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+using autoware::experimental::trajectory::interpolator::AkimaSpline;
+using InterpolationTrajectory =
+  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
+
+void VelocityModifier::on_initialize(const TrajectoryModifierParams & params)
+{
+  enabled_ = params.use_velocity_modifier;
+  trajectory_time_step_ = params.trajectory_time_step;
+  params_ = params.stopping_constraints;
+}
+
+bool VelocityModifier::is_trajectory_modification_required(
+  const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  if (traj_points.size() < 2) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  const auto & stop_point = traj_points.at(stop_idx.value());
+  const auto & prev_point = traj_points.at(stop_idx.value() - 1);
+
+  const auto ds =
+    autoware_utils_geometry::calc_distance2d(stop_point.pose.position, prev_point.pose.position);
+
+  const auto v_prev = prev_point.longitudinal_velocity_mps;
+
+  static constexpr double epsilon = 1e-3;
+  if (ds < epsilon) return v_prev > epsilon;
+
+  const auto expected_accel = -1.0 * (v_prev * v_prev) / (2.0 * ds);
+  const auto a_prev = prev_point.acceleration_mps2;
+
+  constexpr double tolerance = 0.1;
+  return std::abs(a_prev - expected_accel) > tolerance;
+}
+
+bool VelocityModifier::modify_trajectory(TrajectoryPoints & traj_points, const InputData & input)
+{
+  if (!enabled_ || !is_trajectory_modification_required(traj_points, input)) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  auto trajectory = traj_points;
+
+  trajectory.erase(trajectory.begin() + stop_idx.value() + 1, trajectory.end());
+  trajectory.back().longitudinal_velocity_mps = 0.0;
+  trajectory.back().acceleration_mps2 = 0.0;
+
+  const auto traj_length = motion_utils::calcArcLength(trajectory);
+
+  constexpr double min_v_ref = 1.0;
+  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
+  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * traj_length));
+  const auto jerk = std::abs(params_.jerk_limit);
+  const auto decel = std::clamp(
+    required_decel, std::abs(params_.nominal_deceleration), std::abs(params_.maximum_deceleration));
+
+  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
+  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
+
+  auto trajectory_interpolation_util =
+    InterpolationTrajectory::Builder{}
+      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
+      .set_longitudinal_velocity_interpolator<AkimaSpline>()
+      .build(trajectory);
+  if (!trajectory_interpolation_util) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Failed to build interpolation trajectory");
+    return false;
+  }
+
+  const auto dt = trajectory_time_step_;
+
+  if (dt < 1e-3) {
+    RCLCPP_ERROR_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Invalid trajectory time step: %f, unable to interpolate trajectory",
+      dt);
+    traj_points = std::move(trajectory);
+    return true;
+  }
+
+  const auto s_max = trajectory_interpolation_util->length();
+  const auto interpolate_start_arc_length =
+    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
+  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
+  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
+  double s_curr{interpolate_start_arc_length};
+  while (s_curr <= s_max) {
+    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
+    const auto a_curr = traj_points.back().acceleration_mps2;
+    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
+    if (v_curr < 1e-3) break;
+
+    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
+    if (ds < 1e-3) break;
+
+    s_curr += ds;
+    const auto s_clamped = std::min(s_curr, s_max);
+
+    auto p = trajectory_interpolation_util->compute(s_clamped);
+    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
+    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
+    traj_points.push_back(p);
+  }
+
+  return true;
+}
+
+size_t VelocityModifier::update_velocities(
+  TrajectoryPoints & trajectory, const double jerk, const double decel) const
+{
+  if (trajectory.size() < 2) return 0;
+
+  auto get_vel_accel = [&](
+                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
+    const auto v_ref = ref_point.longitudinal_velocity_mps;
+    const auto a_ref = std::abs(ref_point.acceleration_mps2);
+
+    const auto ds =
+      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
+    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
+    const auto a_curr = std::min(a_ref + da, decel);
+    const auto a_avg = (a_ref + a_curr) / 2.0;
+    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
+    return {v_curr, -1.0 * a_curr};
+  };
+
+  const auto stop_index = trajectory.size() - 1;
+  auto vel_update_start_index = stop_index;
+  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
+    auto & curr = trajectory.at(i);
+    auto & next = trajectory.at(i + 1);
+    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
+
+    if (v_curr >= curr.longitudinal_velocity_mps) break;
+    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
+    curr.acceleration_mps2 = static_cast<float>(a_curr);
+    vel_update_start_index = i;
+  }
+  return vel_update_start_index;
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::VelocityModifier,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -217,15 +217,16 @@ protected:
     params_.use_stop_point_fixer = false;
     params_.trajectory_time_step = 0.1;
 
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+
     auto & p = params_.obstacle_stop;
     p.use_objects = true;
     p.use_pointcloud = true;
     p.enable_stop_for_objects = true;
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
-    p.nominal_stopping_decel = 1.0;
-    p.maximum_stopping_decel = 4.0;
-    p.stopping_jerk = 3.0;
     p.lateral_margin = 0.5;
     p.arrived_distance_threshold = 0.5;
 

--- a/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using autoware::trajectory_modifier::TrajectoryModifierContext;
+using autoware::trajectory_modifier::plugin::InputData;
+using autoware::trajectory_modifier::plugin::TrajectoryPoints;
+using autoware::trajectory_modifier::plugin::VelocityModifier;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+TrajectoryPoint create_trajectory_point(
+  double x, double y, double velocity, double acceleration = 0.0)
+{
+  TrajectoryPoint point;
+  point.pose.position.x = x;
+  point.pose.position.y = y;
+  point.pose.position.z = 0.0;
+  point.pose.orientation.x = 0.0;
+  point.pose.orientation.y = 0.0;
+  point.pose.orientation.z = 0.0;
+  point.pose.orientation.w = 1.0;
+  point.longitudinal_velocity_mps = static_cast<float>(velocity);
+  point.acceleration_mps2 = static_cast<float>(acceleration);
+  return point;
+}
+
+TrajectoryPoints create_constant_velocity_trajectory(
+  double length, double velocity, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_step_change_zero_velocity_trajectory(
+  double length, double default_velocity, double zero_velocity_length, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = x < zero_velocity_length ? default_velocity : 0.0;
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, 0.0));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_constant_deceleration_trajectory(
+  double length, double initial_velocity, double spacing = 1.0)
+{
+  const auto accel = -1.0 * initial_velocity * initial_velocity / (2.0 * length);
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = sqrt(initial_velocity * initial_velocity + 2.0 * accel * x);
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, accel));
+  }
+  return trajectory;
+}
+
+}  // namespace
+
+class VelocityModifierIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+    autoware::test_utils::updateNodeOptions(
+      node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<rclcpp::Node>("test_velocity_modifier_node", node_options);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
+
+    set_up_default_params();
+
+    // Create the context and the plugin once. Tests build per-frame InputData inline,
+    // and inject any required TF directly into context_->tf_buffer.
+    context_ = std::make_shared<TrajectoryModifierContext>(node_.get());
+    plugin_ = std::make_unique<VelocityModifier>();
+    plugin_->initialize("test_velocity_modifier", node_.get(), time_keeper_, context_, params_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    plugin_.reset();
+    context_.reset();
+    node_.reset();
+  }
+
+  void set_up_default_params()
+  {
+    params_.use_velocity_modifier = true;
+    params_.trajectory_time_step = 0.1;
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  std::unique_ptr<VelocityModifier> plugin_;
+  trajectory_modifier_params::Params params_;
+  std::shared_ptr<TrajectoryModifierContext> context_;
+};
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenDisabled)
+{
+  // Arrange
+  params_.use_velocity_modifier = false;
+  plugin_->update_params(params_);
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForEmptyTrajectory)
+{
+  // Arrange
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenNoStopPoint)
+{
+  // Arrange
+  auto trajectory = create_constant_velocity_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForSmoothStoppingTrajectory)
+{
+  // Arrange
+  auto trajectory = create_constant_deceleration_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryModifiedForStepChangeZeroVelocityTrajectory)
+{
+  // Arrange
+  auto trajectory = create_step_change_zero_velocity_trajectory(20.0, 10.0, 15.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_TRUE(modified);
+  EXPECT_NEAR(trajectory.back().longitudinal_velocity_mps, 0.0, 0.1);
+  EXPECT_NEAR(trajectory.back().acceleration_mps2, 0.0, 0.1);
+}


### PR DESCRIPTION
## Summary

- Port the independent `VelocityModifier` plugin from X2.
- Move velocity-profile modification out of `ObstacleStop` to avoid applying it only when an obstacle is detected.
- Preserve the existing XX1-specific TrafficLightStop and RSS behavior.
- Include the integration tests from the source PR.

## Test plan

- [x] `colcon build --packages-select autoware_trajectory_modifier`
- [x] `colcon test --packages-select autoware_trajectory_modifier`
- [ ] CI on this PR
- [ ] Pair with the corresponding launcher configuration

## Notes for reviewers

- Source Universe PR: https://github.com/tier4/autoware_universe/pull/2974
- Source Launcher PR: https://github.com/tier4/autoware_launch.x2/pull/2278
- Unrelated X2 RSS changes are not included; the existing XX1 RSS behavior is preserved.
- I could not create the corresponding `autoware_launch.xx1` PR because I do not have push permission to that repository. The launcher-side change has been prepared and tested locally.

## Stack

1. Checker — #3368
2. TrafficLightStop — #3369
3. Boundary departure — #3370
4. This PR — VelocityModifier
5. Temporal controller — #3371

Depends on #3370. The temporal-controller branch should be rebased on this change.