### PR TITLE
feat(traffic_light_stop, traffic_light_compliance_checker): fix inconsistent amber rejection behavior

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -104,11 +104,11 @@ private:
 
   /// @brief return true if ego can safely pass an amber traffic light
   [[nodiscard]] bool can_pass_amber_light(
-    const int64_t traffic_light_id, const double distance_to_stop_line,
+    const int64_t traffic_light_id, const double distance_from_ego_front,
     const double current_velocity, const double current_acceleration,
     const double time_to_cross_stop_line) const;
 
-  bool is_allow_if_cannot_stop(const double distance_to_cross_point) const;
+  bool is_allow_if_cannot_stop(const double distance_from_ego_front) const;
 
   void cleanup_violation_distance_history(
     const std::vector<StopLineInfo> & red_stop_lines,

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -198,10 +198,12 @@ Violations TrafficLightComplianceChecker::get_red_light_violations(
       }
       distance_to_stop_line += static_cast<double>(boost::geometry::length(segment));
     }
+    const auto ego_front_to_stop_line =
+      distance_to_stop_line - vehicle_info_.max_longitudinal_offset_m;
     if (
       intersection_points.empty() ||
       is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line) ||
-      is_allow_if_cannot_stop(distance_to_stop_line))
+      is_allow_if_cannot_stop(ego_front_to_stop_line))
       continue;
 
     violations.emplace_back(
@@ -224,6 +226,7 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
     lanelet::BasicPoint2d intersection_point;
+    auto crossing_speed = 0.0;
     for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
       lanelet::BasicPoints2d intersection_points;
       const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
@@ -240,6 +243,7 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
       amber_stop_line_crossing_time = autoware::interpolation::lerp(
         rclcpp::Duration(trajectory[i].time_from_start).seconds(),
         rclcpp::Duration(trajectory[i + 1].time_from_start).seconds(), ratio);
+      crossing_speed = trajectory[i].longitudinal_velocity_mps;
       intersection_point = intersection_points.front();
       break;
     }
@@ -252,7 +256,13 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
       continue;
     }
 
-    if (is_allow_if_cannot_stop(distance_to_stop_line)) {
+    const auto ego_front_to_stop_line =
+      distance_to_stop_line - vehicle_info_.max_longitudinal_offset_m;
+    const auto ego_front_crossing_time = std::max(
+      0.0, *amber_stop_line_crossing_time -
+             (vehicle_info_.max_longitudinal_offset_m / std::max(crossing_speed, 1e-3)));
+
+    if (is_allow_if_cannot_stop(ego_front_to_stop_line)) {
       continue;
     }
 
@@ -264,8 +274,8 @@ Violations TrafficLightComplianceChecker::get_amber_light_violations(
                              amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
 
     bool can_pass = can_pass_amber_light(
-      amber_stop_line.traffic_light_id, distance_to_stop_line, current_velocity,
-      current_acceleration, *amber_stop_line_crossing_time);
+      amber_stop_line.traffic_light_id, ego_front_to_stop_line, current_velocity,
+      current_acceleration, ego_front_crossing_time);
 
     if (!is_force_reject && can_pass) continue;
 
@@ -430,8 +440,9 @@ bool TrafficLightComplianceChecker::is_stop_point_within_margin_from_stop_line(
 }
 
 bool TrafficLightComplianceChecker::can_pass_amber_light(
-  const int64_t traffic_light_id, const double distance_to_stop_line, const double current_velocity,
-  const double current_acceleration, const double time_to_cross_stop_line) const
+  const int64_t traffic_light_id, const double distance_from_ego_front,
+  const double current_velocity, const double current_acceleration,
+  const double time_to_cross_stop_line) const
 {
   const double decel_limit = params_.deceleration_limit;
   const double jerk_limit = params_.jerk_limit;
@@ -443,19 +454,17 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
     std::max(0.0, params_.crossing_time_limit - status_tracker_->get_duration(traffic_light_id));
 
   const bool can_stop =
-    distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_to_stop_line;
+    distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_from_ego_front;
   const bool can_pass_in_time = time_to_cross_stop_line <= crossing_time_limit;
   const bool can_pass = !can_stop && can_pass_in_time;
   return can_pass;
 }
 
 bool TrafficLightComplianceChecker::is_allow_if_cannot_stop(
-  const double distance_to_cross_point) const
+  const double distance_from_ego_front) const
 {
   if (!ego_stopping_distance_.has_value() || params_.allow_if_cannot_stop_distance < 1e-3)
     return false;
-  const auto distance_from_ego_front =
-    distance_to_cross_point - vehicle_info_.max_longitudinal_offset_m;
   return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
          distance_from_ego_front < *ego_stopping_distance_ - params_.stop_overshoot_margin;
 }

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -110,20 +110,22 @@
     traffic_light_stop:
       stop_margin: 0.75 # [m]
       stop_for_red_light: true
-      stop_for_amber_light: false
+      stop_for_amber_light: true
       treat_amber_light_as_red: false
       treat_unknown_light_as_red: true
-      enable_arrow_aware_amber_passing: true # allow Green->Amber on turn lanes with mapped static arrow
+      enable_arrow_aware_amber_passing: true # [-] allow Green->Amber on turn lanes with mapped static arrow
       overshoot_tolerance: 0.5 # [m]
       allow_if_cannot_stop_distance: 1.0 # [m]
       min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
       th_stable_duration_unknown: 0.5 # [s]
-      crossing_time_limit: 2.75 # [s]
       amber_rejection:
         th_hysteresis: 0.5 # [s]
         reject_if_stop_detected: true # reject if we detect a previous stop attempt from input trajectory
+        can_stop_decel: 2.8
+        can_stop_jerk: 5.0
+        crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
 
     # Surround Obstacle Stop Plugin Parameters
     surround_obstacle_stop:

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -36,6 +36,8 @@ using autoware::trajectory_processor::plugin::ProcessingResult;
 using autoware::trajectory_processor::plugin::TrajectoryPoints;
 using autoware::trajectory_processor::plugin::TrajectoryProcessorPluginBase;
 using ModifierParams = trajectory_processor_params::Params;
+using autoware::traffic_light_compliance_checker::Violation;
+using autoware::traffic_light_compliance_checker::ViolationType;
 using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using visualization_msgs::msg::MarkerArray;
@@ -62,7 +64,7 @@ private:
   ModifierParams::TrafficLightStop params_;
   ModifierParams::StoppingConstraints stopping_params_;
 
-  std::optional<autoware::traffic_light_compliance_checker::Violation> nearest_violation_;
+  std::optional<Violation> nearest_violation_;
 
   std::unique_ptr<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>
     checker_;
@@ -73,6 +75,7 @@ private:
     size_t violations_count = 0;
     double nearest_violation_arc_length = 0.0;
     double stop_point_arc_length = 0.0;
+    ViolationType nearest_violation_type;
   } debug_data_;
 
   rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -107,6 +107,13 @@ trajectory_processor_params:
       read_only: false
       validation:
         bounds<>: [0.0, 10.0]
+    delay_response_time:
+      type: double
+      default_value: 0.5
+      description: Delay response time used to estimate the minimum ego stopping distance [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
     arrived_distance_threshold:
       type: double
       default_value: 0.5
@@ -574,13 +581,6 @@ trajectory_processor_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
-    crossing_time_limit:
-      type: double
-      default_value: 2.75
-      description: Crossing time limit [s]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
     amber_rejection:
       th_hysteresis:
         type: double
@@ -593,6 +593,27 @@ trajectory_processor_params:
         type: bool
         default_value: true
         description: Reject if we detect a previous stop attempt from input trajectory
+        read_only: false
+      can_stop_decel:
+        type: double
+        default_value: 2.8
+        description: Deceleration threshold for ego vehicle to stop [m/s^2]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      can_stop_jerk:
+        type: double
+        default_value: 5.0
+        description: Jerk threshold for ego vehicle to stop [m/s^3]
+        validation:
+          bounds<>: [0.0, 100.0]
+        read_only: false
+      crossing_time_limit:
+        type: double
+        default_value: 2.75
+        description: Crossing time limit [s]
+        validation:
+          bounds<>: [0.0, 10.0]
         read_only: false
   use_akima_spline_interpolation:
     type: bool

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -117,6 +117,12 @@
               "default": 3,
               "minimum": 0
             },
+            "delay_response_time": {
+              "type": "number",
+              "description": "Delay response time used to estimate the minimum ego stopping distance [s]",
+              "default": 0.5,
+              "minimum": 0
+            },
             "arrived_distance_threshold": {
               "type": "number",
               "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
@@ -803,12 +809,41 @@
               "default": 0.5,
               "minimum": 0
             },
-            "crossing_time_limit": {
-              "type": "number",
-              "description": "Crossing time limit [s]",
-              "default": 2.75,
-              "minimum": 0
-            }
+            "amber_rejection": {
+              "type": "object",
+              "properties": {
+                "th_hysteresis": {
+                  "type": "number",
+                  "description": "Threshold for amber rejection hysteresis [s]",
+                  "default": 0.5,
+                  "minimum": 0
+                },
+                "reject_if_stop_detected": {
+                  "type": "boolean",
+                  "description": "Reject if we detect a previous stop attempt from input trajectory",
+                  "default": true
+                },
+                "can_stop_decel": {
+                  "type": "number",
+                  "description": "Deceleration threshold for ego vehicle to stop [m/s^2]",
+                  "default": 2.8,
+                  "minimum": 0
+                },
+                "can_stop_jerk": {
+                  "type": "number",
+                  "description": "Jerk threshold for ego vehicle to stop [m/s^3]",
+                  "default": 5.0,
+                  "minimum": 0
+                },
+                "crossing_time_limit": {
+                  "type": "number",
+                  "description": "Crossing time limit [s]",
+                  "default": 2.75,
+                  "minimum": 0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
           },
           "required": [],
           "additionalProperties": false

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -29,17 +29,17 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   const auto tl_stop_p = params.traffic_light_stop;
   const auto stopping_params = params.stopping_constraints;
   autoware::traffic_light_compliance_checker::Parameters p{};
-  p.deceleration_limit = stopping_params.maximum_deceleration;
-  p.jerk_limit = stopping_params.jerk_limit;
-  p.delay_response_time = 0.0;
-  p.crossing_time_limit = tl_stop_p.crossing_time_limit;
+  p.deceleration_limit = tl_stop_p.amber_rejection.can_stop_decel;
+  p.jerk_limit = tl_stop_p.amber_rejection.can_stop_jerk;
+  p.delay_response_time = stopping_params.delay_response_time;
+  p.crossing_time_limit = tl_stop_p.amber_rejection.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.enable_arrow_aware_amber_passing = tl_stop_p.enable_arrow_aware_amber_passing;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
-  p.ego_stopped_velocity_threshold = 0.01;
+  p.ego_stopped_velocity_threshold = 0.05;
   p.status_tracker_parameters.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.status_tracker_parameters.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.status_tracker_parameters.stable_duration_threshold_unknown =
@@ -116,7 +116,7 @@ bool TrafficLightStop::check_traffic_lights(
     input.lanelet_map,
     *input.route,
     *input.traffic_light_signals,
-    get_clock()->now(),
+    rclcpp::Time(input.current_odometry->header.stamp),
     input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x};
 
@@ -135,6 +135,7 @@ bool TrafficLightStop::check_traffic_lights(
 
   debug_data_.violations_count = result->violations.size();
   debug_data_.nearest_violation_arc_length = nearest_it->arc_length_to_cross_point;
+  debug_data_.nearest_violation_type = nearest_it->type;
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,
@@ -216,6 +217,8 @@ void TrafficLightStop::publish_debug_string() const
        << "VIOLATIONS: " << debug_data_.violations_count << "\n";
     ss << "\t\t"
        << "NEAREST VIOLATION: " << debug_data_.nearest_violation_arc_length << " m"
+       << " (" << (debug_data_.nearest_violation_type == ViolationType::RED_LIGHT ? "RED" : "AMBER")
+       << ")"
        << "\n";
     ss << "\t\t"
        << "STOP POINT: " << debug_data_.stop_point_arc_length << " m"

--- a/planning/autoware_trajectory_processor/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_traffic_light_stop_integration.cpp
@@ -251,7 +251,7 @@ protected:
     tl.th_stable_duration_unknown = 0.0;
     tl.amber_rejection.th_hysteresis = 0.0;
     tl.amber_rejection.reject_if_stop_detected = false;
-    tl.crossing_time_limit = 2.75;
+    tl.amber_rejection.crossing_time_limit = 2.75;
   }
 
   void create_and_set_map(lanelet::Id light_id, double stop_line_x)
@@ -509,7 +509,7 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithAmberLightWhenPrev
   params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
   params_.traffic_light_stop.overshoot_tolerance = 0.5;
   params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
-  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  params_.traffic_light_stop.amber_rejection.crossing_time_limit = 100.0;
   plugin_->update_params(params_);
 
   const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
@@ -539,7 +539,7 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryNotModifiedWhenRejectIfStopDet
   params_.traffic_light_stop.amber_rejection.th_hysteresis = 5.0;
   params_.traffic_light_stop.overshoot_tolerance = 0.5;
   params_.traffic_light_stop.allow_if_cannot_stop_distance = 0.0;
-  params_.traffic_light_stop.crossing_time_limit = 100.0;
+  params_.traffic_light_stop.amber_rejection.crossing_time_limit = 100.0;
   plugin_->update_params(params_);
 
   const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;


### PR DESCRIPTION
## Description
Following changes are applied to compliance checker:
  - Pass `ego_front_to_stop_line` distance to `is_allow_if_cannot_stop()` instead of raw `distance_to_stop_line`
  - Pass `ego_front_to_stop_line` distance to `can_pass_amber_light()` instead of raw `distance_to_stop_line`
  - Pass `ego_front_crossing_time` to `can_pass_amber_light()` instead of raw `amber_stop_line_crossing_time`

Following changes are applied to traffic_light_stop:
- modify `traffic_light_stop` config to be consistent with traffic_light_filter
- update `trajectory_processor_parameter_struct.yaml` and `trajectory_processor.schema.yaml`
- update integration tests
- add `delay_response_time` param

## How was this PR tested:
- LSIM

## Related Links

- [Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2852)