### PR TITLE
chore: sync v4.4.0.1 hotfix

### DIFF
--- a/control/autoware_control_command_gate/src/command/source.hpp
+++ b/control/autoware_control_command_gate/src/command/source.hpp
@@ -42,10 +42,10 @@ protected:
   void send_gear(const GearCommand & msg);
   void send_turn_indicators(const TurnIndicatorsCommand & msg);
   void send_hazard_lights(const HazardLightsCommand & msg);
-
-private:
   const uint16_t source_id_;
   const std::string source_name_;
+
+private:
   CommandOutput * output_;
   std::unique_ptr<TimeoutDiag> timeout_;
 };

--- a/control/autoware_control_command_gate/src/command/subscription.cpp
+++ b/control/autoware_control_command_gate/src/command/subscription.cpp
@@ -19,8 +19,18 @@
 namespace autoware::control_command_gate
 {
 
+bool validate_command(const Control & msg)
+{
+  if (!std::isfinite(msg.longitudinal.velocity)) return false;
+  if (!std::isfinite(msg.longitudinal.acceleration)) return false;
+  if (!std::isfinite(msg.longitudinal.jerk)) return false;
+  if (!std::isfinite(msg.lateral.steering_tire_angle)) return false;
+  if (!std::isfinite(msg.lateral.steering_tire_rotation_rate)) return false;
+  return true;
+}
+
 CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, rclcpp::Node & node)
-: CommandSource(id, name)
+: CommandSource(id, name), clock_(node.get_clock()), logger_(node.get_logger())
 {
   using std::placeholders::_1;
   const auto control_qos = rclcpp::QoS(5);
@@ -41,6 +51,12 @@ CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, 
 
 void CommandSubscription::on_control(const Control & msg)
 {
+  // NOTE: The control command filter does not handle NaN.
+  if (!validate_command(msg)) {
+    RCLCPP_ERROR_STREAM_THROTTLE(logger_, *clock_, 1000, "invalid control from " + source_name_);
+    return;
+  }
+
   // NOTE: Control does not need to be saved because it is sent periodically.
   send_control(msg);
 }

--- a/control/autoware_control_command_gate/src/command/subscription.hpp
+++ b/control/autoware_control_command_gate/src/command/subscription.hpp
@@ -36,6 +36,8 @@ private:
   void on_turn_indicators(const TurnIndicatorsCommand & msg);
   void on_hazard_lights(const HazardLightsCommand & msg);
 
+  rclcpp::Clock::SharedPtr clock_;
+  rclcpp::Logger logger_;
   rclcpp::Subscription<Control>::SharedPtr sub_control_;
   rclcpp::Subscription<GearCommand>::SharedPtr sub_gear_;
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr sub_turn_indicators_;

--- a/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
@@ -59,14 +59,27 @@ CommandModeDeciderBase::CommandModeDeciderBase(const rclcpp::NodeOptions & optio
   }
   is_modes_ready_ = false;
   command_mode_status_.init(command_modes);
-  system_request_.operation_mode = declare_parameter<uint16_t>("initial_operation_mode");
-  system_request_.autoware_control = declare_parameter<bool>("initial_autoware_control");
 
-  curr_autoware_control_ = false;
-  curr_manual_control_ = false;
-  curr_operation_mode_ = autoware::command_mode_types::modes::unknown;
-  curr_mode_ = autoware::command_mode_types::modes::unknown;
-  last_mode_ = system_request_.operation_mode;
+  // The operation_mode and autoware_control represent the states of the respective gates.
+  // On the other hand, the curr_mode_ and last_mode_ are composite states of these.
+  {
+    const auto operation_mode = declare_parameter<uint16_t>("initial_operation_mode");
+    const auto autoware_control = declare_parameter<bool>("initial_autoware_control");
+
+    if (operation_mode == autoware::command_mode_types::modes::manual) {
+      throw std::invalid_argument(
+        "initial_operation_mode must not be manual, use initial_autoware_control=false instead");
+    }
+
+    system_request_.operation_mode = operation_mode;
+    system_request_.autoware_control = autoware_control;
+
+    curr_autoware_control_ = false;
+    curr_manual_control_ = false;
+    curr_operation_mode_ = autoware::command_mode_types::modes::unknown;
+    curr_mode_ = autoware::command_mode_types::modes::unknown;
+    last_mode_ = autoware_control ? operation_mode : autoware::command_mode_types::modes::manual;
+  }
 
   request_stamp_ = std::nullopt;
   transition_stamp_ = std::nullopt;


### PR DESCRIPTION
v4.4.0.1にhotfixとして入れた2件のcherry-pickです。
redundancy_switcher_interface側でも類似対応してるためhashを同時に更新を推奨
https://github.com/tier4/redundancy_switcher_interface/pull/154