### PR TITLE
feat(trajectory_processor): add new MapVelocityLimits plugin

### DIFF
--- a/planning/autoware_trajectory_processor/CMakeLists.txt
+++ b/planning/autoware_trajectory_processor/CMakeLists.txt
@@ -146,6 +146,7 @@ ament_auto_add_library(autoware_trajectory_modifier_plugins SHARED
   src/trajectory_modifier_plugins/velocity_modifier.cpp
   src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
   src/trajectory_modifier_plugins/traffic_light_stop.cpp
+  src/trajectory_modifier_plugins/map_velocity_limits.cpp
 )
 
 target_link_libraries(autoware_trajectory_modifier_plugins

--- a/planning/autoware_trajectory_processor/README.md
+++ b/planning/autoware_trajectory_processor/README.md
@@ -161,6 +161,22 @@ All modifier plugins must inherit from `TrajectoryProcessorPluginBase` and imple
 
 #### Current Plugins
 
+##### MapVelocityLimits
+
+The `autoware::trajectory_processor::plugin::MapVelocityLimits` plugin caps each trajectory point's longitudinal velocity at the map velocity limit for its position. It uses the route and raw lanelet map to build an extended route handler, reuses it while the route message pointer is unchanged, and rebuilds it when a new route message is used.
+
+Optional smoothing raises velocities that cannot be reached from the current forward velocity using the nominal deceleration. It uses the distance along the trajectory from the current odometry position and the constant-deceleration relation `v² = v_current² - 2 × deceleration × distance`. This can temporarily exceed map limits while the vehicle slows down. Points behind the vehicle and negative velocities are left unchanged by smoothing.
+
+| Parameter                                                          | Default | Description                                                       |
+| ------------------------------------------------------------------ | ------- | ----------------------------------------------------------------- |
+| `use_map_velocity_limits`                                          | `true`  | Enable the plugin when included in `plugin_names`.                |
+| `map_velocity_limits.enable_smoothing`                             | `true`  | Enable constant-deceleration smoothing after applying map limits. |
+| `stopping_constraints.nominal_deceleration`                        | `1.0`   | Shared nominal deceleration used for smoothing, in m/s².          |
+| `map_velocity_limits.limit_velocity_from_map_debug_lanelet_ids`    | `[]`    | Lanelet IDs whose map limits are overridden for debugging.        |
+| `map_velocity_limits.limit_velocity_from_map_debug_max_velocities` | `[]`    | Corresponding override velocities in m/s.                         |
+
+The debug arrays must have equal lengths, lanelet IDs must be unique, and override velocities must be finite and non-negative. Setting `map_velocity_limits.enable_smoothing` to `false` keeps map limiting active without smoothing. Place this plugin before stop-enforcing plugins if their stop velocities must be preserved.
+
 ##### Stop Point Fixer
 
 The Stop Point Fixer plugin addresses trajectory issues when the ego vehicle is stationary or moving at very low speeds. It prevents problematic trajectory points that could cause planning issues by replacing the trajectory with a single stop point when either of two independently configurable conditions is met:

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     # Complete plugin execution order: modifiers followed by optimizers.
     plugin_names:
+      - "autoware::trajectory_processor::plugin::MapVelocityLimits"
       - "autoware::trajectory_processor::plugin::TrajectoryTimeSequenceRawOptimizer"
       - "autoware::trajectory_processor::plugin::StopPointFixer"
       - "autoware::trajectory_processor::plugin::SurroundObstacleStop"
@@ -18,6 +19,9 @@
       - "autoware::trajectory_processor::plugin::TrajectorySplineSmoother"
       - "autoware::trajectory_processor::plugin::TrajectoryMPTOptimizer"
       - "autoware::trajectory_processor::plugin::TrajectoryExtender"
+    use_map_velocity_limits: true
+    map_velocity_limits:
+      enable_smoothing: true
     use_stop_point_fixer: true
     use_obstacle_stop: true
     use_traffic_light_stop: true
@@ -176,3 +180,7 @@
       hysteresis_distance: 0.1
       hysteresis_time: 0.2
       ego_stopped_vel_th: 0.1 # [m/s]
+
+  map_velocity_limits:
+    limit_velocity_from_map_debug_lanelet_ids: [0]
+    limit_velocity_from_map_debug_max_velocities: [0]

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -181,6 +181,6 @@
       hysteresis_time: 0.2
       ego_stopped_vel_th: 0.1 # [m/s]
 
-  map_velocity_limits:
-    limit_velocity_from_map_debug_lanelet_ids: [0]
-    limit_velocity_from_map_debug_max_velocities: [0]
+    map_velocity_limits:
+      limit_velocity_from_map_debug_lanelet_ids: [0]
+      limit_velocity_from_map_debug_max_velocities: [1000.0]

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/map_velocity_limits.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/map_velocity_limits.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__MAP_VELOCITY_LIMITS_HPP_
+#define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__MAP_VELOCITY_LIMITS_HPP_
+
+#include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
+#include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
+
+#include <autoware/avoidance_target_detector/boundary.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+namespace autoware::trajectory_processor::plugin
+{
+using autoware::trajectory_processor::TrajectoryProcessorData;
+using autoware::trajectory_processor::TrajectoryProcessorParams;
+using autoware::trajectory_processor::plugin::ProcessingResult;
+using autoware::trajectory_processor::plugin::TrajectoryPoints;
+using autoware::trajectory_processor::plugin::TrajectoryProcessorPluginBase;
+using ModifierParams = trajectory_processor_params::Params;
+
+class MapVelocityLimits : public TrajectoryProcessorPluginBase
+{
+public:
+  MapVelocityLimits() = default;
+
+  ProcessingResult process(
+    TrajectoryPoints & traj_points, TrajectoryProcessorData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, [[maybe_unused]] const TrajectoryProcessorData & input);
+
+  void update_params(const TrajectoryProcessorParams & params) override;
+
+protected:
+  std::shared_ptr<autoware::avoidance_target_detector::ExtendedRouteHandler>
+    extended_route_handler_;
+  autoware::avoidance_target_detector::ExtendedRouteHandler::VelocityLimitOverrides
+    limit_overrides_;
+  double constant_deceleration_;
+  bool enable_smoothing_{true};
+
+  void on_initialize(const TrajectoryProcessorParams & params) override;
+};
+
+}  // namespace autoware::trajectory_processor::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__MAP_VELOCITY_LIMITS_HPP_

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/map_velocity_limits.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/map_velocity_limits.hpp
@@ -41,11 +41,12 @@ public:
     TrajectoryPoints & traj_points, TrajectoryProcessorData & input) override;
 
   [[nodiscard]] bool is_trajectory_modification_required(
-    const TrajectoryPoints & traj_points, [[maybe_unused]] const TrajectoryProcessorData & input);
+    const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input);
 
   void update_params(const TrajectoryProcessorParams & params) override;
 
 protected:
+  autoware_planning_msgs::msg::LaneletRoute::_uuid_type previous_route_uuid_;
   std::shared_ptr<autoware::avoidance_target_detector::ExtendedRouteHandler>
     extended_route_handler_;
   autoware::avoidance_target_detector::ExtendedRouteHandler::VelocityLimitOverrides

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_avoidance_target_detector</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -2,6 +2,7 @@ trajectory_processor_params:
   plugin_names:
     type: string_array
     default_value:
+      - autoware::trajectory_processor::plugin::MapVelocityLimits
       - autoware::trajectory_processor::plugin::StopPointFixer
       - autoware::trajectory_processor::plugin::SurroundObstacleStop
       - autoware::trajectory_processor::plugin::ObstacleStop
@@ -18,6 +19,11 @@ trajectory_processor_params:
       - autoware::trajectory_processor::plugin::TrajectoryMPTOptimizer
       - autoware::trajectory_processor::plugin::TrajectoryExtender
     description: Ordered list of trajectory processor plugin class names
+    read_only: false
+  use_map_velocity_limits:
+    type: bool
+    default_value: true
+    description: Enable the use of map velocity limits
     read_only: false
   use_stop_point_fixer:
     type: bool
@@ -1400,4 +1406,21 @@ trajectory_processor_params:
       description: Yaw threshold for ego nearest search [rad]
       validation:
         bounds<>: [0.0, 3.14]
+      read_only: false
+
+  map_velocity_limits:
+    enable_smoothing:
+      type: bool
+      default_value: true
+      description: Smooth unreachable velocities with constant deceleration from the current velocity
+      read_only: false
+    limit_velocity_from_map_debug_lanelet_ids:
+      type: int_array
+      default_value: []
+      description: Lanelet IDs whose map velocity limits are overridden when map limiting is enabled
+      read_only: false
+    limit_velocity_from_map_debug_max_velocities:
+      type: double_array
+      default_value: []
+      description: Finite non-negative debug maximum velocities in m/s aligned with the lanelet IDs
       read_only: false

--- a/planning/autoware_trajectory_processor/plugins.xml
+++ b/planning/autoware_trajectory_processor/plugins.xml
@@ -96,5 +96,11 @@
         Modifies the trajectory to stop at traffic lights
       </description>
     </class>
+    <class type="autoware::trajectory_processor::plugin::MapVelocityLimits"
+          base_class_type="autoware::trajectory_processor::plugin::TrajectoryProcessorPluginBase">
+      <description>
+        Modifies the velocity of a trajectory to respect the velocity limits from the map
+      </description>
+    </class>
   </library>
 </class_libraries>

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -6,6 +6,29 @@
     "trajectory_processor": {
       "type": "object",
       "properties": {
+        "map_velocity_limits": {
+          "type": "object",
+          "properties": {
+            "enable_smoothing": {
+              "type": "boolean",
+              "default": true,
+              "description": "Smooth unreachable velocities with constant deceleration from the current velocity"
+            },
+            "limit_velocity_from_map_debug_lanelet_ids": {
+              "type": "array",
+              "items": { "type": "integer" },
+              "default": [],
+              "description": "Lanelet IDs whose map velocity limits are overridden when map limiting is enabled"
+            },
+            "limit_velocity_from_map_debug_max_velocities": {
+              "type": "array",
+              "items": { "type": "number", "minimum": 0.0 },
+              "default": [],
+              "description": "Finite non-negative debug maximum velocities in m/s aligned with the lanelet IDs"
+            }
+          },
+          "additionalProperties": false
+        },
         "plugin_names": {
           "type": "array",
           "description": "Ordered list of modifier and optimizer plugin class names",
@@ -29,6 +52,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "use_map_velocity_limits": {
+          "type": "boolean",
+          "description": "Enable the map velocity limits plugin",
+          "default": true
         },
         "use_stop_point_fixer": {
           "type": "boolean",
@@ -844,6 +872,7 @@
               },
               "required": [],
               "additionalProperties": false
+            }
           },
           "required": [],
           "additionalProperties": false

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
@@ -1,0 +1,139 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_processor/trajectory_modifier_plugins/map_velocity_limits.hpp"
+
+#include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/trajectory/trajectory_point.hpp>
+
+#include <cmath>
+#include <memory>
+
+namespace autoware::trajectory_processor::plugin
+{
+
+namespace
+{
+autoware::avoidance_target_detector::ExtendedRouteHandler::VelocityLimitOverrides
+make_velocity_limit_overrides(const TrajectoryProcessorParams & params)
+{
+  autoware::avoidance_target_detector::ExtendedRouteHandler::VelocityLimitOverrides overrides;
+  const auto & ids = params.map_velocity_limits.limit_velocity_from_map_debug_lanelet_ids;
+  const auto & velocities = params.map_velocity_limits.limit_velocity_from_map_debug_max_velocities;
+  if (ids.size() != velocities.size()) {
+    throw std::invalid_argument(
+      "limit_velocity_from_map_debug_lanelet_ids and "
+      "limit_velocity_from_map_debug_max_velocities must have equal lengths");
+  }
+  for (std::size_t index = 0; index < ids.size(); ++index) {
+    if (!std::isfinite(velocities[index]) || velocities[index] < 0.0) {
+      throw std::invalid_argument(
+        "limit_velocity_from_map_debug_max_velocities must contain finite non-negative values");
+    }
+    if (!overrides.emplace(ids[index], velocities[index]).second) {
+      throw std::invalid_argument(
+        "limit_velocity_from_map_debug_lanelet_ids must not contain duplicates");
+    }
+  }
+  return overrides;
+}
+}  // namespace
+
+void MapVelocityLimits::on_initialize(const TrajectoryProcessorParams & params)
+{
+  update_params(params);
+}
+
+void MapVelocityLimits::update_params(const TrajectoryProcessorParams & params)
+{
+  enabled_ = params.use_map_velocity_limits;
+  limit_overrides_ = make_velocity_limit_overrides(params);
+  constant_deceleration_ = params.stopping_constraints.nominal_deceleration;
+  enable_smoothing_ = params.map_velocity_limits.enable_smoothing;
+}
+
+bool MapVelocityLimits::is_trajectory_modification_required(
+  [[maybe_unused]] const TrajectoryPoints & traj_points,
+  [[maybe_unused]] const TrajectoryProcessorData & input)
+{
+  // TODO(Maxime): store the previous input.route and recreate the handler whenever a new route is
+  // used
+  if (!extended_route_handler_) {
+    extended_route_handler_ =
+      std::make_shared<autoware::avoidance_target_detector::ExtendedRouteHandler>(
+        *input.lanelet_map_bin, *input.route);
+    extended_route_handler_->create_map();
+  }
+  return true;
+}
+
+ProcessingResult MapVelocityLimits::process(
+  TrajectoryPoints & traj_points, TrajectoryProcessorData & input)
+{
+  ProcessingResult result = ProcessingResult::Unchanged;
+  if (!enabled_ || !is_trajectory_modification_required(traj_points, input)) {
+    return result;
+  }
+  for (auto & point : traj_points) {
+    const auto map_velocity_limit =
+      extended_route_handler_->get_velocity_limit(point.pose.position, limit_overrides_);
+    if (
+      map_velocity_limit && std::isfinite(*map_velocity_limit) &&
+      point.longitudinal_velocity_mps > *map_velocity_limit) {
+      point.longitudinal_velocity_mps = static_cast<float>(*map_velocity_limit);
+      result = ProcessingResult::Modified;
+    }
+  }
+  if (!enable_smoothing_) {
+    return result;
+  }
+  const auto current_velocity = input.current_odometry->twist.twist.linear.x;
+  if (traj_points.size() < 2 || current_velocity <= 0.0) {
+    return result;
+  }
+
+  auto distance = motion_utils::calcSignedArcLength(
+    traj_points, input.current_odometry->pose.pose.position, size_t{0});
+  const auto velocity_squared = current_velocity * current_velocity;
+  const auto twice_deceleration = 2.0 * std::abs(constant_deceleration_);
+  for (size_t i = 0; i < traj_points.size(); ++i) {
+    auto & point = traj_points[i];
+    if (i > 0) {
+      const auto & previous_position = traj_points[i - 1].pose.position;
+      distance += std::hypot(
+        point.pose.position.x - previous_position.x, point.pose.position.y - previous_position.y);
+    }
+    if (distance < 0.0) {
+      continue;
+    }
+    const auto reachable_velocity_squared = velocity_squared - twice_deceleration * distance;
+    if (reachable_velocity_squared <= 0.0) {
+      break;
+    }
+    const auto velocity = point.longitudinal_velocity_mps;
+    if (velocity >= 0.0 && velocity * velocity < reachable_velocity_squared) {
+      point.longitudinal_velocity_mps = static_cast<float>(std::sqrt(reachable_velocity_squared));
+      result = ProcessingResult::Modified;
+    }
+  }
+  return result;
+}
+}  // namespace autoware::trajectory_processor::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_processor::plugin::MapVelocityLimits,
+  autoware::trajectory_processor::plugin::TrajectoryProcessorPluginBase)

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
@@ -68,6 +68,9 @@ void MapVelocityLimits::update_params(const TrajectoryProcessorParams & params)
 bool MapVelocityLimits::is_trajectory_modification_required(
   [[maybe_unused]] const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
 {
+  if (!input.lanelet_map_bin || !input.route) {
+    return false;
+  }
   if (!extended_route_handler_ || previous_route_uuid_ != input.route->uuid) {
     auto handler = std::make_shared<autoware::avoidance_target_detector::ExtendedRouteHandler>(
       *input.lanelet_map_bin, *input.route);

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/map_velocity_limits.cpp
@@ -66,16 +66,14 @@ void MapVelocityLimits::update_params(const TrajectoryProcessorParams & params)
 }
 
 bool MapVelocityLimits::is_trajectory_modification_required(
-  [[maybe_unused]] const TrajectoryPoints & traj_points,
-  [[maybe_unused]] const TrajectoryProcessorData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
 {
-  // TODO(Maxime): store the previous input.route and recreate the handler whenever a new route is
-  // used
-  if (!extended_route_handler_) {
-    extended_route_handler_ =
-      std::make_shared<autoware::avoidance_target_detector::ExtendedRouteHandler>(
-        *input.lanelet_map_bin, *input.route);
-    extended_route_handler_->create_map();
+  if (!extended_route_handler_ || previous_route_uuid_ != input.route->uuid) {
+    auto handler = std::make_shared<autoware::avoidance_target_detector::ExtendedRouteHandler>(
+      *input.lanelet_map_bin, *input.route);
+    handler->create_map();
+    extended_route_handler_ = handler;
+    previous_route_uuid_ = input.route->uuid;
   }
   return true;
 }


### PR DESCRIPTION
**Description**
This PR introduces the `MapVelocityLimits` plugin to the trajectory processor pipeline. It ensures that the ego vehicle respects speed limits defined in the lanelet map while maintaining safe and comfortable deceleration.

**Key Features:**

* **Map Limit Enforcement:** Caps the longitudinal velocity of each trajectory point based on the map's speed limit for that position.
* **Kinematic Smoothing:** Includes an optional smoothing mechanism using constant deceleration. If a map speed limit drops abruptly and cannot be reached safely from the current speed, the plugin temporarily overrides the map limit to prevent aggressive, physically unfeasible braking.
* **Debug Support:** Exposes parameters to override specific lanelet velocity limits for easy debugging and simulation testing.

*Note: This plugin is added to the beginning of the pipeline so that downstream stop-planning plugins (like traffic lights or obstacle stops) can still enforce their target `0.0` velocities without interference.*

https://github.com/user-attachments/assets/008b7994-6abc-4f51-a023-35f2ba9ecae1


