### PR TITLE
fix(boundary_departure): align footprint to match ego pose

### DIFF
--- a/common/autoware_boundary_departure_checker/README.md
+++ b/common/autoware_boundary_departure_checker/README.md
@@ -33,14 +33,15 @@ The module uses a structured parameter configuration to define thresholds, footp
 
 ## 5. Process Overview
 
-1. **Footprint Generation:** The module generates geometric footprints for the ego vehicle at every point along the candidate trajectory. It expands the footprint size using margins to account for localization uncertainty.
-2. **Boundary Extraction and Filtering:** Uncrossable boundaries (e.g., `road_border`) are extracted from the Lanelet2 map and stored in a spatial R-tree. Boundaries significantly above or below the vehicle's Z-axis height are filtered out to prevent false positives from overpasses.
-3. **Distance Calculation:** The system calculates the shortest lateral distance from the left and right footprint segments to the nearest filtered boundary.
-4. **Severity Evaluation:** A minimum physical braking distance is dynamically calculated using current speed, acceleration, maximum allowed deceleration, jerk, and brake delay. The departure severity is assigned as follows:
+1. **Ego pose alignment:** The trajectory start states the pose that the ego vehicle holds now, and localization measures that pose. The module moves the trajectory start onto the measured pose, and the correction decreases to nothing over the front overhang. A trajectory point inside that distance sits under the front body of the ego vehicle, ahead of no wheel, so the ego vehicle cannot have steered there yet. The trajectory therefore keeps its own shape and its own heading changes, and a trajectory that already starts at the measured pose does not change. A pose error from the trajectory generator therefore cannot raise a departure near the ego vehicle, and a measured departure still raises one. The module takes the align distance from the vehicle, so the distance has no parameter. The `enable_align_to_ego_pose` parameter turns the alignment off, and the module then evaluates the trajectory that the generator gives.
+2. **Footprint Generation:** The module generates geometric footprints for the ego vehicle at every point along the candidate trajectory. It expands the footprint size using margins to account for localization uncertainty.
+3. **Boundary Extraction and Filtering:** Uncrossable boundaries (e.g., `road_border`) are extracted from the Lanelet2 map and stored in a spatial R-tree. Boundaries significantly above or below the vehicle's Z-axis height are filtered out to prevent false positives from overpasses.
+4. **Distance Calculation:** The system calculates the shortest lateral distance from the left and right footprint segments to the nearest filtered boundary.
+5. **Severity Evaluation:** A minimum physical braking distance is dynamically calculated using current speed, acceleration, maximum allowed deceleration, jerk, and brake delay. The departure severity is assigned as follows:
    - **NONE:** The footprint lateral distance is greater than the critical lateral margin.
    - **APPROACHING:** A departure is detected, but it is farther than the braking distance AND the time to departure is greater than the cutoff threshold.
    - **CRITICAL:** A departure is detected within the braking distance OR before the cutoff time expires.
-5. **Hysteresis Logic:** To ensure stability, an **ON-Time buffer** suppresses the `CRITICAL` state until the departure is continuously detected for a set duration. If a collision is imminent, this buffer is bypassed. An **OFF-Time buffer** ensures the status does not revert to `NONE` until the trajectory is continuously evaluated as safe.
+6. **Hysteresis Logic:** To ensure stability, an **ON-Time buffer** suppresses the `CRITICAL` state until the departure is continuously detected for a set duration. If a collision is imminent, this buffer is bypassed. An **OFF-Time buffer** ensures the status does not revert to `NONE` until the trajectory is continuously evaluated as safe.
 
 ## 6. Possible Scenarios and Expected Behavior
 

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/debug.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/debug.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
 #include "autoware/boundary_departure_checker/detail/hysteresis_logic.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -24,6 +25,18 @@ namespace autoware::boundary_departure_checker::debug
 {
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
+
+/**
+ * @brief Create a marker that shows the footprints that the alignment to the ego pose changes.
+ * @param[in] aligned_footprints footprints after the alignment
+ * @param[in] aligned_count number of leading footprints that the alignment changes
+ * @param[in] curr_time current time
+ * @param[in] base_link_z z-coordinate of the base_link
+ * @return array of markers for visualization
+ */
+MarkerArray create_pose_alignment_markers(
+  const footprints::Footprints & aligned_footprints, const size_t aligned_count,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z);
 
 /**
  * @brief Create debug markers for boundary departure.
@@ -34,7 +47,8 @@ using visualization_msgs::msg::MarkerArray;
  */
 MarkerArray create_debug_markers(
   const HysteresisState & hysteresis_state, const footprints::Footprints & footprints,
-  const EgoDynamicState & ego_state, const bool enable_developer_marker);
+  const size_t aligned_count, const EgoDynamicState & ego_state,
+  const bool enable_developer_marker);
 }  // namespace autoware::boundary_departure_checker::debug
 
 #endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DEBUG_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
@@ -43,7 +43,7 @@ struct FootprintMargin
  * @brief Give the number of leading trajectory points within an arc length from the start.
  * @param[in] trajectory_points points along the trajectory
  * @param[in] dist_m arc length from the trajectory start [m]
- * @return number of leading points inside the arc length
+ * @return number of points ahead of ego's baselink
  */
 size_t count_points_within_distance(
   const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m);

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
@@ -40,24 +40,33 @@ struct FootprintMargin
 };
 
 /**
- * @brief Give the number of leading trajectory points within an arc length from the start.
+ * @brief Extent of the ego pose alignment along a trajectory.
+ */
+struct FootprintAlignment
+{
+  double align_dist_m{0.0};  ///< arc length over which the alignment applies [m]
+  size_t align_count{0};     ///< number of leading points that the alignment covers
+};
+
+/**
+ * @brief Give the alignment extent for the leading trajectory points within an arc length.
  * @param[in] trajectory_points points along the trajectory
  * @param[in] dist_m arc length from the trajectory start [m]
- * @return number of points ahead of ego's baselink
+ * @return alignment arc length and the number of leading points it covers
  */
-size_t count_points_within_distance(
+FootprintAlignment count_points_within_distance(
   const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m);
 
 /**
  * @brief Correct the trajectory poses near the ego vehicle to start at the measured ego pose.
  * @param[in] trajectory_points points along the trajectory
  * @param[in] ego_pose measured ego pose
- * @param[in] align_dist_m arc length over which the alignment applies [m]
+ * @param[in] expected_alignment extent of the alignment from the trajectory start
  * @return trajectory points with the poses near the ego vehicle corrected
  */
 std::vector<TrajectoryPoint> align_to_ego_pose(
   const std::vector<TrajectoryPoint> & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
-  const double align_dist_m);
+  const FootprintAlignment expected_alignment);
 
 /**
  * @brief Generate vehicle footprints along a trajectory.

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
@@ -40,6 +40,26 @@ struct FootprintMargin
 };
 
 /**
+ * @brief Give the number of leading trajectory points within an arc length from the start.
+ * @param[in] trajectory_points points along the trajectory
+ * @param[in] dist_m arc length from the trajectory start [m]
+ * @return number of leading points inside the arc length
+ */
+size_t count_points_within_distance(
+  const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m);
+
+/**
+ * @brief Correct the trajectory poses near the ego vehicle to start at the measured ego pose.
+ * @param[in] trajectory_points points along the trajectory
+ * @param[in] ego_pose measured ego pose
+ * @param[in] align_dist_m arc length over which the alignment applies [m]
+ * @return trajectory points with the poses near the ego vehicle corrected
+ */
+std::vector<TrajectoryPoint> align_to_ego_pose(
+  const std::vector<TrajectoryPoint> & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
+  const double align_dist_m);
+
+/**
  * @brief Generate vehicle footprints along a trajectory.
  * @param[in] trajectory_points points along the trajectory
  * @param[in] vehicle_info information about the vehicle

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -36,7 +36,8 @@ struct UncrossableBoundaryDepartureParam
   double time_to_departure_cutoff_s{2.0};  ///< time to departure cutoff [s]
   double on_time_buffer_s{0.15};           ///< buffer for activating departure detection [s]
   double off_time_buffer_s{0.15};          ///< buffer for deactivating departure detection [s]
-  bool enable_developer_marker{true};      ///< flag marker only for developer
+  bool enable_align_to_ego_pose{true};  ///< align trajectory poses to match the measured ego pose
+  bool enable_developer_marker{true};   ///< flag marker only for developer
   std::vector<std::string> boundary_types_to_detect{"road_border"};  ///< boundary types to detect
 };
 }  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/package.xml
+++ b/common/autoware_boundary_departure_checker/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory</depend>

--- a/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
+++ b/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
@@ -57,6 +57,11 @@
           "description": "Continuous safe detection time required to clear a departure alert [s].",
           "default": 0.15
         },
+        "enable_align_to_ego_pose": {
+          "type": "boolean",
+          "description": "Correct the trajectory poses near the ego vehicle to match the measured ego pose.",
+          "default": true
+        },
         "enable_developer_marker": {
           "type": "boolean",
           "description": "Enable advanced debug markers for developers.",

--- a/common/autoware_boundary_departure_checker/src/detail/debug.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/debug.cpp
@@ -24,6 +24,7 @@
 
 #include <std_msgs/msg/detail/color_rgba__struct.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 
@@ -215,9 +216,36 @@ MarkerArray create_virtual_wall_marker(
   return marker_array;
 }
 
+MarkerArray create_pose_alignment_markers(
+  const footprints::Footprints & aligned_footprints, const size_t aligned_count,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+{
+  MarkerArray marker_array;
+  const auto count = std::min(aligned_count, aligned_footprints.size());
+  if (count == 0) {
+    return marker_array;
+  }
+
+  auto marker = autoware_utils_visualization::create_default_marker(
+    "map", curr_time, "aligned_footprint", 0, Marker::LINE_LIST,
+    autoware_utils_visualization::create_marker_scale(0.05, 0.0, 0.0), color::aqua());
+
+  for (size_t idx = 0; idx < count; ++idx) {
+    const auto & footprint = aligned_footprints.at(idx);
+    for (size_t i = 0; i + 1 < footprint.size(); ++i) {
+      marker.points.push_back(autoware_utils_geometry::to_msg(footprint.at(i).to_3d(base_link_z)));
+      marker.points.push_back(
+        autoware_utils_geometry::to_msg(footprint.at(i + 1).to_3d(base_link_z)));
+    }
+  }
+  marker_array.markers.push_back(marker);
+
+  return marker_array;
+}
+
 MarkerArray create_debug_markers(
   const HysteresisState & hysteresis_state, const footprints::Footprints & footprints,
-  const EgoDynamicState & ego_state, const bool enable_developer_marker)
+  const size_t aligned_count, const EgoDynamicState & ego_state, const bool enable_developer_marker)
 {
   builtin_interfaces::msg::Time curr_time = std::invoke([&ego_state]() {
     const auto current_time_s = ego_state.current_time_s;
@@ -254,6 +282,10 @@ MarkerArray create_debug_markers(
       marker_array.markers.push_back(
         create_projected_segment_bound_marker(side_value, side_str, curr_time, base_link_z));
     });
+
+  autoware_utils_visualization::append_marker_array(
+    create_pose_alignment_markers(footprints, aligned_count, curr_time, base_link_z),
+    &marker_array);
 
   return marker_array;
 }

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -45,14 +45,14 @@ FootprintMargin calc_margin_from_covariance(
 size_t count_points_within_distance(
   const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m)
 {
- if (dist_m <= 0.0 || trajectory_points.empty()) {
+  if (dist_m <= 0.0 || trajectory_points.empty()) {
     return 0;
   }
 
   double accumulated_dist = 0.0;
   for (size_t i = 1; i < trajectory_points.size(); ++i) {
-    accumulated_dist += autoware_utils_geometry::calc_distance2d(
-      trajectory_points[i - 1], trajectory_points[i]);
+    accumulated_dist +=
+      autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
 
     if (accumulated_dist > dist_m) return i;
   }
@@ -71,8 +71,8 @@ std::vector<TrajectoryPoint> align_to_ego_pose(
 
   const auto & start_pose = trajectory_points.front().pose;
   const auto start_yaw = tf2::getYaw(start_pose.orientation);
-  const auto yaw_correction_rad = angles::shortest_angular_distance(
-    tf2::getYaw(ego_pose.orientation), start_yaw);
+  const auto yaw_correction_rad =
+    angles::shortest_angular_distance(tf2::getYaw(ego_pose.orientation), start_yaw);
   const auto x_correction_m = ego_pose.position.x - start_pose.position.x;
   const auto y_correction_m = ego_pose.position.y - start_pose.position.y;
 

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -45,24 +45,19 @@ FootprintMargin calc_margin_from_covariance(
 size_t count_points_within_distance(
   const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m)
 {
-  if (dist_m <= 0.0) {
+ if (dist_m <= 0.0 || trajectory_points.empty()) {
     return 0;
   }
 
-  auto arc_length_m = 0.0;
-  size_t count = 0;
-  for (size_t i = 0; i < trajectory_points.size(); ++i) {
-    if (i > 0) {
-      arc_length_m +=
-        autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
-    }
+  double accumulated_dist = 0.0;
+  for (size_t i = 1; i < trajectory_points.size(); ++i) {
+    accumulated_dist += autoware_utils_geometry::calc_distance2d(
+      trajectory_points[i - 1], trajectory_points[i]);
 
-    if (arc_length_m > dist_m) {
-      break;
-    }
-    ++count;
+    if (accumulated_dist > dist_m) return i;
   }
-  return count;
+
+  return trajectory_points.size();
 }
 
 std::vector<TrajectoryPoint> align_to_ego_pose(

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
 
+#include <angles/angles.h>
+
 #include <vector>
 
 namespace autoware::boundary_departure_checker::footprints
@@ -42,11 +44,11 @@ FootprintMargin calc_margin_from_covariance(
   return FootprintMargin{cov_xy_vehicle(0, 0) * scale, cov_xy_vehicle(1, 1) * scale};
 }
 
-size_t count_points_within_distance(
+FootprintAlignment count_points_within_distance(
   const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m)
 {
   if (dist_m <= 0.0 || trajectory_points.empty()) {
-    return 0;
+    return {dist_m, 0UL};
   }
 
   double accumulated_dist = 0.0;
@@ -54,38 +56,38 @@ size_t count_points_within_distance(
     accumulated_dist +=
       autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
 
-    if (accumulated_dist > dist_m) return i;
+    if (accumulated_dist >= dist_m) return {dist_m, i};
   }
 
-  return trajectory_points.size();
+  return {dist_m, trajectory_points.size()};
 }
 
 std::vector<TrajectoryPoint> align_to_ego_pose(
   const std::vector<TrajectoryPoint> & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
-  const double align_dist_m)
+  const FootprintAlignment expected_alignment)
 {
   auto aligned_points = trajectory_points;
-  if (aligned_points.empty() || align_dist_m <= 0.0) {
+  if (
+    aligned_points.empty() || expected_alignment.align_dist_m <= 0.0 ||
+    expected_alignment.align_count == 0) {
     return aligned_points;
   }
 
   const auto & start_pose = trajectory_points.front().pose;
   const auto start_yaw = tf2::getYaw(start_pose.orientation);
   const auto yaw_correction_rad =
-    angles::shortest_angular_distance(tf2::getYaw(ego_pose.orientation), start_yaw);
+    angles::shortest_angular_distance(start_yaw, tf2::getYaw(ego_pose.orientation));
   const auto x_correction_m = ego_pose.position.x - start_pose.position.x;
   const auto y_correction_m = ego_pose.position.y - start_pose.position.y;
 
-  const auto aligned_count = count_points_within_distance(trajectory_points, align_dist_m);
-
   auto arc_length_m = 0.0;
-  for (size_t i = 0; i < aligned_count; ++i) {
+  for (size_t i = 0; i < expected_alignment.align_count; ++i) {
     if (i > 0) {
       arc_length_m +=
         autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
     }
 
-    const auto weight = 1.0 - arc_length_m / align_dist_m;
+    const auto weight = 1.0 - arc_length_m / expected_alignment.align_dist_m;
     auto & pose = aligned_points[i].pose;
     pose.position.x += weight * x_correction_m;
     pose.position.y += weight * y_correction_m;

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -41,6 +41,66 @@ FootprintMargin calc_margin_from_covariance(
 
   return FootprintMargin{cov_xy_vehicle(0, 0) * scale, cov_xy_vehicle(1, 1) * scale};
 }
+
+size_t count_points_within_distance(
+  const std::vector<TrajectoryPoint> & trajectory_points, const double dist_m)
+{
+  if (dist_m <= 0.0) {
+    return 0;
+  }
+
+  auto arc_length_m = 0.0;
+  size_t count = 0;
+  for (size_t i = 0; i < trajectory_points.size(); ++i) {
+    if (i > 0) {
+      arc_length_m +=
+        autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
+    }
+
+    if (arc_length_m > dist_m) {
+      break;
+    }
+    ++count;
+  }
+  return count;
+}
+
+std::vector<TrajectoryPoint> align_to_ego_pose(
+  const std::vector<TrajectoryPoint> & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
+  const double align_dist_m)
+{
+  auto aligned_points = trajectory_points;
+  if (aligned_points.empty() || align_dist_m <= 0.0) {
+    return aligned_points;
+  }
+
+  const auto & start_pose = trajectory_points.front().pose;
+  const auto start_yaw = tf2::getYaw(start_pose.orientation);
+  const auto yaw_difference = tf2::getYaw(ego_pose.orientation) - start_yaw;
+  const auto yaw_correction_rad = std::atan2(std::sin(yaw_difference), std::cos(yaw_difference));
+  const auto x_correction_m = ego_pose.position.x - start_pose.position.x;
+  const auto y_correction_m = ego_pose.position.y - start_pose.position.y;
+
+  const auto aligned_count = count_points_within_distance(trajectory_points, align_dist_m);
+
+  auto arc_length_m = 0.0;
+  for (size_t i = 0; i < aligned_count; ++i) {
+    if (i > 0) {
+      arc_length_m +=
+        autoware_utils_geometry::calc_distance2d(trajectory_points[i - 1], trajectory_points[i]);
+    }
+
+    const auto weight = 1.0 - arc_length_m / align_dist_m;
+    auto & pose = aligned_points[i].pose;
+    pose.position.x += weight * x_correction_m;
+    pose.position.y += weight * y_correction_m;
+    pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(
+      tf2::getYaw(trajectory_points[i].pose.orientation) + weight * yaw_correction_rad);
+  }
+
+  return aligned_points;
+}
+
 // clang-format off
 /**
  * footprints::generate:

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -71,8 +71,8 @@ std::vector<TrajectoryPoint> align_to_ego_pose(
 
   const auto & start_pose = trajectory_points.front().pose;
   const auto start_yaw = tf2::getYaw(start_pose.orientation);
-  const auto yaw_difference = tf2::getYaw(ego_pose.orientation) - start_yaw;
-  const auto yaw_correction_rad = std::atan2(std::sin(yaw_difference), std::cos(yaw_difference));
+  const auto yaw_correction_rad = angles::shortest_angular_distance(
+    tf2::getYaw(ego_pose.orientation), start_yaw);
   const auto x_correction_m = ego_pose.position.x - start_pose.position.x;
   const auto y_correction_m = ego_pose.position.y - start_pose.position.y;
 

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -50,7 +50,7 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
   }
 
   // An align distance of zero leaves the trajectory that the generator gives.
-  const auto align_dist_m = param_.enable_align_to_ego_pose ? vehicle_info_.front_overhang_m : 0.0;
+  const auto align_dist_m = param_.enable_align_to_ego_pose ? vehicle_info_.max_longitudinal_offset_m : 0.0;
   const auto aligned_traj =
     footprints::align_to_ego_pose(predicted_traj, ego_state.pose_with_cov.pose, align_dist_m);
 

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -49,12 +49,17 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
     return result;
   }
 
+  // An align distance of zero leaves the trajectory that the generator gives.
+  const auto align_dist_m = param_.enable_align_to_ego_pose ? vehicle_info_.front_overhang_m : 0.0;
+  const auto aligned_traj =
+    footprints::align_to_ego_pose(predicted_traj, ego_state.pose_with_cov.pose, align_dist_m);
+
   const auto footprints =
-    footprints::generate(predicted_traj, vehicle_info_, ego_state.pose_with_cov);
+    footprints::generate(aligned_traj, vehicle_info_, ego_state.pose_with_cov);
   const auto footprints_sides = footprints::get_sides_from_footprints(footprints);
 
   const auto evaluation_result =
-    evaluator_ptr_->evaluate(predicted_traj, footprints_sides, ego_state);
+    evaluator_ptr_->evaluate(aligned_traj, footprints_sides, ego_state);
 
   const auto hysteresis_result =
     update_and_judge(state, evaluation_result, param_, ego_state.current_time_s);
@@ -78,8 +83,10 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
       severity_evaluator::get_min_lateral_distance_to_bound(*evaluation_result);
   }
 
-  result.debug_markers =
-    debug::create_debug_markers(state, footprints, ego_state, param_.enable_developer_marker);
+  const auto aligned_count = footprints::count_points_within_distance(predicted_traj, align_dist_m);
+
+  result.debug_markers = debug::create_debug_markers(
+    state, footprints, aligned_count, ego_state, param_.enable_developer_marker);
   return result;
 }
 

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -50,7 +50,8 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
   }
 
   // An align distance of zero leaves the trajectory that the generator gives.
-  const auto align_dist_m = param_.enable_align_to_ego_pose ? vehicle_info_.max_longitudinal_offset_m : 0.0;
+  const auto align_dist_m =
+    param_.enable_align_to_ego_pose ? vehicle_info_.max_longitudinal_offset_m : 0.0;
   const auto aligned_traj =
     footprints::align_to_ego_pose(predicted_traj, ego_state.pose_with_cov.pose, align_dist_m);
 

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -52,8 +52,10 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
   // An align distance of zero leaves the trajectory that the generator gives.
   const auto align_dist_m =
     param_.enable_align_to_ego_pose ? vehicle_info_.max_longitudinal_offset_m : 0.0;
+  const auto expected_alignment =
+    footprints::count_points_within_distance(predicted_traj, align_dist_m);
   const auto aligned_traj =
-    footprints::align_to_ego_pose(predicted_traj, ego_state.pose_with_cov.pose, align_dist_m);
+    footprints::align_to_ego_pose(predicted_traj, ego_state.pose_with_cov.pose, expected_alignment);
 
   const auto footprints =
     footprints::generate(aligned_traj, vehicle_info_, ego_state.pose_with_cov);
@@ -84,10 +86,8 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
       severity_evaluator::get_min_lateral_distance_to_bound(*evaluation_result);
   }
 
-  const auto aligned_count = footprints::count_points_within_distance(predicted_traj, align_dist_m);
-
   result.debug_markers = debug::create_debug_markers(
-    state, footprints, aligned_count, ego_state, param_.enable_developer_marker);
+    state, footprints, expected_alignment.align_count, ego_state, param_.enable_developer_marker);
   return result;
 }
 

--- a/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
@@ -24,6 +24,20 @@
 
 namespace autoware::boundary_departure_checker
 {
+UncrossableBoundaryDepartureParam create_default_param()
+{
+  UncrossableBoundaryDepartureParam param;
+  param.critical_departure_lateral_th_m = 0.01;  // [m]
+  param.on_time_buffer_s = 0.15;   // 150ms of continuous violation to trigger CRITICAL
+  param.off_time_buffer_s = 0.15;  // 150ms of continuous safety to clear CRITICAL
+  param.max_deceleration_mps2 = -4.0;
+  param.max_jerk_mps3 = -5.0;
+  param.brake_delay_s = 1.0;
+  param.time_to_departure_cutoff_s = 3.0;
+  param.boundary_types_to_detect = {"road_border"};
+  return param;
+}
+
 UncrossableBoundaryChecker create_default_checker()
 {
   // 1. Setup Vehicle Info (Standard Sedan Size)
@@ -41,15 +55,7 @@ UncrossableBoundaryChecker create_default_checker()
   );
 
   // 2. Param
-  UncrossableBoundaryDepartureParam param;
-  param.critical_departure_lateral_th_m = 0.01;  // [m]
-  param.on_time_buffer_s = 0.15;   // 150ms of continuous violation to trigger CRITICAL
-  param.off_time_buffer_s = 0.15;  // 150ms of continuous safety to clear CRITICAL
-  param.max_deceleration_mps2 = -4.0;
-  param.max_jerk_mps3 = -5.0;
-  param.brake_delay_s = 1.0;
-  param.time_to_departure_cutoff_s = 3.0;
-  param.boundary_types_to_detect = {"road_border"};
+  const auto param = create_default_param();
 
   // 3. Create a LaneletMap with a straight road border at Y = 2.0
   auto map = std::make_shared<lanelet::LaneletMap>();
@@ -130,7 +136,121 @@ TEST(UncrossableBoundaryCheckerTest, TestCheckDepartureZeroVelocity)
 }
 
 // ==============================================================================
-// 2. Hysteresis and Time Buffering Tests
+// 2. Ego Pose Alignment Tests
+// ==============================================================================
+
+TrajectoryPoints create_stacked_trajectory(const double x, const double y, const double yaw)
+{
+  TrajectoryPoints traj;
+  for (int i = 0; i < 5; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = x;
+    p.pose.position.y = y;
+    p.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+    const double time = i * 0.5;
+    p.time_from_start.sec = static_cast<int32_t>(time);
+    p.time_from_start.nanosec = static_cast<uint32_t>((time - p.time_from_start.sec) * 1e9);
+    p.longitudinal_velocity_mps = 0.0F;
+    traj.push_back(p);
+  }
+  return traj;
+}
+
+EgoDynamicState create_stopped_ego_state(const double x, const double y, const double yaw)
+{
+  EgoDynamicState state;
+  state.pose_with_cov.pose.position.x = x;
+  state.pose_with_cov.pose.position.y = y;
+  state.pose_with_cov.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+  for (auto & c : state.pose_with_cov.covariance) c = 0.0;
+  state.velocity = 0.0;
+  state.acceleration = 0.0;
+  state.current_time_s = 0.0;
+  return state;
+}
+
+TEST(UncrossableBoundaryCheckerTest, TestAlignToEgoPoseRejectsGeneratorYawError)
+{
+  // 1-line summary: A generator yaw error on a stopped ego raises no critical departure.
+
+  // Arrange: ego clears the boundary by 0.13 m, and the generator yaw puts a corner at Y = 2.09.
+  constexpr double ego_x = 0.0;
+  constexpr double ego_y = -1.45;
+  constexpr double generator_yaw_error_rad = 0.06;
+  auto traj = create_stacked_trajectory(ego_x, ego_y, generator_yaw_error_rad);
+  auto ego_state = create_stopped_ego_state(ego_x, ego_y, 0.0);
+
+  // Act:
+  auto checker = create_default_checker();
+  HysteresisState state;
+  auto result = checker.update_departure_status(traj, ego_state, state);
+
+  // Assert:
+  EXPECT_NE(result.status, DepartureType::CRITICAL);
+}
+
+TEST(UncrossableBoundaryCheckerTest, TestAlignToEgoPoseDisabledKeepsGeneratorPoses)
+{
+  // 1-line summary: With the alignment off, the generator yaw error raises a critical departure.
+  constexpr double ego_x = 0.0;
+  constexpr double ego_y = -1.45;
+  constexpr double generator_yaw_error_rad = 0.06;
+  auto traj = create_stacked_trajectory(ego_x, ego_y, generator_yaw_error_rad);
+  auto ego_state = create_stopped_ego_state(ego_x, ego_y, 0.0);
+
+  // Act:
+  auto checker = create_default_checker();
+  auto param_without_alignment = create_default_param();
+  param_without_alignment.enable_align_to_ego_pose = false;
+  checker.update_parameters(param_without_alignment);
+
+  HysteresisState state;
+  auto result = checker.update_departure_status(traj, ego_state, state);
+
+  // Assert:
+  EXPECT_EQ(result.status, DepartureType::CRITICAL);
+}
+
+TEST(UncrossableBoundaryCheckerTest, TestAlignToEgoPoseKeepsMeasuredDeparture)
+{
+  // 1-line summary: A measured ego pose across the boundary still raises a critical departure.
+  constexpr double ego_x = 0.0;
+  constexpr double ego_y = -1.45;
+  constexpr double measured_yaw_rad = 0.06;
+  auto traj = create_stacked_trajectory(ego_x, ego_y, measured_yaw_rad);
+  auto ego_state = create_stopped_ego_state(ego_x, ego_y, measured_yaw_rad);
+
+  // Act:
+  auto checker = create_default_checker();
+  HysteresisState state;
+  auto result = checker.update_departure_status(traj, ego_state, state);
+
+  // Assert:
+  EXPECT_EQ(result.status, DepartureType::CRITICAL);
+}
+
+TEST(UncrossableBoundaryCheckerTest, TestAlignToEgoPoseKeepsGeneratorPathAwayFromBoundary)
+{
+  // 1-line summary: An ego heading 0.2 rad off a clear trajectory raises no critical departure.
+  constexpr double ego_yaw_offset_rad = 0.2;
+  constexpr double safe_y = -2.5;
+  auto traj = create_trajectory(0.0, safe_y, 10.0, 0.0);
+
+  auto ego_state = create_ego_state(traj, 10.0, 0.0);
+  ego_state.pose_with_cov.pose.orientation =
+    autoware_utils_geometry::create_quaternion_from_yaw(ego_yaw_offset_rad);
+
+  // Act:
+  auto checker = create_default_checker();
+  HysteresisState state;
+  auto result = checker.update_departure_status(traj, ego_state, state);
+
+  // Assert:
+  EXPECT_NE(result.status, DepartureType::CRITICAL);
+}
+
+// ==============================================================================
+// 3. Hysteresis and Time Buffering Tests
 // ==============================================================================
 
 // clang-format off

--- a/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
@@ -97,10 +97,10 @@ TEST_F(FootprintGeneratorTest, TestCountPointsWithinDistance)
   // Arrange: the fixture holds two poses that sit 1.0 m apart.
 
   // Act and assert:
-  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 2.0), 2U);
-  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.5), 1U);
-  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.0), 0U);
-  EXPECT_EQ(footprints::count_points_within_distance(TrajectoryPoints{}, 2.0), 0U);
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 2.0).align_count, 2U);
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.5).align_count, 1U);
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.0).align_count, 0U);
+  EXPECT_EQ(footprints::count_points_within_distance(TrajectoryPoints{}, 2.0).align_count, 0U);
 }
 
 TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseIsNoOpWhenTrajectoryStartsAtEgo)
@@ -111,7 +111,8 @@ TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseIsNoOpWhenTrajectoryStartsAtEgo
   const auto ego_pose = pred_traj_.front().pose;
 
   // Act:
-  const auto aligned = footprints::align_to_ego_pose(pred_traj_, ego_pose, 5.71);
+  const auto aligned = footprints::align_to_ego_pose(
+    pred_traj_, ego_pose, footprints::count_points_within_distance(pred_traj_, 5.71));
 
   // Assert:
   ASSERT_EQ(aligned.size(), pred_traj_.size());
@@ -140,7 +141,8 @@ TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseCorrectsStoppedEgoPoses)
   }
 
   // Act:
-  const auto aligned = footprints::align_to_ego_pose(stopped_traj, ego_pose, 5.71);
+  const auto aligned = footprints::align_to_ego_pose(
+    stopped_traj, ego_pose, footprints::count_points_within_distance(stopped_traj, 5.71));
 
   // Assert:
   ASSERT_EQ(aligned.size(), stopped_traj.size());
@@ -165,7 +167,8 @@ TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseKeepsGeneratorHeadingChanges)
   ego_pose.orientation = create_quaternion_from_yaw(ego_yaw_offset_rad);
 
   // Act: the align distance is 2.0 m, so the second pose keeps half of the correction.
-  const auto aligned = footprints::align_to_ego_pose(turning_traj, ego_pose, 2.0);
+  const auto aligned = footprints::align_to_ego_pose(
+    turning_traj, ego_pose, footprints::count_points_within_distance(turning_traj, 2.0));
 
   // Assert: the turn of the generator survives the correction.
   ASSERT_EQ(aligned.size(), 2U);
@@ -187,7 +190,8 @@ TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseKeepsPosesBeyondTheAlignDistanc
   ego_pose.orientation = create_quaternion_from_yaw(0.0);
 
   // Act:
-  const auto aligned = footprints::align_to_ego_pose(offset_traj, ego_pose, 0.5);
+  const auto aligned = footprints::align_to_ego_pose(
+    offset_traj, ego_pose, footprints::count_points_within_distance(offset_traj, 0.5));
 
   // Assert:
   ASSERT_EQ(aligned.size(), 2U);
@@ -203,7 +207,8 @@ TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseEmptyTrajectory)
   ego_pose.orientation = create_quaternion_from_yaw(0.0);
 
   // Act:
-  const auto aligned = footprints::align_to_ego_pose(empty_traj, ego_pose, 5.71);
+  const auto aligned = footprints::align_to_ego_pose(
+    empty_traj, ego_pose, footprints::count_points_within_distance(empty_traj, 5.71));
 
   // Assert:
   EXPECT_TRUE(aligned.empty());

--- a/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
@@ -25,6 +25,7 @@ namespace autoware::boundary_departure_checker
 {
 namespace
 {
+using autoware_utils_geometry::create_quaternion_from_yaw;
 }  // namespace
 
 class FootprintGeneratorTest : public ::testing::Test
@@ -87,6 +88,125 @@ TEST_F(FootprintGeneratorTest, TestSteeringFootprintGeneratorEmptyTrajectory)
 
   // Assert:
   EXPECT_TRUE(footprints.empty());
+}
+
+TEST_F(FootprintGeneratorTest, TestCountPointsWithinDistance)
+{
+  // 1-line summary: The count covers the leading points inside the arc length from the start.
+
+  // Arrange: the fixture holds two poses that sit 1.0 m apart.
+
+  // Act and assert:
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 2.0), 2U);
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.5), 1U);
+  EXPECT_EQ(footprints::count_points_within_distance(pred_traj_, 0.0), 0U);
+  EXPECT_EQ(footprints::count_points_within_distance(TrajectoryPoints{}, 2.0), 0U);
+}
+
+TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseIsNoOpWhenTrajectoryStartsAtEgo)
+{
+  // 1-line summary: A trajectory that already starts at the measured pose keeps every pose.
+
+  // Arrange: a correction here would overwrite the heading that the generator chose.
+  const auto ego_pose = pred_traj_.front().pose;
+
+  // Act:
+  const auto aligned = footprints::align_to_ego_pose(pred_traj_, ego_pose, 5.71);
+
+  // Assert:
+  ASSERT_EQ(aligned.size(), pred_traj_.size());
+  for (size_t i = 0; i < aligned.size(); ++i) {
+    EXPECT_NEAR(aligned[i].pose.position.x, pred_traj_[i].pose.position.x, 1e-9);
+    EXPECT_NEAR(aligned[i].pose.position.y, pred_traj_[i].pose.position.y, 1e-9);
+    EXPECT_NEAR(
+      tf2::getYaw(aligned[i].pose.orientation), tf2::getYaw(pred_traj_[i].pose.orientation), 1e-9);
+  }
+}
+
+TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseCorrectsStoppedEgoPoses)
+{
+  // 1-line summary: A stopped ego moves every stacked trajectory pose onto its measured pose.
+
+  // Arrange: neither pose advances, so both keep the full correction.
+  geometry_msgs::msg::Pose ego_pose;
+  ego_pose.orientation = create_quaternion_from_yaw(0.0);
+
+  TrajectoryPoints stopped_traj = pred_traj_;
+  for (auto & p : stopped_traj) {
+    p.pose.position.x = 0.0;
+    p.pose.position.y = 0.3;
+    p.pose.orientation = create_quaternion_from_yaw(0.1);
+    p.longitudinal_velocity_mps = 0.0;
+  }
+
+  // Act:
+  const auto aligned = footprints::align_to_ego_pose(stopped_traj, ego_pose, 5.71);
+
+  // Assert:
+  ASSERT_EQ(aligned.size(), stopped_traj.size());
+  for (const auto & p : aligned) {
+    EXPECT_NEAR(p.pose.position.x, 0.0, 1e-9);
+    EXPECT_NEAR(p.pose.position.y, 0.0, 1e-9);
+    EXPECT_NEAR(tf2::getYaw(p.pose.orientation), 0.0, 1e-9);
+  }
+}
+
+TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseKeepsGeneratorHeadingChanges)
+{
+  // 1-line summary: The correction keeps the heading changes that the generator gives.
+
+  // Arrange: the generator turns 0.2 rad over 1.0 m, and ego measures 0.1 rad off at the start.
+  constexpr double generator_turn_rad = 0.2;
+  constexpr double ego_yaw_offset_rad = 0.1;
+  TrajectoryPoints turning_traj = pred_traj_;
+  turning_traj[1].pose.orientation = create_quaternion_from_yaw(generator_turn_rad);
+
+  auto ego_pose = turning_traj.front().pose;
+  ego_pose.orientation = create_quaternion_from_yaw(ego_yaw_offset_rad);
+
+  // Act: the align distance is 2.0 m, so the second pose keeps half of the correction.
+  const auto aligned = footprints::align_to_ego_pose(turning_traj, ego_pose, 2.0);
+
+  // Assert: the turn of the generator survives the correction.
+  ASSERT_EQ(aligned.size(), 2U);
+  EXPECT_NEAR(tf2::getYaw(aligned[0].pose.orientation), ego_yaw_offset_rad, 1e-9);
+  EXPECT_NEAR(
+    tf2::getYaw(aligned[1].pose.orientation), generator_turn_rad + 0.5 * ego_yaw_offset_rad, 1e-9);
+}
+
+TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseKeepsPosesBeyondTheAlignDistance)
+{
+  // 1-line summary: A pose past the align distance keeps the value that the generator gives.
+
+  // Arrange: the second pose sits 1.0 m ahead, past the 0.5 m align distance.
+  TrajectoryPoints offset_traj = pred_traj_;
+  offset_traj[0].pose.position.y = 0.3;
+  offset_traj[1].pose.position.y = 0.3;
+
+  geometry_msgs::msg::Pose ego_pose;
+  ego_pose.orientation = create_quaternion_from_yaw(0.0);
+
+  // Act:
+  const auto aligned = footprints::align_to_ego_pose(offset_traj, ego_pose, 0.5);
+
+  // Assert:
+  ASSERT_EQ(aligned.size(), 2U);
+  EXPECT_NEAR(aligned[0].pose.position.y, 0.0, 1e-9);
+  EXPECT_NEAR(aligned[1].pose.position.y, 0.3, 1e-9);
+}
+
+TEST_F(FootprintGeneratorTest, TestAlignToEgoPoseEmptyTrajectory)
+{
+  // Arrange:
+  TrajectoryPoints empty_traj;
+  geometry_msgs::msg::Pose ego_pose;
+  ego_pose.orientation = create_quaternion_from_yaw(0.0);
+
+  // Act:
+  const auto aligned = footprints::align_to_ego_pose(empty_traj, ego_pose, 5.71);
+
+  // Assert:
+  EXPECT_TRUE(aligned.empty());
 }
 
 TEST_F(FootprintGeneratorTest, TestGetSidesFromFootprintsEmpty)

--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -95,3 +95,4 @@ The input trajectory is detected as invalid if the index exceeds the following t
 | `boundary_departure.on_time_buffer_s`           | double       | continuous-violation time required to activate a critical departure [s]           | 0.20            |
 | `boundary_departure.off_time_buffer_s`          | double       | continuous-safety time required to deactivate a critical departure [s]            | 0.10            |
 | `boundary_departure.enable_developer_marker`    | bool         | if true, publish developer debug markers from the boundary departure checker      | false           |
+| `boundary_departure.enable_align_to_ego_pose`   | bool         | correct the trajectory poses near the ego vehicle to match the measured ego pose  | true            |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -25,6 +25,7 @@
       time_to_departure_cutoff_s: 2.0
       on_time_buffer_s: 0.20
       off_time_buffer_s: 0.10
+      enable_align_to_ego_pose: true
       enable_developer_marker: false
 
     latency_validator:

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -274,6 +274,8 @@ public:
       params.uncrossable_bound_departure_validator.time_to_departure_cutoff_s;
     params_.on_time_buffer_s = params.uncrossable_bound_departure_validator.on_time_buffer_s;
     params_.off_time_buffer_s = params.uncrossable_bound_departure_validator.off_time_buffer_s;
+    params_.enable_align_to_ego_pose =
+      params.uncrossable_bound_departure_validator.enable_align_to_ego_pose;
     params_.enable_developer_marker =
       params.uncrossable_bound_departure_validator.enable_developer_marker;
     params_.boundary_types_to_detect = params.uncrossable_bound_departure_validator.boundary_types;

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -53,6 +53,9 @@ control_validator:
     off_time_buffer_s:
       type: double
       description: Continuous-safety time required to deactivate a critical departure [s].
+    enable_align_to_ego_pose:
+      type: bool
+      description: Correct the trajectory poses near the ego vehicle to match the measured ego pose.
     enable_developer_marker:
       type: bool
       description: If true, publish developer debug markers from the boundary departure checker.

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -155,6 +155,7 @@
     boundary_departure:
       boundary_types: ["road_border"]
       brake_delay_s: 1.0
+      enable_align_to_ego_pose: true
       enable_developer_marker: false
       lateral_margin_m: 0.01
       longitudinal_margin_m: 1.0

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -573,6 +573,11 @@ validator:
       default_value: 0.15
       description: buffer for deactivating departure detection [s]
       read_only: false
+    enable_align_to_ego_pose:
+      type: bool
+      default_value: true
+      description: correct the trajectory poses near the ego vehicle to match the measured ego pose
+      read_only: false
     enable_developer_marker:
       type: bool
       default_value: true

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -783,6 +783,11 @@
               "default": 0.15,
               "minimum": 0.0
             },
+            "enable_align_to_ego_pose": {
+              "type": "boolean",
+              "description": "Correct the trajectory poses near the ego vehicle to match the measured ego pose.",
+              "default": true
+            },
             "enable_developer_marker": {
               "type": "boolean",
               "description": "Publish diagnostic visualization markers intended for developer use.",

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -91,6 +91,7 @@ void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Para
   params_.time_to_departure_cutoff_s = params.boundary_departure.time_to_departure_cutoff_s;
   params_.on_time_buffer_s = params.boundary_departure.on_time_buffer_s;
   params_.off_time_buffer_s = params.boundary_departure.off_time_buffer_s;
+  params_.enable_align_to_ego_pose = params.boundary_departure.enable_align_to_ego_pose;
   params_.enable_developer_marker = params.boundary_departure.enable_developer_marker;
   params_.boundary_types_to_detect = params.boundary_departure.boundary_types;
 


### PR DESCRIPTION
## Description

A stopped vehicle beside a road border reported a critical departure, even though ego vehicle actual footprint stays away from road border.

<img width="500" height="450" alt="image" src="https://github.com/user-attachments/assets/47b01c16-c683-4e7b-9de8-ca89e30375fc" />


The trajectory generator places its poses close to the ego vehicle, but the orientation of the first few poses does not match the measured ego orientation.

This PR corrects the poses the ego vehicle already occupies against the measured pose, decreasing to nothing over the front overhang.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

Tested using 

```
webauto ci scenario run --project-id x2_dev --scenario-id 071f86e7-f0a1-4d5b-b1b0-dc58402a3da5 --scenario-version-id 6 --scenario-parameters __tier4_modifier_npc_speed=4.1667 --simulation-name planning_sim_v2_j6_gen2
```

## Notes for reviewers

The correction moves the poses rather than replacing them. An earlier version replaced them with a roll-out along the measured orientation, which overwrote the orientation the generator chose and blocked engagement.

The distance comes from the front overhang because a pose inside it sits under the front body, ahead of no wheel, so the vehicle cannot have steered there yet. Past that distance the poses carry the steering intent of the generator.

`enable_align_to_ego_pose` is in the schema `properties` and in every config, and deliberately not in the schema `required` lists. A required key that a launcher config in another repository does not supply stops the node from starting.

The launcher config change is a separate PR.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                                                   | Type   | Default Value | Description                                                                      |
| :---------- | :--------------------------------------------------------------- | :----- | :------------ | :------------------------------------------------------------------------------- |
| Added       | `boundary_departure.enable_align_to_ego_pose`                    | `bool` | `true`        | correct the trajectory poses near the ego vehicle to match the measured ego pose |
| Added       | `uncrossable_bound_departure_validator.enable_align_to_ego_pose` | `bool` | `true`        | correct the trajectory poses near the ego vehicle to match the measured ego pose |

## Effects on system behavior

An orientation error from the trajectory generator no longer raises a critical departure near the ego vehicle. A departure measured from the ego pose still raises one.

With `enable_align_to_ego_pose` off the trajectory passes through untouched.

Only the poses inside the align distance are corrected, which is the first pose or two while the vehicle moves. A generator error further along the trajectory still falls inside the `time_to_departure_cutoff_s` window and is unchanged by this PR.