### PR TITLE
feat(trajectory_modifier): add ModelPlanningFactorID plugin

### DIFF
--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -12,6 +12,7 @@ generate_parameter_library(trajectory_modifier_param
 ament_auto_add_library(${PROJECT_NAME}_utils SHARED
   src/trajectory_modifier_utils/utils.cpp
   src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+  src/trajectory_modifier_utils/planning_factor_utils.cpp
 )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -37,6 +38,7 @@ ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/obstacle_stop.cpp
   src/trajectory_modifier_plugins/traffic_light_stop.cpp
   src/trajectory_modifier_plugins/velocity_modifier.cpp
+  src/trajectory_modifier_plugins/model_planning_factor_id.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -98,7 +98,7 @@
 
     # ModelPlanningFactorID Plugin Parameters
     # Inspect the input pose-sequence trajectory (any learning-based planner) and
-    # publish /planning/planning_factors/model_planning_factor_id. Does not mutate the trajectory.
+    # publish /planning/planning_factors/planning_model. Does not mutate the trajectory.
     # Source: autoware_diffusion_planner planning_factor_utils.
     model_planning_factor_id:
       enable_stop: true

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
     plugin_names:
+      - "autoware::trajectory_modifier::plugin::ModelPlanningFactorID"
       - "autoware::trajectory_modifier::plugin::ObstacleStop"
       - "autoware::trajectory_modifier::plugin::TrafficLightStop"
       - "autoware::trajectory_modifier::plugin::VelocityModifier"
@@ -9,6 +10,7 @@
     use_obstacle_stop: true
     use_traffic_light_stop: true
     use_velocity_modifier: true
+    use_model_planning_factor_id: true
     trajectory_time_step: 0.1 # [s]
 
     # Stop Point Fixer Plugin Parameters
@@ -93,3 +95,14 @@
       amber_rejection:
         th_hysteresis: 0.5 # [s]
         reject_if_stop_detected: true
+
+    # ModelPlanningFactorID Plugin Parameters
+    # Inspect the input pose-sequence trajectory (any learning-based planner) and
+    # publish /planning/planning_factors/model_planning_factor_id. Does not mutate the trajectory.
+    # Source: autoware_diffusion_planner planning_factor_utils.
+    model_planning_factor_id:
+      enable_stop: true
+      enable_slowdown: false
+      stop_velocity_threshold: 0.1       # [m/s]
+      stop_keep_duration_threshold: 1.0  # [s]
+      slowdown_accel_threshold: -0.3     # [m/s^2]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -98,7 +98,8 @@
 
     # ModelPlanningFactorID Plugin Parameters
     # Inspect the input pose-sequence trajectory (any learning-based planner) and
-    # publish /planning/planning_factors/planning_model. Does not mutate the trajectory.
+    # publish /planning/planning_factors/planning_model (launch remaps to
+    # /planning/planning_factors/neural_network_planner). Does not mutate.
     # Source: autoware_diffusion_planner planning_factor_utils.
     model_planning_factor_id:
       enable_stop: true

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__MODEL_PLANNING_FACTOR_ID_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__MODEL_PLANNING_FACTOR_ID_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp"
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+/**
+ * @brief Inspection-only plugin that labels stop / slowdown implied by the planner trajectory.
+ *
+ * Learning-based planners (diffusion, tensorrt e2e, …) emit a pose sequence without an
+ * explicit planning-factor. This plugin reads the *input* trajectory kinematics, does not
+ * mutate points, and publishes `/planning/planning_factors/model_planning_factor_id`.
+ *
+ * Load it first in `plugin_names` so labels describe the raw model output, not later
+ * ObstacleStop / TrafficLightStop insertions.
+ */
+class ModelPlanningFactorID : public TrajectoryModifierPluginBase
+{
+public:
+  ModelPlanningFactorID() = default;
+
+  /**
+   * @brief Detect stop/slowdown and queue planning factors. Never mutates @p traj_points.
+   * @return Always false (inspection only). The host still publishes queued factors.
+   */
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override;
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  void apply_params(const TrajectoryModifierParams & params);
+  void add_detected_factors(const TrajectoryPoints & traj_points);
+
+  TrajectoryModifierParams::ModelPlanningFactorId params_{};
+  utils::PlanningFactorDetectionConfig detection_config_{};
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__MODEL_PLANNING_FACTOR_ID_HPP_

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
@@ -26,7 +26,8 @@ namespace autoware::trajectory_modifier::plugin
  *
  * Learning-based planners (diffusion, tensorrt e2e, …) emit a pose sequence without an
  * explicit planning-factor. This plugin reads the *input* trajectory kinematics, does not
- * mutate points, and publishes `/planning/planning_factors/planning_model`.
+ * mutate points, and publishes `/planning/planning_factors/planning_model`
+ * (launch remaps that topic to `/planning/planning_factors/neural_network_planner`).
  * The factor `module` (RViz red-wall reason) is `planning_model`; this plugin
  * only identifies that factor from the model trajectory.
  *

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp
@@ -26,7 +26,9 @@ namespace autoware::trajectory_modifier::plugin
  *
  * Learning-based planners (diffusion, tensorrt e2e, …) emit a pose sequence without an
  * explicit planning-factor. This plugin reads the *input* trajectory kinematics, does not
- * mutate points, and publishes `/planning/planning_factors/model_planning_factor_id`.
+ * mutate points, and publishes `/planning/planning_factors/planning_model`.
+ * The factor `module` (RViz red-wall reason) is `planning_model`; this plugin
+ * only identifies that factor from the model trajectory.
  *
  * Load it first in `plugin_names` so labels describe the raw model output, not later
  * ObstacleStop / TrafficLightStop insertions.

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp
@@ -1,0 +1,76 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__PLANNING_FACTOR_UTILS_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__PLANNING_FACTOR_UTILS_HPP_
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace autoware::trajectory_modifier::utils
+{
+
+/**
+ * @brief Thresholds for stop / slowdown detection on a pose-sequence trajectory.
+ *
+ * Ported from `autoware_diffusion_planner` so any learning-based planner that
+ * outputs a sequence of poses (diffusion, tensorrt e2e, etc.) can be labeled
+ * through trajectory_modifier instead of inside the model node.
+ */
+struct PlanningFactorDetectionConfig
+{
+  double stop_velocity_threshold{0.1};         // [m/s]
+  double stop_keep_duration_threshold{1.0};    // [s]
+  double slowdown_accel_threshold{-0.3};       // [m/s^2]
+};
+
+struct DetectedStopFactor
+{
+  geometry_msgs::msg::Pose ego_pose;
+  geometry_msgs::msg::Pose stop_pose;
+};
+
+struct DetectedSlowdownFactor
+{
+  geometry_msgs::msg::Pose ego_pose;
+  geometry_msgs::msg::Pose start_pose;
+  geometry_msgs::msg::Pose end_pose;
+  double start_velocity;
+  double end_velocity;
+};
+
+struct PlanningFactorDetectionResult
+{
+  std::optional<DetectedStopFactor> stop;
+  std::optional<DetectedSlowdownFactor> slowdown;
+};
+
+/**
+ * @brief Inspect trajectory kinematics and report the first valid stop and slowdown.
+ *
+ * Stop: first point at or below `stop_velocity_threshold` that stays at/below
+ * that speed for at least `stop_keep_duration_threshold` (no resume in between).
+ * Slowdown: first contiguous run of points whose `acceleration_mps2` is below
+ * `slowdown_accel_threshold`; if the run never ends, the last point is the end.
+ */
+PlanningFactorDetectionResult detect_planning_factors(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points,
+  const PlanningFactorDetectionConfig & config);
+
+}  // namespace autoware::trajectory_modifier::utils
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__PLANNING_FACTOR_UTILS_HPP_

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -21,5 +21,10 @@
     <remap from="~/input/vector_map" to="$(var input_vector_map)"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>
     <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
+    <!-- ModelPlanningFactorID publishes /planning/planning_factors/planning_model.
+         Remap onto neural_network_planner so RViz / bags keep a stable topic.
+         Factor.module (RViz red-wall reason) stays planning_model. -->
+    <remap from="/planning/planning_factors/planning_model"
+           to="/planning/planning_factors/neural_network_planner"/>
   </node>
 </launch>

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -3,6 +3,7 @@ trajectory_modifier_params:
     type: string_array
     default_value:
       [
+        autoware::trajectory_modifier::plugin::ModelPlanningFactorID,
         autoware::trajectory_modifier::plugin::ObstacleStop,
         autoware::trajectory_modifier::plugin::TrafficLightStop,
         autoware::trajectory_modifier::plugin::StopPointFixer,
@@ -29,6 +30,11 @@ trajectory_modifier_params:
     type: bool
     default_value: true
     description: Enable the use of velocity modifier
+    read_only: false
+  use_model_planning_factor_id:
+    type: bool
+    default_value: true
+    description: Enable model-planning-factor-id stop/slowdown planning-factor labeling
     read_only: false
   trajectory_time_step:
     type: double
@@ -442,3 +448,36 @@ trajectory_modifier_params:
         default_value: true
         description: Reject if we detect a previous stop attempt from input trajectory
         read_only: false
+
+  model_planning_factor_id:
+    enable_stop:
+      type: bool
+      default_value: true
+      description: Publish STOP planning factors inferred from the planner trajectory
+      read_only: false
+    enable_slowdown:
+      type: bool
+      default_value: false
+      description: Publish SLOW_DOWN planning factors inferred from the planner trajectory
+      read_only: false
+    stop_velocity_threshold:
+      type: double
+      default_value: 0.1
+      description: Velocity at or below which a trajectory point is treated as stopped [m/s]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
+    stop_keep_duration_threshold:
+      type: double
+      default_value: 1.0
+      description: Minimum duration the trajectory must remain stopped to accept the stop [s]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
+    slowdown_accel_threshold:
+      type: double
+      default_value: -0.3
+      description: Acceleration below which a slowdown section starts [m/s^2]
+      read_only: false
+      validation:
+        bounds<>: [-10.0, 0.0]

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -34,7 +34,7 @@ trajectory_modifier_params:
   use_model_planning_factor_id:
     type: bool
     default_value: true
-    description: Enable model-planning-factor-id stop/slowdown planning-factor labeling
+    description: Enable ModelPlanningFactorID (publishes module planning_model)
     read_only: false
   trajectory_time_step:
     type: double

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -28,7 +28,7 @@
          base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
     <description>
       Inspects the planner trajectory kinematics and publishes stop/slowdown planning factors
-      as module model_planning_factor_id without mutating the trajectory
+      as module planning_model without mutating the trajectory
     </description>
   </class>
 </library>

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -24,4 +24,11 @@
       Modifies the velocity of a trajectory to smooth the motion
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::ModelPlanningFactorID"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Inspects the planner trajectory kinematics and publishes stop/slowdown planning factors
+      as module model_planning_factor_id without mutating the trajectory
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -386,7 +386,7 @@
         },
         "model_planning_factor_id": {
           "type": "object",
-          "description": "Inspect the planner trajectory and publish stop/slowdown planning factors",
+          "description": "Inspect the planner trajectory and publish stop/slowdown factors as module planning_model",
           "properties": {
             "enable_stop": {
               "type": "boolean",

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -10,7 +10,9 @@
           "type": "array",
           "description": "List of trajectory modifier plugins to load",
           "default": [
+            "autoware::trajectory_modifier::plugin::ModelPlanningFactorID",
             "autoware::trajectory_modifier::plugin::ObstacleStop",
+            "autoware::trajectory_modifier::plugin::TrafficLightStop",
             "autoware::trajectory_modifier::plugin::StopPointFixer",
             "autoware::trajectory_modifier::plugin::VelocityModifier"
           ],
@@ -31,6 +33,11 @@
         "use_velocity_modifier": {
           "type": "boolean",
           "description": "Enable the velocity modifier plugin",
+          "default": true
+        },
+        "use_model_planning_factor_id": {
+          "type": "boolean",
+          "description": "Enable ModelPlanningFactorID stop/slowdown planning-factor labeling",
           "default": true
         },
         "trajectory_time_step": {
@@ -372,6 +379,42 @@
               },
               "required": [],
               "additionalProperties": false
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "model_planning_factor_id": {
+          "type": "object",
+          "description": "Inspect the planner trajectory and publish stop/slowdown planning factors",
+          "properties": {
+            "enable_stop": {
+              "type": "boolean",
+              "description": "Publish STOP planning factors inferred from the planner trajectory",
+              "default": true
+            },
+            "enable_slowdown": {
+              "type": "boolean",
+              "description": "Publish SLOW_DOWN planning factors inferred from the planner trajectory",
+              "default": false
+            },
+            "stop_velocity_threshold": {
+              "type": "number",
+              "description": "Velocity at or below which a trajectory point is treated as stopped [m/s]",
+              "default": 0.1,
+              "minimum": 0.0
+            },
+            "stop_keep_duration_threshold": {
+              "type": "number",
+              "description": "Minimum duration the trajectory must remain stopped to accept the stop [s]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "slowdown_accel_threshold": {
+              "type": "number",
+              "description": "Acceleration below which a slowdown section starts [m/s^2]",
+              "default": -0.3,
+              "maximum": 0.0
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -112,8 +112,11 @@ void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg
   std::string modified_plugins_str;
   for (auto & trajectory : output_trajectories.candidate_trajectories) {
     for (auto & modifier : plugins_) {
-      if (!modifier->modify_trajectory(trajectory.points, input)) continue;
+      const bool modified = modifier->modify_trajectory(trajectory.points, input);
+      // Always publish so inspection-only plugins (ModelPlanningFactorID) can emit factors
+      // without mutating the trajectory. An empty publish also clears stale factors.
       modifier->publish_planning_factor();
+      if (!modified) continue;
       const auto ns = "trajectory_" + std::to_string(trajectory_count);
       modifier->publish_debug_data(ns);
       if (!modified_plugins_str.empty()) modified_plugins_str += ", ";

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/model_planning_factor_id.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/model_planning_factor_id.cpp
@@ -1,0 +1,93 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp"
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp"
+
+#include <memory>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+void ModelPlanningFactorID::apply_params(const TrajectoryModifierParams & params)
+{
+  enabled_ = params.use_model_planning_factor_id;
+  params_ = params.model_planning_factor_id;
+  detection_config_.stop_velocity_threshold = params_.stop_velocity_threshold;
+  detection_config_.stop_keep_duration_threshold = params_.stop_keep_duration_threshold;
+  detection_config_.slowdown_accel_threshold = params_.slowdown_accel_threshold;
+}
+
+void ModelPlanningFactorID::on_initialize(const TrajectoryModifierParams & params)
+{
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      get_node_ptr(), "model_planning_factor_id");
+  apply_params(params);
+}
+
+void ModelPlanningFactorID::update_params(const TrajectoryModifierParams & params)
+{
+  apply_params(params);
+}
+
+bool ModelPlanningFactorID::is_trajectory_modification_required(
+  const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  if (!enabled_ || traj_points.empty()) {
+    return false;
+  }
+  const auto result = utils::detect_planning_factors(traj_points, detection_config_);
+  return (params_.enable_stop && result.stop.has_value()) ||
+         (params_.enable_slowdown && result.slowdown.has_value());
+}
+
+void ModelPlanningFactorID::add_detected_factors(const TrajectoryPoints & traj_points)
+{
+  const auto result = utils::detect_planning_factors(traj_points, detection_config_);
+
+  if (params_.enable_stop && result.stop) {
+    const auto & stop = *result.stop;
+    planning_factor_interface_->add(
+      traj_points, stop.ego_pose, stop.stop_pose, PlanningFactor::STOP,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+  }
+
+  if (params_.enable_slowdown && result.slowdown) {
+    const auto & slowdown = *result.slowdown;
+    planning_factor_interface_->add(
+      traj_points, slowdown.ego_pose, slowdown.start_pose, slowdown.end_pose,
+      PlanningFactor::SLOW_DOWN, autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true,
+      slowdown.start_velocity, slowdown.end_velocity);
+  }
+}
+
+bool ModelPlanningFactorID::modify_trajectory(
+  TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  if (!enabled_ || traj_points.empty()) {
+    return false;
+  }
+  add_detected_factors(traj_points);
+  // Inspection only: never rewrite the planner trajectory.
+  return false;
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::ModelPlanningFactorID,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/model_planning_factor_id.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/model_planning_factor_id.cpp
@@ -34,7 +34,7 @@ void ModelPlanningFactorID::on_initialize(const TrajectoryModifierParams & param
 {
   planning_factor_interface_ =
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      get_node_ptr(), "model_planning_factor_id");
+      get_node_ptr(), "planning_model");
   apply_params(params);
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/planning_factor_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/planning_factor_utils.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp"
+
+#include <rclcpp/duration.hpp>
+
+#include <vector>
+
+namespace autoware::trajectory_modifier::utils
+{
+
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+std::optional<DetectedStopFactor> detect_stop_factor(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  std::optional<size_t> stop_idx;
+  rclcpp::Duration stop_start_time(0, 0);
+  bool is_valid_stop = true;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (!stop_idx && points[i].longitudinal_velocity_mps <= config.stop_velocity_threshold) {
+      stop_idx = i;
+      stop_start_time = rclcpp::Duration(points[i].time_from_start);
+    }
+    if (
+      stop_idx &&
+      (rclcpp::Duration(points[i].time_from_start) - stop_start_time).seconds() <
+        config.stop_keep_duration_threshold &&
+      points[i].longitudinal_velocity_mps > config.stop_velocity_threshold) {
+      is_valid_stop = false;
+    }
+  }
+
+  if (!stop_idx || !is_valid_stop) {
+    return std::nullopt;
+  }
+
+  DetectedStopFactor stop;
+  stop.ego_pose = points[0].pose;
+  stop.stop_pose = points[*stop_idx].pose;
+  return stop;
+}
+
+std::optional<DetectedSlowdownFactor> detect_slowdown_factor(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  std::optional<size_t> slowdown_start_idx;
+  std::optional<size_t> slowdown_end_idx;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (points[i].acceleration_mps2 < config.slowdown_accel_threshold) {
+      if (!slowdown_start_idx) slowdown_start_idx = i;
+    } else if (slowdown_start_idx && !slowdown_end_idx) {
+      slowdown_end_idx = i;
+    }
+  }
+
+  if (slowdown_start_idx && !slowdown_end_idx) {
+    slowdown_end_idx = points.size() - 1;
+  }
+
+  if (!slowdown_start_idx) {
+    return std::nullopt;
+  }
+
+  DetectedSlowdownFactor slowdown;
+  slowdown.ego_pose = points[0].pose;
+  slowdown.start_pose = points[*slowdown_start_idx].pose;
+  slowdown.end_pose = points[*slowdown_end_idx].pose;
+  slowdown.start_velocity = points[*slowdown_start_idx].longitudinal_velocity_mps;
+  slowdown.end_velocity = points[*slowdown_end_idx].longitudinal_velocity_mps;
+  return slowdown;
+}
+
+PlanningFactorDetectionResult detect_planning_factors(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  PlanningFactorDetectionResult result;
+
+  if (points.empty()) {
+    return result;
+  }
+
+  result.stop = detect_stop_factor(points, config);
+  result.slowdown = detect_slowdown_factor(points, config);
+  return result;
+}
+
+}  // namespace autoware::trajectory_modifier::utils

--- a/planning/autoware_trajectory_modifier/tests/test_model_planning_factor_id_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_model_planning_factor_id_integration.cpp
@@ -126,7 +126,7 @@ TEST_F(ModelPlanningFactorIDIntegrationTest, PublishesStopFactorFromInputTraject
   const auto factors = plugin_->get_planning_factors();
   ASSERT_EQ(factors.size(), 1u);
   EXPECT_EQ(factors.front().behavior, PlanningFactor::STOP);
-  EXPECT_EQ(factors.front().module, "model_planning_factor_id");
+  EXPECT_EQ(factors.front().module, "planning_model");
   ASSERT_FALSE(factors.front().control_points.empty());
   EXPECT_DOUBLE_EQ(factors.front().control_points.front().pose.position.x, 3.0);
 }

--- a/planning/autoware_trajectory_modifier/tests/test_model_planning_factor_id_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_model_planning_factor_id_integration.cpp
@@ -1,0 +1,179 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/model_planning_factor_id.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+using autoware::trajectory_modifier::TrajectoryModifierContext;
+using autoware::trajectory_modifier::plugin::InputData;
+using autoware::trajectory_modifier::plugin::ModelPlanningFactorID;
+using autoware::trajectory_modifier::plugin::TrajectoryPoints;
+using autoware_internal_planning_msgs::msg::PlanningFactor;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+TrajectoryPoint make_point(
+  const double time_from_start_sec, const double x, const float velocity, const float accel)
+{
+  TrajectoryPoint p;
+  p.time_from_start.sec = static_cast<int32_t>(time_from_start_sec);
+  p.time_from_start.nanosec =
+    static_cast<uint32_t>((time_from_start_sec - static_cast<int32_t>(time_from_start_sec)) * 1e9);
+  p.pose.position.x = x;
+  p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
+  p.pose.orientation.w = 1.0;
+  p.longitudinal_velocity_mps = velocity;
+  p.acceleration_mps2 = accel;
+  return p;
+}
+
+}  // namespace
+
+class ModelPlanningFactorIDIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+    autoware::test_utils::updateNodeOptions(
+      node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<rclcpp::Node>("test_model_planning_factor_id_node", node_options);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
+
+    params_.use_model_planning_factor_id = true;
+    params_.model_planning_factor_id.enable_stop = true;
+    params_.model_planning_factor_id.enable_slowdown = true;
+    params_.model_planning_factor_id.stop_velocity_threshold = 0.1;
+    params_.model_planning_factor_id.stop_keep_duration_threshold = 1.0;
+    params_.model_planning_factor_id.slowdown_accel_threshold = -0.3;
+
+    context_ = std::make_shared<TrajectoryModifierContext>(node_.get());
+    plugin_ = std::make_unique<ModelPlanningFactorID>();
+    plugin_->initialize(
+      "test_model_planning_factor_id", node_.get(), time_keeper_, context_, params_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    plugin_.reset();
+    context_.reset();
+    node_.reset();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  std::unique_ptr<ModelPlanningFactorID> plugin_;
+  trajectory_modifier_params::Params params_;
+  std::shared_ptr<TrajectoryModifierContext> context_;
+};
+
+TEST_F(ModelPlanningFactorIDIntegrationTest, DoesNotMutateTrajectory)
+{
+  TrajectoryPoints trajectory;
+  trajectory.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  trajectory.push_back(make_point(0.5, 1.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(1.5, 2.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(2.5, 3.0, 0.0f, 0.0f));
+  const auto original_size = trajectory.size();
+  const auto original_v0 = trajectory.front().longitudinal_velocity_mps;
+
+  EXPECT_FALSE(plugin_->modify_trajectory(trajectory, InputData{}));
+  EXPECT_EQ(trajectory.size(), original_size);
+  EXPECT_FLOAT_EQ(trajectory.front().longitudinal_velocity_mps, original_v0);
+}
+
+TEST_F(ModelPlanningFactorIDIntegrationTest, PublishesStopFactorFromInputTrajectory)
+{
+  TrajectoryPoints trajectory;
+  trajectory.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  trajectory.push_back(make_point(0.5, 1.0, 2.0f, -0.2f));
+  trajectory.push_back(make_point(1.0, 2.0, 1.0f, -0.2f));
+  trajectory.push_back(make_point(1.5, 3.0, 0.05f, -0.1f));
+  trajectory.push_back(make_point(2.0, 4.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(2.5, 5.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(3.0, 6.0, 0.0f, 0.0f));
+
+  EXPECT_FALSE(plugin_->modify_trajectory(trajectory, InputData{}));
+
+  const auto factors = plugin_->get_planning_factors();
+  ASSERT_EQ(factors.size(), 1u);
+  EXPECT_EQ(factors.front().behavior, PlanningFactor::STOP);
+  EXPECT_EQ(factors.front().module, "model_planning_factor_id");
+  ASSERT_FALSE(factors.front().control_points.empty());
+  EXPECT_DOUBLE_EQ(factors.front().control_points.front().pose.position.x, 3.0);
+}
+
+TEST_F(ModelPlanningFactorIDIntegrationTest, PublishesSlowdownFactorWhenEnabled)
+{
+  TrajectoryPoints trajectory;
+  trajectory.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  trajectory.push_back(make_point(0.5, 1.0, 4.5f, -0.1f));
+  trajectory.push_back(make_point(1.0, 2.0, 3.5f, -0.5f));
+  trajectory.push_back(make_point(1.5, 3.0, 2.5f, -0.5f));
+  trajectory.push_back(make_point(2.0, 4.0, 2.0f, -0.1f));
+  trajectory.push_back(make_point(2.5, 5.0, 2.0f, 0.0f));
+
+  EXPECT_FALSE(plugin_->modify_trajectory(trajectory, InputData{}));
+
+  const auto factors = plugin_->get_planning_factors();
+  ASSERT_EQ(factors.size(), 1u);
+  EXPECT_EQ(factors.front().behavior, PlanningFactor::SLOW_DOWN);
+  ASSERT_EQ(factors.front().control_points.size(), 2u);
+  EXPECT_DOUBLE_EQ(factors.front().control_points.front().pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(factors.front().control_points.back().pose.position.x, 4.0);
+}
+
+TEST_F(ModelPlanningFactorIDIntegrationTest, DisabledPluginEmitsNoFactors)
+{
+  params_.use_model_planning_factor_id = false;
+  plugin_->update_params(params_);
+
+  TrajectoryPoints trajectory;
+  trajectory.push_back(make_point(0.0, 0.0, 0.0f, 0.0f));
+
+  EXPECT_FALSE(plugin_->modify_trajectory(trajectory, InputData{}));
+  EXPECT_TRUE(plugin_->get_planning_factors().empty());
+}
+
+TEST_F(ModelPlanningFactorIDIntegrationTest, StopDisabledSkipsStopFactor)
+{
+  params_.model_planning_factor_id.enable_stop = false;
+  plugin_->update_params(params_);
+
+  TrajectoryPoints trajectory;
+  trajectory.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  trajectory.push_back(make_point(1.5, 3.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(2.5, 4.0, 0.0f, 0.0f));
+  trajectory.push_back(make_point(3.5, 5.0, 0.0f, 0.0f));
+
+  EXPECT_FALSE(plugin_->modify_trajectory(trajectory, InputData{}));
+  EXPECT_TRUE(plugin_->get_planning_factors().empty());
+}

--- a/planning/autoware_trajectory_modifier/tests/test_planning_factor_utils.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_planning_factor_utils.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/planning_factor_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::trajectory_modifier::utils::test
+{
+
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+namespace
+{
+
+TrajectoryPoint make_point(
+  const double time_from_start_sec, const double x, const float velocity, const float accel)
+{
+  TrajectoryPoint p;
+  p.time_from_start.sec = static_cast<int32_t>(time_from_start_sec);
+  p.time_from_start.nanosec =
+    static_cast<uint32_t>((time_from_start_sec - static_cast<int32_t>(time_from_start_sec)) * 1e9);
+  p.pose.position.x = x;
+  p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
+  p.longitudinal_velocity_mps = velocity;
+  p.acceleration_mps2 = accel;
+  return p;
+}
+
+}  // namespace
+
+class PlanningFactorUtilsTest : public ::testing::Test
+{
+protected:
+  PlanningFactorDetectionConfig config_;
+
+  void SetUp() override
+  {
+    config_.stop_velocity_threshold = 0.1;
+    config_.stop_keep_duration_threshold = 1.0;
+    config_.slowdown_accel_threshold = -0.3;
+  }
+};
+
+TEST_F(PlanningFactorUtilsTest, EmptyPoints)
+{
+  std::vector<TrajectoryPoint> points;
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, NoStopNoSlowdown)
+{
+  std::vector<TrajectoryPoint> points;
+  for (int i = 0; i < 10; ++i) {
+    points.push_back(make_point(i * 0.5, i * 1.0, 5.0f, 0.0f));
+  }
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, StopDetected)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 2.0f, -0.2f));
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.2f));
+  points.push_back(make_point(1.5, 3.0, 0.05f, -0.1f));
+  points.push_back(make_point(2.0, 4.0, 0.0f, 0.0f));
+  points.push_back(make_point(2.5, 5.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.0, 6.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 3.0);
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, StopInvalidatedByVelocityResume)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 0.05f, -0.1f));
+  points.push_back(make_point(0.8, 2.0, 0.5f, 0.1f));
+  points.push_back(make_point(1.0, 3.0, 2.0f, 0.1f));
+
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, SlowdownDetected)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 4.5f, -0.1f));
+  points.push_back(make_point(1.0, 2.0, 3.5f, -0.5f));
+  points.push_back(make_point(1.5, 3.0, 2.5f, -0.5f));
+  points.push_back(make_point(2.0, 4.0, 2.0f, -0.1f));
+  points.push_back(make_point(2.5, 5.0, 2.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 4.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_velocity, 3.5);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_velocity, 2.0);
+}
+
+TEST_F(PlanningFactorUtilsTest, BothStopAndSlowdown)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 3.0f, -0.5f));
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.5f));
+  points.push_back(make_point(1.5, 3.0, 0.5f, -0.1f));
+  points.push_back(make_point(2.0, 4.0, 0.05f, -0.05f));
+  points.push_back(make_point(2.5, 5.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.0, 6.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.5, 7.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 4.0);
+
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 3.0);
+}
+
+TEST_F(PlanningFactorUtilsTest, SlowdownWithoutEnd)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 3.0f, -0.5f));
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.5f));
+  points.push_back(make_point(1.5, 3.0, 0.5f, -0.5f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_velocity, 3.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_velocity, 0.5);
+}
+
+TEST_F(PlanningFactorUtilsTest, SingleStoppedPoint)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 0.0);
+}
+
+}  // namespace autoware::trajectory_modifier::utils::test


### PR DESCRIPTION
## Description

Add inspection-only trajectory_modifier plugin `ModelPlanningFactorID`.

Learning-based planners emit a pose sequence, not a planning factor. This plugin inspects the **input** trajectory kinematics (any learning-based planner, not only diffusion_planner), does **not** mutate points, and publishes a STOP / SLOW_DOWN factor.

| Role | Name |
|---|---|
| Plugin (identifier) | `ModelPlanningFactorID` |
| Factor `module` (RViz red-wall reason) | `planning_model` |
| Publisher name | `/planning/planning_factors/planning_model` |
| Launch remap | `/planning/planning_factors/neural_network_planner` |

Detection is ported from `autoware_diffusion_planner`:

- STOP: first `v ≤ 0.1 m/s` held ≥ 1.0 s (`enable_stop: true`)
- SLOW_DOWN: first run with `a < -0.3 m/s²` (`enable_slowdown: false` by default)

Load it **first** in `plugin_names` so labels describe the raw model output, not later ObstacleStop / TrafficLightStop insertions.

Host `on_traj` always calls `publish_planning_factor()` so inspection plugins can emit (or clear) factors when `modify_trajectory` returns false.

## Related links

**Parent Issue:**

- None

- Launcher YAML + RViz — https://github.com/tier4/autoware_launch.xx1/pull/2194
- FOA RViz — https://github.com/tier4/FieldOperatorApplication/pull/787

## How was this PR tested?

- [x] `colcon build --packages-select autoware_trajectory_modifier`
- [x] `colcon test --packages-select autoware_trajectory_modifier` (80/80, including new utils + plugin tests)
- [ ] CI on this PR
- [ ] Pair with launcher enablement — https://github.com/tier4/autoware_launch.xx1/pull/2194
- [ ] Vehicle/runtime — not in this pass

## Notes for reviewers

- `diffusion_planner` C++ still has its own planning-factor path. Launcher PR disables `planning_factor.enable_stop` there so e2e does not double-publish STOP.
- Not a processor-merge. XX1 keeps split modifier / optimizer.
- Merge this PR first, then launcher `#2194`. FOA `#787` is visualization-only.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name | Message Type | Description |
|:------------|:-----------|:-----------|:-------------|:------------|
| Added | Pub | `/planning/planning_factors/planning_model` | `autoware_internal_planning_msgs/PlanningFactorArray` | Model stop/slowdown factor. Launch remaps this to `/planning/planning_factors/neural_network_planner`. |

#### Modifications

| Version | Topic Type | Topic Name | Message Type | Description |
|:--------|:-----------|:-----------|:-------------|:------------|
| Old | Pub | `/planning/planning_factors/planning_model` | `autoware_internal_planning_msgs/PlanningFactorArray` | Name used by `PlanningFactorInterface("planning_model")` |
| New | Pub | `/planning/planning_factors/neural_network_planner` | `autoware_internal_planning_msgs/PlanningFactorArray` | Remap in `trajectory_modifier.launch.xml`. `factor.module` stays `planning_model`. |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `use_model_planning_factor_id` | `bool` | `true` | Enable ModelPlanningFactorID |
| Added | `model_planning_factor_id.enable_stop` | `bool` | `true` | Publish STOP from input trajectory |
| Added | `model_planning_factor_id.enable_slowdown` | `bool` | `false` | Publish SLOW_DOWN from input trajectory |
| Added | `model_planning_factor_id.stop_velocity_threshold` | `double` | `0.1` | Stop velocity threshold [m/s] |
| Added | `model_planning_factor_id.stop_keep_duration_threshold` | `double` | `1.0` | Stop hold duration [s] |
| Added | `model_planning_factor_id.slowdown_accel_threshold` | `double` | `-0.3` | Slowdown accel threshold [m/s²] |

## Effects on system behavior

When the input pose-sequence trajectory implies a stop, RViz shows a red STOP wall labeled `planning_model` on `/planning/planning_factors/neural_network_planner`. The trajectory itself is unchanged by this plugin.