### PR TITLE
feat(planning): persist model load errors on inference_status and report missing planner input

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -46,6 +46,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -133,11 +134,24 @@ private:
    * @brief Load TensorRT model and normalization statistics.
    *
    * Updates the normalization_map_ and diffusion_planner_inference_ member variables.
+   * On failure, stores the exception text in model_load_error_ and publishes model_status
+   * before rethrowing.
    *
    * @throws std::runtime_error if args_path or model paths are invalid, if the
    *         model version is incompatible, or if TensorRT engine setup fails.
    */
   void load_model();
+
+  /**
+   * @brief Publish model_status diagnostics (load error, loading, or OK).
+   * @param stamp Timestamp forwarded to DiagnosticsInterface::publish.
+   */
+  void publish_model_status(const rclcpp::Time & stamp);
+
+  /**
+   * @brief Add model path and backend key-values to model_status.
+   */
+  void fill_model_status_key_values();
 
   /**
    * @brief Timer callback for periodic processing and publishing.
@@ -270,6 +284,8 @@ private:
   VehicleInfo vehicle_info_;
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
+  std::unique_ptr<DiagnosticsInterface> diagnostics_model_status_;
+  std::optional<std::string> model_load_error_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
 
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -134,8 +134,8 @@ private:
    * @brief Load TensorRT model and normalization statistics.
    *
    * Updates the normalization_map_ and diffusion_planner_inference_ member variables.
-   * On failure, stores the exception text in model_load_error_ and publishes model_status
-   * before rethrowing.
+   * On failure, stores the exception text in model_load_error_ and publishes it on
+   * inference_status before rethrowing.
    *
    * @throws std::runtime_error if args_path or model paths are invalid, if the
    *         model version is incompatible, or if TensorRT engine setup fails.
@@ -143,15 +143,9 @@ private:
   void load_model();
 
   /**
-   * @brief Publish model_status diagnostics (load error, loading, or OK).
-   * @param stamp Timestamp forwarded to DiagnosticsInterface::publish.
+   * @brief Add model path and backend key-values to inference_status.
    */
-  void publish_model_status(const rclcpp::Time & stamp);
-
-  /**
-   * @brief Add model path and backend key-values to model_status.
-   */
-  void fill_model_status_key_values();
+  void fill_model_key_values();
 
   /**
    * @brief Timer callback for periodic processing and publishing.
@@ -284,7 +278,6 @@ private:
   VehicleInfo vehicle_info_;
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
-  std::unique_ptr<DiagnosticsInterface> diagnostics_model_status_;
   std::optional<std::string> model_load_error_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
 

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -45,6 +45,7 @@
 #include <std_srvs/srv/set_bool.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -146,6 +147,11 @@ private:
    * @brief Add model path and backend key-values to inference_status.
    */
   void fill_model_key_values();
+
+  /**
+   * @brief Clear inference_status, refill model key-values, set level/message, and publish.
+   */
+  void publish_inference_status(int8_t level, const std::string & message = "");
 
   /**
    * @brief Timer callback for periodic processing and publishing.

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -277,27 +277,29 @@ void DiffusionPlanner::fill_model_key_values()
   }
 }
 
-void DiffusionPlanner::load_model()
+void DiffusionPlanner::publish_inference_status(const int8_t level, const std::string & message)
 {
   diagnostics_inference_->clear();
   fill_model_key_values();
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  if (level > DiagnosticStatus::OK) {
+    diagnostics_inference_->update_level_and_message(level, message);
+  }
   diagnostics_inference_->publish(get_clock()->now());
+}
+
+void DiffusionPlanner::load_model()
+{
+  publish_inference_status(DiagnosticStatus::WARN, "Loading model");
   try {
     core_->resolve_model_paths();
     core_->load_model();
   } catch (const std::exception & e) {
     model_load_error_ = e.what();
-    diagnostics_inference_->clear();
-    fill_model_key_values();
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, *model_load_error_);
-    diagnostics_inference_->publish(get_clock()->now());
+    publish_inference_status(DiagnosticStatus::ERROR, *model_load_error_);
     throw;
   }
   model_load_error_.reset();
-  diagnostics_inference_->clear();
-  fill_model_key_values();
-  diagnostics_inference_->publish(get_clock()->now());
+  publish_inference_status(DiagnosticStatus::OK);
 
   if (params_.model_type == "single_step") {
     RCLCPP_INFO_STREAM(

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -136,6 +136,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
       this, "diffusion_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
+  diagnostics_model_status_ = std::make_unique<DiagnosticsInterface>(this, "model_status");
   try {
     load_model();
     if (params_.build_only) {
@@ -144,7 +145,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     }
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what() << ". Inference will be disabled.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());
+    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
     diagnostics_inference_->publish(get_clock()->now());
     if (params_.build_only) {
       RCLCPP_ERROR(get_logger(), "Build only mode: exiting due to model load failure.");
@@ -254,14 +255,60 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<bool>("debug_params.publish_debug_linestrings", true);
 }
 
+void DiffusionPlanner::fill_model_status_key_values()
+{
+  diagnostics_model_status_->add_key_value("backend", params_.backend);
+  diagnostics_model_status_->add_key_value("model_type", params_.model_type);
+  diagnostics_model_status_->add_key_value("model_loaded", core_->is_model_loaded());
+  diagnostics_model_status_->add_key_value("base_model_directory", params_.base_model_directory);
+  if (!params_.args_path.empty()) {
+    diagnostics_model_status_->add_key_value("args_path", params_.args_path);
+  }
+  if (params_.model_type == "multi_step") {
+    if (!params_.encoder_model_path.empty()) {
+      diagnostics_model_status_->add_key_value("encoder_model_path", params_.encoder_model_path);
+    }
+    if (!params_.decoder_model_path.empty()) {
+      diagnostics_model_status_->add_key_value("decoder_model_path", params_.decoder_model_path);
+    }
+    if (!params_.turn_indicator_model_path.empty()) {
+      diagnostics_model_status_->add_key_value(
+        "turn_indicator_model_path", params_.turn_indicator_model_path);
+    }
+  } else if (!params_.single_step_model_path.empty()) {
+    diagnostics_model_status_->add_key_value("onnx_model_path", params_.single_step_model_path);
+  }
+}
+
+void DiffusionPlanner::publish_model_status(const rclcpp::Time & stamp)
+{
+  diagnostics_model_status_->clear();
+  fill_model_status_key_values();
+  if (model_load_error_) {
+    diagnostics_model_status_->update_level_and_message(
+      DiagnosticStatus::ERROR, *model_load_error_);
+  } else if (!core_->is_model_loaded()) {
+    diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  }
+  diagnostics_model_status_->publish(stamp);
+}
+
 void DiffusionPlanner::load_model()
 {
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  diagnostics_inference_->publish(get_clock()->now());
-  core_->resolve_model_paths();
-  core_->load_model();
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::OK, "Model loaded");
-  diagnostics_inference_->publish(get_clock()->now());
+  diagnostics_model_status_->clear();
+  fill_model_status_key_values();
+  diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  diagnostics_model_status_->publish(get_clock()->now());
+  try {
+    core_->resolve_model_paths();
+    core_->load_model();
+  } catch (const std::exception & e) {
+    model_load_error_ = e.what();
+    publish_model_status(get_clock()->now());
+    throw;
+  }
+  model_load_error_.reset();
+  publish_model_status(get_clock()->now());
 
   if (params_.model_type == "single_step") {
     RCLCPP_INFO_STREAM(
@@ -551,9 +598,11 @@ void DiffusionPlanner::on_timer()
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing_time");
 
+  const rclcpp::Time current_time(get_clock()->now());
+  publish_model_status(current_time);
+
   diagnostics_inference_->clear();
 
-  const rclcpp::Time current_time(get_clock()->now());
   if (!core_->is_model_loaded()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -136,7 +136,6 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
       this, "diffusion_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
-  diagnostics_model_status_ = std::make_unique<DiagnosticsInterface>(this, "model_status");
   try {
     load_model();
     if (params_.build_only) {
@@ -145,8 +144,6 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     }
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what() << ". Inference will be disabled.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
-    diagnostics_inference_->publish(get_clock()->now());
     if (params_.build_only) {
       RCLCPP_ERROR(get_logger(), "Build only mode: exiting due to model load failure.");
       std::exit(EXIT_FAILURE);
@@ -255,60 +252,52 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<bool>("debug_params.publish_debug_linestrings", true);
 }
 
-void DiffusionPlanner::fill_model_status_key_values()
+void DiffusionPlanner::fill_model_key_values()
 {
-  diagnostics_model_status_->add_key_value("backend", params_.backend);
-  diagnostics_model_status_->add_key_value("model_type", params_.model_type);
-  diagnostics_model_status_->add_key_value("model_loaded", core_->is_model_loaded());
-  diagnostics_model_status_->add_key_value("base_model_directory", params_.base_model_directory);
+  diagnostics_inference_->add_key_value("backend", params_.backend);
+  diagnostics_inference_->add_key_value("model_type", params_.model_type);
+  diagnostics_inference_->add_key_value("model_loaded", core_->is_model_loaded());
+  diagnostics_inference_->add_key_value("base_model_directory", params_.base_model_directory);
   if (!params_.args_path.empty()) {
-    diagnostics_model_status_->add_key_value("args_path", params_.args_path);
+    diagnostics_inference_->add_key_value("args_path", params_.args_path);
   }
   if (params_.model_type == "multi_step") {
     if (!params_.encoder_model_path.empty()) {
-      diagnostics_model_status_->add_key_value("encoder_model_path", params_.encoder_model_path);
+      diagnostics_inference_->add_key_value("encoder_model_path", params_.encoder_model_path);
     }
     if (!params_.decoder_model_path.empty()) {
-      diagnostics_model_status_->add_key_value("decoder_model_path", params_.decoder_model_path);
+      diagnostics_inference_->add_key_value("decoder_model_path", params_.decoder_model_path);
     }
     if (!params_.turn_indicator_model_path.empty()) {
-      diagnostics_model_status_->add_key_value(
+      diagnostics_inference_->add_key_value(
         "turn_indicator_model_path", params_.turn_indicator_model_path);
     }
   } else if (!params_.single_step_model_path.empty()) {
-    diagnostics_model_status_->add_key_value("onnx_model_path", params_.single_step_model_path);
+    diagnostics_inference_->add_key_value("onnx_model_path", params_.single_step_model_path);
   }
-}
-
-void DiffusionPlanner::publish_model_status(const rclcpp::Time & stamp)
-{
-  diagnostics_model_status_->clear();
-  fill_model_status_key_values();
-  if (model_load_error_) {
-    diagnostics_model_status_->update_level_and_message(
-      DiagnosticStatus::ERROR, *model_load_error_);
-  } else if (!core_->is_model_loaded()) {
-    diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  }
-  diagnostics_model_status_->publish(stamp);
 }
 
 void DiffusionPlanner::load_model()
 {
-  diagnostics_model_status_->clear();
-  fill_model_status_key_values();
-  diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  diagnostics_model_status_->publish(get_clock()->now());
+  diagnostics_inference_->clear();
+  fill_model_key_values();
+  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  diagnostics_inference_->publish(get_clock()->now());
   try {
     core_->resolve_model_paths();
     core_->load_model();
   } catch (const std::exception & e) {
     model_load_error_ = e.what();
-    publish_model_status(get_clock()->now());
+    diagnostics_inference_->clear();
+    fill_model_key_values();
+    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, *model_load_error_);
+    diagnostics_inference_->publish(get_clock()->now());
     throw;
   }
   model_load_error_.reset();
-  publish_model_status(get_clock()->now());
+  diagnostics_inference_->clear();
+  fill_model_key_values();
+  diagnostics_inference_->publish(get_clock()->now());
 
   if (params_.model_type == "single_step") {
     RCLCPP_INFO_STREAM(
@@ -599,15 +588,16 @@ void DiffusionPlanner::on_timer()
   stop_watch_ptr_->tic("processing_time");
 
   const rclcpp::Time current_time(get_clock()->now());
-  publish_model_status(current_time);
 
   diagnostics_inference_->clear();
+  fill_model_key_values();
 
   if (!core_->is_model_loaded()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
       "Model not loaded. Inference is disabled. Check model.* parameters.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
+    diagnostics_inference_->update_level_and_message(
+      DiagnosticStatus::ERROR, model_load_error_.value_or("Model not loaded"));
     diagnostics_inference_->publish(current_time);
     return;
   }

--- a/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
+++ b/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
@@ -45,6 +45,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -130,10 +131,23 @@ private:
    * @brief Load TensorRT model and normalization statistics.
    *
    * Updates the normalization_map_ and ml_planner_inference_ member variables.
+   * On failure, stores the exception text in model_load_error_ and publishes model_status
+   * before rethrowing.
    *
    * @throws std::runtime_error if the model path is invalid or engine setup fails.
    */
   void load_model();
+
+  /**
+   * @brief Publish model_status diagnostics (load error, loading, or OK).
+   * @param stamp Timestamp forwarded to DiagnosticsInterface::publish.
+   */
+  void publish_model_status(const rclcpp::Time & stamp);
+
+  /**
+   * @brief Add model path and backend key-values to model_status.
+   */
+  void fill_model_status_key_values();
 
   /**
    * @brief Timer callback for periodic processing and publishing.
@@ -246,6 +260,8 @@ private:
   VehicleInfo vehicle_info_;
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
+  std::unique_ptr<DiagnosticsInterface> diagnostics_model_status_;
+  std::optional<std::string> model_load_error_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
 
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
+++ b/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
@@ -44,6 +44,7 @@
 #include <std_srvs/srv/set_bool.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -142,6 +143,11 @@ private:
    * @brief Add model path and backend key-values to inference_status.
    */
   void fill_model_key_values();
+
+  /**
+   * @brief Clear inference_status, refill model key-values, set level/message, and publish.
+   */
+  void publish_inference_status(int8_t level, const std::string & message = "");
 
   /**
    * @brief Timer callback for periodic processing and publishing.

--- a/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
+++ b/planning/autoware_ml_planner/include/autoware/ml_planner/ml_planner_node.hpp
@@ -131,23 +131,17 @@ private:
    * @brief Load TensorRT model and normalization statistics.
    *
    * Updates the normalization_map_ and ml_planner_inference_ member variables.
-   * On failure, stores the exception text in model_load_error_ and publishes model_status
-   * before rethrowing.
+   * On failure, stores the exception text in model_load_error_ and publishes it on
+   * inference_status before rethrowing.
    *
    * @throws std::runtime_error if the model path is invalid or engine setup fails.
    */
   void load_model();
 
   /**
-   * @brief Publish model_status diagnostics (load error, loading, or OK).
-   * @param stamp Timestamp forwarded to DiagnosticsInterface::publish.
+   * @brief Add model path and backend key-values to inference_status.
    */
-  void publish_model_status(const rclcpp::Time & stamp);
-
-  /**
-   * @brief Add model path and backend key-values to model_status.
-   */
-  void fill_model_status_key_values();
+  void fill_model_key_values();
 
   /**
    * @brief Timer callback for periodic processing and publishing.
@@ -260,7 +254,6 @@ private:
   VehicleInfo vehicle_info_;
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
-  std::unique_ptr<DiagnosticsInterface> diagnostics_model_status_;
   std::optional<std::string> model_load_error_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
 

--- a/planning/autoware_ml_planner/src/ml_planner_node.cpp
+++ b/planning/autoware_ml_planner/src/ml_planner_node.cpp
@@ -33,6 +33,7 @@
 #include <functional>
 #include <iomanip>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -130,6 +131,7 @@ MLPlanner::MLPlanner(const rclcpp::NodeOptions & options)
       this, "ml_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
+  diagnostics_model_status_ = std::make_unique<DiagnosticsInterface>(this, "model_status");
   try {
     load_model();
     if (params_.build_only) {
@@ -138,7 +140,7 @@ MLPlanner::MLPlanner(const rclcpp::NodeOptions & options)
     }
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what() << ". Inference will be disabled.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());
+    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
     diagnostics_inference_->publish(get_clock()->now());
     if (params_.build_only) {
       RCLCPP_ERROR(get_logger(), "Build only mode: exiting due to model load failure.");
@@ -279,13 +281,43 @@ void MLPlanner::set_up_params()
     this->declare_parameter<bool>("debug_params.publish_debug_linestrings", true);
 }
 
+void MLPlanner::fill_model_status_key_values()
+{
+  diagnostics_model_status_->add_key_value("backend", params_.backend);
+  diagnostics_model_status_->add_key_value("model_loaded", core_->is_model_loaded());
+  if (!params_.model_path.empty()) {
+    diagnostics_model_status_->add_key_value("onnx_model_path", params_.model_path);
+  }
+}
+
+void MLPlanner::publish_model_status(const rclcpp::Time & stamp)
+{
+  diagnostics_model_status_->clear();
+  fill_model_status_key_values();
+  if (model_load_error_) {
+    diagnostics_model_status_->update_level_and_message(
+      DiagnosticStatus::ERROR, *model_load_error_);
+  } else if (!core_->is_model_loaded()) {
+    diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  }
+  diagnostics_model_status_->publish(stamp);
+}
+
 void MLPlanner::load_model()
 {
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  diagnostics_inference_->publish(get_clock()->now());
-  core_->load_model();
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::OK, "Model loaded");
-  diagnostics_inference_->publish(get_clock()->now());
+  diagnostics_model_status_->clear();
+  fill_model_status_key_values();
+  diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  diagnostics_model_status_->publish(get_clock()->now());
+  try {
+    core_->load_model();
+  } catch (const std::exception & e) {
+    model_load_error_ = e.what();
+    publish_model_status(get_clock()->now());
+    throw;
+  }
+  model_load_error_.reset();
+  publish_model_status(get_clock()->now());
 
   RCLCPP_INFO_STREAM(
     get_logger(), "Loaded model.onnx_model_path=" << params_.model_path << " (hash="
@@ -574,9 +606,11 @@ void MLPlanner::on_timer()
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing_time");
 
+  const rclcpp::Time current_time(get_clock()->now());
+  publish_model_status(current_time);
+
   diagnostics_inference_->clear();
 
-  const rclcpp::Time current_time(get_clock()->now());
   if (!core_->is_model_loaded()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,

--- a/planning/autoware_ml_planner/src/ml_planner_node.cpp
+++ b/planning/autoware_ml_planner/src/ml_planner_node.cpp
@@ -131,7 +131,6 @@ MLPlanner::MLPlanner(const rclcpp::NodeOptions & options)
       this, "ml_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
-  diagnostics_model_status_ = std::make_unique<DiagnosticsInterface>(this, "model_status");
   try {
     load_model();
     if (params_.build_only) {
@@ -140,8 +139,6 @@ MLPlanner::MLPlanner(const rclcpp::NodeOptions & options)
     }
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what() << ". Inference will be disabled.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
-    diagnostics_inference_->publish(get_clock()->now());
     if (params_.build_only) {
       RCLCPP_ERROR(get_logger(), "Build only mode: exiting due to model load failure.");
       std::exit(EXIT_FAILURE);
@@ -281,43 +278,35 @@ void MLPlanner::set_up_params()
     this->declare_parameter<bool>("debug_params.publish_debug_linestrings", true);
 }
 
-void MLPlanner::fill_model_status_key_values()
+void MLPlanner::fill_model_key_values()
 {
-  diagnostics_model_status_->add_key_value("backend", params_.backend);
-  diagnostics_model_status_->add_key_value("model_loaded", core_->is_model_loaded());
+  diagnostics_inference_->add_key_value("backend", params_.backend);
+  diagnostics_inference_->add_key_value("model_loaded", core_->is_model_loaded());
   if (!params_.model_path.empty()) {
-    diagnostics_model_status_->add_key_value("onnx_model_path", params_.model_path);
+    diagnostics_inference_->add_key_value("onnx_model_path", params_.model_path);
   }
-}
-
-void MLPlanner::publish_model_status(const rclcpp::Time & stamp)
-{
-  diagnostics_model_status_->clear();
-  fill_model_status_key_values();
-  if (model_load_error_) {
-    diagnostics_model_status_->update_level_and_message(
-      DiagnosticStatus::ERROR, *model_load_error_);
-  } else if (!core_->is_model_loaded()) {
-    diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  }
-  diagnostics_model_status_->publish(stamp);
 }
 
 void MLPlanner::load_model()
 {
-  diagnostics_model_status_->clear();
-  fill_model_status_key_values();
-  diagnostics_model_status_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
-  diagnostics_model_status_->publish(get_clock()->now());
+  diagnostics_inference_->clear();
+  fill_model_key_values();
+  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  diagnostics_inference_->publish(get_clock()->now());
   try {
     core_->load_model();
   } catch (const std::exception & e) {
     model_load_error_ = e.what();
-    publish_model_status(get_clock()->now());
+    diagnostics_inference_->clear();
+    fill_model_key_values();
+    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, *model_load_error_);
+    diagnostics_inference_->publish(get_clock()->now());
     throw;
   }
   model_load_error_.reset();
-  publish_model_status(get_clock()->now());
+  diagnostics_inference_->clear();
+  fill_model_key_values();
+  diagnostics_inference_->publish(get_clock()->now());
 
   RCLCPP_INFO_STREAM(
     get_logger(), "Loaded model.onnx_model_path=" << params_.model_path << " (hash="
@@ -607,15 +596,16 @@ void MLPlanner::on_timer()
   stop_watch_ptr_->tic("processing_time");
 
   const rclcpp::Time current_time(get_clock()->now());
-  publish_model_status(current_time);
 
   diagnostics_inference_->clear();
+  fill_model_key_values();
 
   if (!core_->is_model_loaded()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
       "Model not loaded. Inference is disabled. Check model.* parameters.");
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, "Model not loaded");
+    diagnostics_inference_->update_level_and_message(
+      DiagnosticStatus::ERROR, model_load_error_.value_or("Model not loaded"));
     diagnostics_inference_->publish(current_time);
     return;
   }

--- a/planning/autoware_ml_planner/src/ml_planner_node.cpp
+++ b/planning/autoware_ml_planner/src/ml_planner_node.cpp
@@ -287,26 +287,28 @@ void MLPlanner::fill_model_key_values()
   }
 }
 
-void MLPlanner::load_model()
+void MLPlanner::publish_inference_status(const int8_t level, const std::string & message)
 {
   diagnostics_inference_->clear();
   fill_model_key_values();
-  diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
+  if (level > DiagnosticStatus::OK) {
+    diagnostics_inference_->update_level_and_message(level, message);
+  }
   diagnostics_inference_->publish(get_clock()->now());
+}
+
+void MLPlanner::load_model()
+{
+  publish_inference_status(DiagnosticStatus::WARN, "Loading model");
   try {
     core_->load_model();
   } catch (const std::exception & e) {
     model_load_error_ = e.what();
-    diagnostics_inference_->clear();
-    fill_model_key_values();
-    diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, *model_load_error_);
-    diagnostics_inference_->publish(get_clock()->now());
+    publish_inference_status(DiagnosticStatus::ERROR, *model_load_error_);
     throw;
   }
   model_load_error_.reset();
-  diagnostics_inference_->clear();
-  fill_model_key_values();
-  diagnostics_inference_->publish(get_clock()->now());
+  publish_inference_status(DiagnosticStatus::OK);
 
   RCLCPP_INFO_STREAM(
     get_logger(), "Loaded model.onnx_model_path=" << params_.model_path << " (hash="

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -36,6 +36,8 @@
     use_time_sequence_raw_optimizer: false
 
     trajectory_time_step: 0.1 # [s]
+    input_trajectories_warn_timeout_s: 1.0 # [s]
+    input_trajectories_error_timeout_s: 3.0 # [s]
 
     # Stop Point Fixer Plugin Parameters
     stop_point_fixer:

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_processor.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_processor.hpp
@@ -22,6 +22,7 @@
 #include <autoware_trajectory_processor/trajectory_processor_param.hpp>
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -43,6 +44,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -66,6 +68,7 @@ private:
   using SteeringReport = autoware_vehicle_msgs::msg::SteeringReport;
   using PointCloud2 = sensor_msgs::msg::PointCloud2;
   using Plugin = plugin::TrajectoryProcessorPluginBase;
+  using DiagnosticsInterface = autoware_utils_diagnostics::DiagnosticsInterface;
 
   /// @brief Process every candidate through the configured plugin sequence.
   void on_trajectories(const CandidateTrajectories::ConstSharedPtr msg);
@@ -81,6 +84,10 @@ private:
   void update_params();
   /// @brief Publish the total callback processing duration.
   void publish_processing_time(double processing_time_ms);
+  /// @brief Heartbeat for missing ~/input/trajectories when the planner is silent.
+  void on_input_trajectories_watchdog();
+  /// @brief Publish input_trajectories diagnostics from the latest receive time.
+  void publish_input_trajectories_diagnostic();
 
   std::unique_ptr<trajectory_processor_params::ParamListener> param_listener_;
   TrajectoryProcessorParams params_;
@@ -120,6 +127,13 @@ private:
 
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
   autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr lanelet_map_bin_ptr_;
+
+  std::unique_ptr<DiagnosticsInterface> diagnostics_input_trajectories_;
+  rclcpp::TimerBase::SharedPtr input_trajectories_watchdog_timer_;
+  rclcpp::Time watchdog_origin_time_{0, 0, RCL_ROS_TIME};
+  std::optional<rclcpp::Time> last_input_time_;
+  std::size_t last_candidate_count_{0};
+  bool ever_received_input_{false};
 };
 
 }  // namespace autoware::trajectory_processor

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -39,6 +39,7 @@
   <depend>autoware_traffic_light_compliance_checker</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
   <depend>autoware_utils_rclcpp</depend>

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -51,6 +51,20 @@ trajectory_processor_params:
     read_only: false
     validation:
       bounds<>: [0.05, 1.0]
+  input_trajectories_warn_timeout_s:
+    type: double
+    default_value: 1.0
+    description: Age of ~/input/trajectories after which input_trajectories diagnostics become WARN [s]
+    read_only: false
+    validation:
+      bounds<>: [0.0, 60.0]
+  input_trajectories_error_timeout_s:
+    type: double
+    default_value: 3.0
+    description: Age of ~/input/trajectories after which input_trajectories diagnostics become ERROR [s]
+    read_only: false
+    validation:
+      bounds<>: [0.0, 60.0]
 
   stop_point_fixer:
     force_stop_long_stopped_trajectories:

--- a/planning/autoware_trajectory_processor/src/trajectory_processor.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_processor.cpp
@@ -21,7 +21,9 @@
 #include <rclcpp_components/register_node_macro.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <exception>
 #include <functional>
@@ -31,6 +33,7 @@
 
 namespace autoware::trajectory_processor
 {
+using diagnostic_msgs::msg::DiagnosticStatus;
 
 TrajectoryProcessor::TrajectoryProcessor(const rclcpp::NodeOptions & options)
 : Node{"trajectory_processor", options},
@@ -56,6 +59,13 @@ TrajectoryProcessor::TrajectoryProcessor(const rclcpp::NodeOptions & options)
   debug_publisher_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
+
+  diagnostics_input_trajectories_ =
+    std::make_unique<DiagnosticsInterface>(this, "input_trajectories");
+  watchdog_origin_time_ = now();
+  input_trajectories_watchdog_timer_ = rclcpp::create_timer(
+    this, get_clock(), rclcpp::Rate(1.0).period(),
+    std::bind(&TrajectoryProcessor::on_input_trajectories_watchdog, this));
 
   load_plugins();
   RCLCPP_INFO(get_logger(), "TrajectoryProcessor initialized with %zu plugins", plugins_.size());
@@ -160,11 +170,57 @@ void TrajectoryProcessor::publish_processing_time(const double processing_time_m
     "processing_time_ms", processing_time_ms);
 }
 
+void TrajectoryProcessor::on_input_trajectories_watchdog()
+{
+  if (param_listener_->is_old(params_)) {
+    update_params();
+  }
+  publish_input_trajectories_diagnostic();
+}
+
+void TrajectoryProcessor::publish_input_trajectories_diagnostic()
+{
+  const auto current_time = now();
+  const auto reference_time = last_input_time_.value_or(watchdog_origin_time_);
+  const double age_sec = std::max(0.0, (current_time - reference_time).seconds());
+  const double warn_timeout_s = params_.input_trajectories_warn_timeout_s;
+  const double error_timeout_s =
+    std::max(params_.input_trajectories_error_timeout_s, warn_timeout_s);
+
+  diagnostics_input_trajectories_->clear();
+  diagnostics_input_trajectories_->add_key_value("age_sec", age_sec);
+  diagnostics_input_trajectories_->add_key_value("ever_received", ever_received_input_);
+  diagnostics_input_trajectories_->add_key_value("candidate_count", last_candidate_count_);
+
+  if (age_sec >= error_timeout_s) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "No planner candidate_trajectories (age=%.2fs, ever_received=%s)", age_sec,
+      ever_received_input_ ? "true" : "false");
+    diagnostics_input_trajectories_->update_level_and_message(
+      DiagnosticStatus::ERROR, "No planner candidate_trajectories");
+  } else if (age_sec >= warn_timeout_s) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "No planner candidate_trajectories (age=%.2fs, ever_received=%s)", age_sec,
+      ever_received_input_ ? "true" : "false");
+    diagnostics_input_trajectories_->update_level_and_message(
+      DiagnosticStatus::WARN, "No planner candidate_trajectories");
+  }
+
+  diagnostics_input_trajectories_->publish(current_time);
+}
+
 void TrajectoryProcessor::on_trajectories(const CandidateTrajectories::ConstSharedPtr msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic(__func__);
+
+  last_input_time_ = now();
+  last_candidate_count_ = msg->candidate_trajectories.size();
+  ever_received_input_ = true;
+  publish_input_trajectories_diagnostic();
 
   if (param_listener_->is_old(params_)) {
     update_params();


### PR DESCRIPTION
## Description

Keep using the existing `inference_status` diagnostic on `diffusion_planner` / `ml_planner` (no new updater). Persist the original TensorRT/ONNX load exception and republish it every planning tick instead of overwriting it with `"Model not loaded"`.

`trajectory_processor` had no diagnostics. Add a 1 Hz `input_trajectories` watchdog so a silent planner (engine build, load failure, crash, or remap) is visible downstream.

Companion launcher config: https://github.com/tier4/autoware_launch.x2/pull/2857

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

- [x] `colcon build --packages-select autoware_diffusion_planner autoware_ml_planner autoware_trajectory_processor` (`BUILD_TESTING=OFF`, Release)
- [ ] Vehicle / HIL / logging sim (not run in this change)

## Notes for reviewers

- `inference_status` is unchanged as a name. On model load failure the **message** is now `e.what()` (JSON version, missing files, TRT I/O, unsupported backend), with key-values `backend`, `model_loaded`, and resolved paths.
- Runtime gates are unchanged: map missing, no odom/objects/route, invalid tensors, inference/postprocess failure.
- Constructor still blocks during TensorRT engine build, so the planner cannot heartbeat until load returns. `trajectory_processor: input_trajectories` is the live signal in that window (WARN 1.0 s, ERROR 3.0 s).
- Async engine-build heartbeat is out of scope.

## Interface changes

### Diagnostic status

| Change type | Name | Node | Description |
|:--------------|:-----|:-----|:------------|
| Modified | `inference_status` | `diffusion_planner` / `ml_planner` | Load failure keeps the original exception text instead of `"Model not loaded"` |
| Added | `input_trajectories` | `trajectory_processor` | Missing/stale `~/input/trajectories` |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `input_trajectories_warn_timeout_s` | `double` | `1.0` | Age of `~/input/trajectories` after which `input_trajectories` becomes WARN [s] |
| Added | `input_trajectories_error_timeout_s` | `double` | `3.0` | Age of `~/input/trajectories` after which `input_trajectories` becomes ERROR [s] |

## Effects on system behavior

No change to published trajectories. Foxglove / `/diagnostics` show the real model-load error on `inference_status`, and `trajectory_processor` reports missing planner candidates.