### PR TITLE
feat(obstacle_stop): improve rss safety check

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -123,7 +123,6 @@
           bicycle: 3.0
           pedestrian: 5.0
         ego_decel: 2.0           # [m/s^2]
-        reaction_time: 0.4       # [s]
         safety_margin: 1.5       # [m]
         lookahead_horizon: 1.5   # [s]
 

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -84,6 +84,7 @@
       nominal_stopping_decel: 1.0 # [m/s^2]
       maximum_stopping_decel: 4.0 # [m/s^2]
       stopping_jerk: 3.0 # [m/s^3]
+      delay_response_time: 0.5 #[s]
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 0.7 # [s]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
@@ -123,7 +124,7 @@
           pedestrian: 5.0
         ego_decel: 2.0           # [m/s^2]
         reaction_time: 0.4       # [s]
-        safety_margin: 3.0       # [m]
+        safety_margin: 1.5       # [m]
         lookahead_horizon: 1.5   # [s]
 
     surround_obstacle_stop:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -360,6 +360,10 @@ minimum_rule_based_planner:
       type: double
       default_value: 3.0
       description: stopping jerk [m/s^3]
+    delay_response_time:
+      type: double
+      default_value: 0.5
+      description: delay response time used to estimate the minimum ego stopping distance [s]
     on_time_buffer:
       type: double
       default_value: 0.5
@@ -552,15 +556,9 @@ minimum_rule_based_planner:
         description: deceleration for ego vehicle used in RSS calculation [m/s^2]
         validation:
           bounds<>: [0.0, 10.0]
-      reaction_time:
-        type: double
-        default_value: 0.4
-        description: reaction time used in RSS calculation [s]
-        validation:
-          bounds<>: [0.0, 10.0]
       safety_margin:
         type: double
-        default_value: 3.0
+        default_value: 1.5
         description: safety margin used in RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -93,7 +93,8 @@ bool ObstacleStop::is_obstacle_detected(
   debug_data_.trajectory_shape = build_trajectory_footprint_index(
     traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
     data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
-    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin);
+    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
+    params_.delay_response_time);
   const auto collision_point_pcd = check_pointcloud(traj_points, data);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points, data);
@@ -161,7 +162,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
     nearest_collision_point_->arc_length - stop_margin,
     debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
     data.acceleration_ptr->accel.accel.linear.x, params_.maximum_stopping_decel,
-    params_.stopping_jerk);
+    params_.stopping_jerk, params_.delay_response_time);
 
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
@@ -203,7 +204,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   auto collision_point = get_nearest_object_collision(
     debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
-    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.ego_decel, params_.delay_response_time, params_.stop_margin,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
@@ -480,6 +481,8 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     add_text_marker(
       ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
       ns + "/target_objects_text", id, white);
+    if (!obj.is_safe)
+      add_polygon_marker(obj.ego_footprint, ns + "/overlapping_ego_footprint", id, magenta);
     id++;
   }
 

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -421,6 +421,12 @@
               "default": 3.0,
               "minimum": 0.0
             },
+            "delay_response_time": {
+              "type": "number",
+              "description": "Delay response time [s]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
             "on_time_buffer": {
               "type": "number",
               "description": "On time buffer [s]",
@@ -664,16 +670,10 @@
                   "default": 4.0,
                   "minimum": 0.0
                 },
-                "reaction_time": {
-                  "type": "number",
-                  "description": "Reaction time used in RSS calculation [s]",
-                  "default": 0.2,
-                  "minimum": 0.0
-                },
                 "safety_margin": {
                   "type": "number",
                   "description": "Safety margin used in RSS calculation [m]",
-                  "default": 2.0,
+                  "default": 1.5,
                   "minimum": 0.0
                 },
                 "lookahead_horizon": {

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -49,6 +49,7 @@
       nominal_deceleration: 1.0 # [m/s^2]
       maximum_deceleration: 4.0 # [m/s^2]
       jerk_limit: 3.0 # [m/s^3]
+      delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
     # Obstacle Stop Plugin Parameters
@@ -104,8 +105,7 @@
           pedestrian: 5.0
           animal: 5.0
         ego_decel: 2.0 # [m/s^2]
-        reaction_time: 0.4 # [s]
-        safety_margin: 3.0 # [m]
+        safety_margin: 1.5 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Traffic Light Stop Plugin Parameters

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -274,7 +274,8 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
 TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin);
+  const double ego_accel, const double decel, const double jerk, const double stop_margin,
+  const double time_delay = 0.0);
 
 using QueryResult = std::pair<size_t, Polygon2d>;
 
@@ -332,7 +333,8 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
  * the safe-distance model.
  * @param ego_decel Magnitude of ego deceleration [m/s^2] for the ego stopping term.
  * @param reaction_time system reaction time [s] to respond to detected collision.
- * @param safety_margin Extra longitudinal buffer [m] added to the computed safe distance.
+ * @param min_safe_distance Lower limit on the required gap while the object is moving [m].
+ * @param rss_safety_buffer Buffer added inside the RSS safe-distance formula [m].
  * @param stopped_vel_th Objects with longitudinal speed along the path below this [m/s] are
  * considered static.
  * @param lookahead_horizon Maximum `time_from_start` along the trajectory [s] to propagate objects
@@ -343,8 +345,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  const bool use_rss_check = true);
+  const double min_safe_distance, const double rss_safety_buffer, const double stopped_vel_th,
+  const double lookahead_horizon, const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -235,6 +235,7 @@ struct TargetObject
 {
   PredictedObject object;
   Polygon2d polygon;
+  Polygon2d ego_footprint;
   bool is_safe{false};
   double distance_from_ego{0.0};
   double safe_distance{0.0};
@@ -248,7 +249,6 @@ struct DebugData
   PointCloud2::SharedPtr filtered_points;
   PredictedObjects filtered_objects;
   TargetObjects target_objects;
-  MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
   std::optional<PredictedObject> colliding_object;
@@ -276,23 +276,27 @@ TrajectoryShape build_trajectory_footprint_index(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
   const double ego_accel, const double decel, const double jerk, const double stop_margin);
 
+using QueryResult = std::pair<size_t, Polygon2d>;
+
 /**
- * @brief Find ego footprints whose expanded OBB contains the given point.
+ * @brief Find the nearest ego footprint whose expanded OBB contains the given point.
  * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise vehicle-frame
  * OBB test: x in [-ego_back_offset, ego_front_offset], |y| <= ego_half_width + lat_margin.
- * @return Footprint indices sorted by increasing arc_length.
+ * @return Overlapping footprint index and Ego OBB (including `lat_margin`) transformed into the
+ * nearest hit pose frame, or nullopt if none contain the point.
  */
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Point2d & point, const double lat_margin);
 
 /**
- * @brief Find ego footprints that intersect the given object polygon.
+ * @brief Find the nearest ego footprint that intersects the given object polygon.
  * @details Coarse R-tree AABB query (inflated by `lat_margin`), then
  * `autoware_utils_geometry::sat::intersects` in the footprint frame. The ego OBB (including
  * `lat_margin`) is built once per query; each candidate only inverse-transforms the object.
- * @return Footprint indices sorted by increasing arc_length.
+ * @return Overlapping footprint index and Ego OBB (including `lat_margin`) transformed into the
+ * nearest hit pose frame, or nullopt if none intersect.
  */
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin);
 
 /**
@@ -333,7 +337,6 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
  * considered static.
  * @param lookahead_horizon Maximum `time_from_start` along the trajectory [s] to propagate objects
  * and ego states.
- * @param[out] colliding_object Object with the smallest arc-length collision among unsafe cases.
  * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
  */
 std::optional<CollisionPoint> get_nearest_object_collision(
@@ -399,7 +402,7 @@ struct ObjectFilter
    * @brief Keep only objects that intersect ego footprints, dropping those leaving laterally.
    * @details Objects with no overlapping footprint (expanded by `lat_margin`) are removed. Moving
    * objects judged to be exiting the corridor (using lateral velocity and a short prediction
-   * horizon) are also removed. Polygons of retained objects are accumulated in `target_polygons`.
+   * horizon) are also removed.
    * @param[in,out] objects Predicted objects to filter in place.
    * @param trajectory_points Reference path for time and geometry queries.
    * @param trajectory_shape Ego footprint index used for overlap queries.

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
@@ -42,7 +42,8 @@ bool is_ego_vehicle_moving(
 
 double clamp_stop_point_arc_length(
   const double stop_point_arc_length, const double max_length, const double ego_vel,
-  const double ego_accel, const double decel_limit, const double jerk_limit);
+  const double ego_accel, const double decel_limit, const double jerk_limit,
+  const double time_delay = 0.0);
 
 bool stop_point_exists(
   const TrajectoryPoints & traj_points, const double stop_point_arc_length,

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -411,16 +411,9 @@ trajectory_processor_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      reaction_time:
-        type: double
-        default_value: 0.4
-        description: Reaction time to consider for RSS calculation [s]
-        validation:
-          bounds<>: [0.0, 10.0]
-        read_only: false
       safety_margin:
         type: double
-        default_value: 3.0
+        default_value: 1.5
         description: Safety margin to consider for RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -446,16 +446,10 @@
                   "default": 2,
                   "minimum": 0
                 },
-                "reaction_time": {
-                  "type": "number",
-                  "description": "Reaction time to consider for RSS calculation [s]",
-                  "default": 0.4,
-                  "minimum": 0
-                },
                 "safety_margin": {
                   "type": "number",
                   "description": "Safety margin to consider for RSS calculation [m]",
-                  "default": 3,
+                  "default": 1.5,
                   "minimum": 0
                 },
                 "lookahead_horizon": {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -183,7 +183,7 @@ bool ObstacleStop::is_trajectory_modification_required(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
       input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
-      stopping_params_.jerk_limit, params_.stop_margin);
+      stopping_params_.jerk_limit, params_.stop_margin, stopping_params_.delay_response_time);
   }
 
   check_obstacles(traj_points, input);
@@ -233,7 +233,7 @@ bool ObstacleStop::set_stop_point(
     nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
-    stopping_params_.jerk_limit);
+    stopping_params_.jerk_limit, stopping_params_.delay_response_time);
 
   // actual stop margin from ego front to collision point
   const auto actual_stop_margin =
@@ -345,7 +345,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   auto collision_point = get_nearest_object_collision(
     debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
-    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.ego_decel, stopping_params_.delay_response_time, params_.stop_margin,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -446,7 +446,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
      << "SAFE: " << is_safe << "\n";
   ss << "\t\t"
      << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
-     << debug_data_.target_polygons.size() << "\n";
+     << debug_data_.target_objects.size() << "\n";
   ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
@@ -560,8 +560,7 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   }
 
   for (const auto & obj : debug_data_.target_objects) {
-    const auto & target_polygon = obj.polygon;
-    add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    add_polygon_marker(obj.polygon, ns + "/target_objects", id, magenta);
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2);
     ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
@@ -570,6 +569,8 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     add_text_marker(
       ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
       ns + "/target_objects_text", id, white);
+    if (!obj.is_safe)
+      add_polygon_marker(obj.ego_footprint, ns + "/overlapping_ego_footprint", id, magenta);
     id++;
   }
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -255,13 +256,11 @@ std::vector<FootprintNode> query_rtree_candidates(
   return candidates;
 }
 
-std::vector<size_t> sort_hits_by_arc_length(
-  const TrajectoryShape & shape, std::vector<size_t> && hits)
+void sort_hits_by_arc_length(const TrajectoryShape & shape, std::vector<size_t> & hits)
 {
   std::sort(hits.begin(), hits.end(), [&](const size_t a, const size_t b) {
     return shape.footprints[a].arc_length < shape.footprints[b].arc_length;
   });
-  return hits;
 }
 
 bool is_point_within_footprint(
@@ -285,23 +284,26 @@ Polygon2d make_local_ego_polygon(const TrajectoryShape & shape, const double lat
   return ego;
 }
 
-Polygon2d transform_polygon_to_pose_frame(
-  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose)
+Polygon2d transform_polygon(
+  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose, bool inverse = false)
 {
+  auto pose_2d = pose;
+  pose_2d.orientation = autoware_utils::create_quaternion_from_yaw(tf2::getYaw(pose.orientation));
   Polygon2d local;
   local.outer().reserve(polygon.outer().size());
   for (const auto & p : polygon.outer()) {
-    const auto rel = autoware_utils::inverse_transform_point(p.to_3d(), pose);
+    const auto rel = inverse ? autoware_utils::inverse_transform_point(p.to_3d(), pose_2d)
+                             : autoware_utils::transform_point(p.to_3d(), pose_2d);
     local.outer().emplace_back(rel.x(), rel.y());
   }
   return local;
 }
 }  // namespace
 
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
 {
-  if (polygon.outer().empty()) return {};
+  if (polygon.outer().empty()) return std::nullopt;
 
   const auto query_box = inflate_box(
     boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
@@ -311,16 +313,19 @@ std::vector<size_t> query_overlapping_footprints(
   std::vector<size_t> hits;
   hits.reserve(candidates.size());
   for (const auto & node : candidates) {
-    const auto object_local =
-      transform_polygon_to_pose_frame(polygon, shape.footprints[node.second].pose);
+    const auto object_local = transform_polygon(polygon, shape.footprints[node.second].pose, true);
     if (autoware_utils_geometry::sat::intersects(ego_local, object_local)) {
       hits.push_back(node.second);
     }
   }
-  return sort_hits_by_arc_length(shape, std::move(hits));
+
+  if (hits.empty()) return std::nullopt;
+  sort_hits_by_arc_length(shape, hits);
+  const auto overlap_polygon = transform_polygon(ego_local, shape.footprints[hits.front()].pose);
+  return QueryResult(hits.front(), overlap_polygon);
 }
 
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Point2d & point, const double lat_margin)
 {
   const autoware_utils_geometry::Box2d query_box{
@@ -335,7 +340,12 @@ std::vector<size_t> query_overlapping_footprints(
       hits.push_back(node.second);
     }
   }
-  return sort_hits_by_arc_length(shape, std::move(hits));
+
+  if (hits.empty()) return std::nullopt;
+  sort_hits_by_arc_length(shape, hits);
+  const auto overlap_polygon = transform_polygon(
+    make_local_ego_polygon(shape, lat_margin), shape.footprints[hits.front()].pose);
+  return QueryResult(hits.front(), overlap_polygon);
 }
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(
@@ -353,10 +363,11 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
     const auto classification = static_cast<PointCloudClassification>(point.class_id);
     const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(classification));
     const Point2d query_point{point.x, point.y};
-    const auto hits = query_overlapping_footprints(trajectory_shape, query_point, lat_margin);
-    if (hits.empty()) continue;
+    const auto result = query_overlapping_footprint(trajectory_shape, query_point, lat_margin);
+    if (!result) continue;
 
-    const auto & footprint = trajectory_shape.footprints[hits.front()];
+    const auto & [index, overlap_polygon] = result.value();
+    const auto & footprint = trajectory_shape.footprints[index];
     const auto rel = autoware_utils::inverse_transform_point(query_point.to_3d(), footprint.pose);
     const auto arc_length = footprint.arc_length + rel.x();
 
@@ -549,7 +560,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   for (auto & object : target_objects) {
     auto last_p = trajectory_points.front().pose.position;
     auto curr_arc_length = 0.0;
-    bool is_first = true;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
@@ -559,14 +569,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       const auto obj_state = get_object_state_at_time(trajectory_points, object.object, t);
       const auto obj_stopping_distance =
         get_object_stopping_distance(object.object, obj_state.lon_vel);
-      const auto [safe, safe_distance, distance_from_ego] =
+      std::tie(object.is_safe, object.safe_distance, object.distance_from_ego) =
         is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
-      object.is_safe = safe;
-      if (is_first) {
-        is_first = false;
-        object.safe_distance = safe_distance;
-        object.distance_from_ego = distance_from_ego;
-      }
       if (object.is_safe) continue;
       found_collision = true;
       auto collision_arc_length = obj_state.arc_length + obj_stopping_distance;
@@ -682,10 +686,6 @@ void ObjectFilter::filter_by_target_area(
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };
 
-  auto overlaps_ego_footprints = [&](const Polygon2d & polygon, const double lat_margin) {
-    return !query_overlapping_footprints(trajectory_shape, polygon, lat_margin).empty();
-  };
-
   auto is_exiting = [&](const auto & object, const double lat_margin) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
@@ -705,7 +705,8 @@ void ObjectFilter::filter_by_target_area(
     if (!t_to_obj_current_pos) return true;
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos.value());
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
-    return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
+    return query_overlapping_footprint(trajectory_shape, obj_pred_polygon, lat_margin) ==
+           std::nullopt;
   };
 
   target_objects.erase(
@@ -716,9 +717,12 @@ void ObjectFilter::filter_by_target_area(
         const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(object));
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
-        if (!overlaps_ego_footprints(object_polygon, lat_margin)) return true;
+        const auto query_result =
+          query_overlapping_footprint(trajectory_shape, object_polygon, lat_margin);
+        if (!query_result) return true;
         if (is_exiting(object, lat_margin)) return true;
         obj.polygon = object_polygon;
+        obj.ego_footprint = query_result.value().second;
         return false;
       }),
     target_objects.end());

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -56,11 +56,10 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
 
 double get_detection_length(
   const double forward_traj_length, const double current_vel, const double current_accel,
-  const double decel, const double jerk, const double stop_margin)
+  const double decel, const double jerk, const double stop_margin, const double time_delay)
 {
   // add a buffer length to account for the reaction time of the vehicle
   constexpr double buffer_length = 1.0;
-  constexpr double time_delay = 0.3;
   const auto margin = stop_margin + buffer_length;
   auto nominal_stopping_distance = autoware::motion_utils::calculate_stop_distance(
     current_vel, current_accel, decel, jerk, time_delay);
@@ -143,7 +142,8 @@ TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, c
 TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin)
+  const double ego_accel, const double decel, const double jerk, const double stop_margin,
+  const double time_delay)
 {
   TrajectoryShape shape;
   shape.trajectory_length = 0.0;
@@ -165,8 +165,8 @@ TrajectoryShape build_trajectory_footprint_index(
   shape.trajectory_length = traj_length;
   shape.forward_traj_length = forward_traj_length;
 
-  const auto detection_length =
-    get_detection_length(forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin);
+  const auto detection_length = get_detection_length(
+    forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin, time_delay);
 
   const auto detection_traj = std::invoke([&]() -> TrajectoryPoints {
     if (detection_length < forward_traj_length) {
@@ -476,7 +476,7 @@ double get_safe_distance(
   const auto ego_stopping_distance = ego_vel * ego_vel / (2 * ego_decel_mag);
   const auto safe_distance =
     reaction_distance + ego_stopping_distance - object_stopping_distance + safety_margin;
-  return std::max(safe_distance, safety_margin);
+  return safe_distance;
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
@@ -512,8 +512,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  const bool use_rss_check)
+  const double min_safe_distance, const double rss_safety_buffer, const double stopped_vel_th,
+  const double lookahead_horizon, const bool use_rss_check)
 {
   if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
@@ -547,8 +547,10 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     if (obj_stopping_distance <= eps)
       return std::make_tuple(false, relative_arc_length, relative_arc_length);
-    const auto safe_dist =
-      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+    const auto safe_dist = std::max(
+      min_safe_distance,
+      get_safe_distance(
+        ego_vel, ego_decel, obj_stopping_distance, reaction_time, rss_safety_buffer));
     return std::make_tuple(relative_arc_length - safe_dist > 1e-3, safe_dist, relative_arc_length);
   };
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
@@ -75,10 +75,11 @@ bool is_ego_vehicle_moving(const geometry_msgs::msg::Twist & twist, const double
 
 double clamp_stop_point_arc_length(
   const double stop_point_arc_length, const double max_length, const double ego_vel,
-  const double ego_accel, const double decel_limit, const double jerk_limit)
+  const double ego_accel, const double decel_limit, const double jerk_limit,
+  const double time_delay)
 {
   auto min_stopping_distance =
-    motion_utils::calculate_stop_distance(ego_vel, ego_accel, decel_limit, jerk_limit, 0.0);
+    motion_utils::calculate_stop_distance(ego_vel, ego_accel, decel_limit, jerk_limit, time_delay);
   if (!min_stopping_distance) min_stopping_distance = 0.0;
   return std::clamp(stop_point_arc_length, min_stopping_distance.value(), max_length);
 }

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -250,7 +250,6 @@ protected:
 
     p.rss_params.enable = true;
     p.rss_params.object_decel.car = 1.5;
-    p.rss_params.reaction_time = 0.2;
     p.rss_params.safety_margin = 2.0;
     p.rss_params.ego_decel = 4.0;
     p.rss_params.lookahead_horizon = 2.0;


### PR DESCRIPTION
## Description
Until now RSS check used a single parameter `rss_params.safety_margin` as both:
- distance buffer to add to the computed safe distance
- a lower limit applied on the computed safe distance
```
const auto safe_distance = std:: max(rss_params.safety_margin, 
    reaction_distance + ego_stopping_distance - object_stopping_distance + rss_params.safety_margin);
```

This limited the ability to freely tune how ego reacts to nearby vs further object, if we reduced the value of `rss_params.safety_margin` to make ego less sensitive to further moving targets, it would make it unsafe for close moving targets.
So we could either relax the behavior for further objects or prioritize safety for close objects but not both.

This PR resolves the issue by using 2 separate parameters for each purpose:
- The existing `obstacle_stop.stop_margin` [6.0 m] is used as a lower limit for the computed rss safe distance to control how close ego can safely get to the front target
- `rss_params.safety_margin` is used as a distance buffer added to the raw safe distance, the value is reduced from 3.0 m to 1.5 m to relax ego behavior with respect to further moving targets

### Changes
- update `get_nearest_object_collision()` function interface to take `min_safe_distance` and `rss_safety_buffer` as arguments
- use common parameter `delay_response_time` for stopping distance calculation
- update `build_trajectory_footprint_index()` function interface to take `time_delay` as argument
- update `clamp_stop_point_arc_length()` function interface to take `time_delay` as argument
- add overlapping ego footprint data to `TargetObject` struct
- visualize overlapping ego footprint for unsafe target objects

## How was this PR tested?
- PSIM
- LSIM

## Related Links
- [Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2858)