### PR TITLE
feat(diffusion_planner): ego-snap rework (bounded blend, spline heading, snap_strength) for vehicle testing

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -44,6 +44,10 @@
       max_position_error_m: 0.3       # [m]   skip the snap when the actual ego pose is farther than this from the snapped pose
       max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
+      min_speed_mps: 1.0              # [m/s] skip the snap below this speed (short, noisy leading segments carry no heading information)
+      yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
+      yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
+      yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -45,9 +45,12 @@
       max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
       min_speed_mps: 1.0              # [m/s] skip the snap below this speed (short, noisy leading segments carry no heading information)
+      limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
+      correction_gain: 0.1            # fraction of the raw-vs-snapped residual re-injected per frame (bound mode); 0 = stay exactly on the previous plan
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
       yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
       yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this
+      history_prefix_count: 10        # earlier ego poses prepended to the previous trajectory so the tangent window can extend behind the ego
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -44,7 +44,6 @@
       max_position_error_m: 0.3       # [m]   skip the snap when the actual ego pose is farther than this from the snapped pose
       max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
-      min_speed_mps: 0.0              # [m/s] skip the snap below this speed; measured worse than no gate, so disabled by default
       limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
       snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan; values above 0.95 are clipped to 0.95 with a warning
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -46,7 +46,7 @@
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
       min_speed_mps: 1.0              # [m/s] skip the snap below this speed (short, noisy leading segments carry no heading information)
       limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
-      correction_gain: 0.1            # fraction of the raw-vs-snapped residual re-injected per frame (bound mode); 0 = stay exactly on the previous plan
+      snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
       yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
       yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -44,7 +44,7 @@
       max_position_error_m: 0.3       # [m]   skip the snap when the actual ego pose is farther than this from the snapped pose
       max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
-      min_speed_mps: 1.0              # [m/s] skip the snap below this speed (short, noisy leading segments carry no heading information)
+      min_speed_mps: 0.0              # [m/s] skip the snap below this speed; measured worse than no gate, so disabled by default
       limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
       snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan; values above 0.95 are clipped to 0.95 with a warning
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -46,7 +46,7 @@
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
       min_speed_mps: 1.0              # [m/s] skip the snap below this speed (short, noisy leading segments carry no heading information)
       limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
-      snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan
+      snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan; values above 0.95 are clipped to 0.95 with a warning
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
       yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
       yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -140,11 +140,10 @@ struct EgoSnapParams
   //    (utils::bound_snapped_pose); continuous, no step.
   std::string limit_mode;
 
-  // Fraction of the (raw - snapped) residual re-injected into the snapped pose every frame, in
-  // [0, 1]. 0 keeps the pose exactly on the previous plan; small values let the virtual pose follow
-  // reality with a time constant of about 1 / gain frames instead of accumulating tracking error
-  // until the limit is hit. Only used with limit_mode "bound".
-  double correction_gain;
+  // How far from the raw pose toward the snapped pose the virtual pose is placed, in [0, 1].
+  // 0 is the raw pose, so the feature has no effect; 1 is the snapped pose, fully on the previous
+  // plan; values in between sit on the segment between the two. Only used with limit_mode "bound".
+  double snap_strength;
 
   // Number of leading segments of the previous trajectory searched for the closest one. The
   // planning cycle only advances the ego by ~1 segment, so a small window is enough and it keeps

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -137,6 +137,23 @@ struct EgoSnapParams
   // planning cycle only advances the ego by ~1 segment, so a small window is enough and it keeps
   // a far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected.
   int64_t max_search_segment_count;
+
+  // Ego speed [m/s] below which the snap is skipped. When (nearly) stopped the first segments of
+  // the previous trajectory are only centimetres long, so their direction is dominated by model
+  // noise and snapping onto them injects heading jitter instead of removing it.
+  double min_speed_mps;
+
+  // Where the heading of the snapped pose comes from:
+  //  - "predicted_heading": the vertex headings of the previous trajectory interpolated at the
+  //    snapped point (the model's own heading channel, which is not kinematically tied to its xy
+  //    output).
+  //  - "polyline_tangent": tangent of the spline through the previous trajectory's xy positions,
+  //    averaged over +-yaw_fit_half_window_m of arc length around the snapped point (see
+  //    utils::snap_point_to_trajectory). Falls back to the raw localization heading when the
+  //    window is shorter than yaw_fit_min_length_m.
+  std::string yaw_source;
+  double yaw_fit_half_window_m;
+  double yaw_fit_min_length_m;
 };
 
 struct DiffusionPlannerParams
@@ -384,6 +401,15 @@ private:
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_;
   std::vector<std::vector<std::vector<Eigen::Matrix4d>>> last_agent_poses_map_;
   std::optional<Eigen::Matrix4d> last_ego_to_map_transform_;
+
+  /**
+   * @brief Snapped ego pose (map frame, model frame convention) and interpolation time [s] of the
+   *        snapped point along the previous planning trajectory, according to
+   *        params_.ego_snap_to_prev_trajectory. std::nullopt when the snap is disabled, not yet
+   *        possible (no previous trajectory), skipped (low speed) or rejected (error limits).
+   */
+  std::optional<std::pair<Eigen::Matrix4d, double>> snap_ego_to_previous_trajectory(
+    const nav_msgs::msg::Odometry & kinematic_state) const;
 
   // Lanelet map
   LaneletRoute::ConstSharedPtr route_ptr_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -133,6 +133,19 @@ struct EgoSnapParams
   // Maximum allowed heading difference [deg] between the actual ego pose and the snapped pose.
   double max_yaw_error_deg;
 
+  // What happens at the error limits:
+  //  - "reject": the snap is skipped for the frame and the raw pose is used (a step in the ego pose
+  //    and in the ego history whenever the limit is crossed).
+  //  - "bound": the snapped pose is pulled toward the raw pose so it never exceeds the limits
+  //    (utils::bound_snapped_pose); continuous, no step.
+  std::string limit_mode;
+
+  // Fraction of the (raw - snapped) residual re-injected into the snapped pose every frame, in
+  // [0, 1]. 0 keeps the pose exactly on the previous plan; small values let the virtual pose follow
+  // reality with a time constant of about 1 / gain frames instead of accumulating tracking error
+  // until the limit is hit. Only used with limit_mode "bound".
+  double correction_gain;
+
   // Number of leading segments of the previous trajectory searched for the closest one. The
   // planning cycle only advances the ego by ~1 segment, so a small window is enough and it keeps
   // a far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected.
@@ -154,6 +167,12 @@ struct EgoSnapParams
   std::string yaw_source;
   double yaw_fit_half_window_m;
   double yaw_fit_min_length_m;
+
+  // Number of earlier ego poses (from the ego history, i.e. the virtual poses of the previous
+  // frames) prepended to the previous trajectory before snapping. They extend the spline behind the
+  // snapped point so the tangent window stays symmetric and long even though the ego is always
+  // within the first metre of the previous trajectory.
+  int64_t history_prefix_count;
 };
 
 struct DiffusionPlannerParams

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -187,9 +187,10 @@ struct EgoSnapParams
   int64_t history_prefix_count;
 };
 
-// Checks every EgoSnapParams field for a value the snap can run with: finite numbers, the documented
-// ranges, and a recognised mode string. Returns an empty string when valid, otherwise a message
-// naming the parameter and the accepted values. Used at startup and on every runtime update.
+// Checks every EgoSnapParams field for a value the snap can run with: finite numbers, the
+// documented ranges, and a recognised mode string. Returns an empty string when valid, otherwise a
+// message naming the parameter and the accepted values. Used at startup and on every runtime
+// update.
 std::string validate_ego_snap_params(const EgoSnapParams & params);
 
 // What snap_ego_to_previous_trajectory produces: the virtual ego pose handed to the model (map

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -166,7 +166,6 @@ struct EgoSnapParams
   // Ego speed [m/s] below which the snap is skipped. When (nearly) stopped the first segments of
   // the previous trajectory are only centimetres long, so their direction is dominated by model
   // noise and snapping onto them injects heading jitter instead of removing it.
-  double min_speed_mps;
 
   // Where the heading of the snapped pose comes from:
   //  - "predicted_heading": the vertex headings of the previous trajectory interpolated at the

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -114,14 +114,6 @@ struct FrameContext
   std::optional<double> snapped_interpolation_time_s;
 };
 
-/**
- * @brief Parameters for snapping the ego pose onto the previous planning trajectory.
- *
- * The ego pose fed to the model is replaced by the foot of the perpendicular to the closest
- * segment of the previous planning trajectory, so that consecutive frames stay on a single
- * consistent trajectory instead of re-planning from a slightly drifted localization pose. The
- * error limits reject the snap when the previous trajectory no longer reflects reality.
- */
 // Upper limit applied to snap_strength. At exactly 1 no part of the localized pose enters the
 // virtual pose, so once the vehicle sits against the position clamp the reference is regenerated
 // at the clamp distance every cycle and nothing pulls it back onto the vehicle; the gap to the
@@ -130,6 +122,18 @@ struct FrameContext
 // that gap by itself with a time constant of about 20 planning cycles.
 inline constexpr double kMaxSnapStrength = 0.95;
 
+/**
+ * @brief Parameters for snapping the ego pose onto the previous planning trajectory.
+ *
+ * The ego pose fed to the model is replaced by a virtual pose derived from the previous planning
+ * trajectory, so that consecutive frames continue one trajectory instead of re-planning from a
+ * slightly drifted localization pose. The snapped position is the closest point on a cubic spline
+ * through the previous trajectory's vertices (preceded by recent ego poses so the spline extends
+ * behind the vehicle); the snapped heading is the spline tangent averaged over a window of arc
+ * length, or the model's own heading channel. Distance and heading limits then apply either by
+ * blending the snapped pose toward the localized pose and bounding the result ("bound", the
+ * default, continuous) or by skipping the snap for the frame ("reject").
+ */
 struct EgoSnapParams
 {
   // When false, the raw ego pose is used as-is.
@@ -181,6 +185,19 @@ struct EgoSnapParams
   // snapped point so the tangent window stays symmetric and long even though the ego is always
   // within the first metre of the previous trajectory.
   int64_t history_prefix_count;
+};
+
+// Checks every EgoSnapParams field for a value the snap can run with: finite numbers, the documented
+// ranges, and a recognised mode string. Returns an empty string when valid, otherwise a message
+// naming the parameter and the accepted values. Used at startup and on every runtime update.
+std::string validate_ego_snap_params(const EgoSnapParams & params);
+
+// What snap_ego_to_previous_trajectory produces: the virtual ego pose handed to the model (map
+// frame) and how far along the previous trajectory it sits, as an interpolation time.
+struct SnappedEgo
+{
+  Eigen::Matrix4d pose;
+  double interpolation_time_s;
 };
 
 struct DiffusionPlannerParams
@@ -435,7 +452,12 @@ private:
    *        params_.ego_snap_to_prev_trajectory. std::nullopt when the snap is disabled, not yet
    *        possible (no previous trajectory), skipped (low speed) or rejected (error limits).
    */
-  std::optional<std::pair<Eigen::Matrix4d, double>> snap_ego_to_previous_trajectory(
+  // Recent distinct ego poses, oldest first, to prepend to the previous trajectory so the snap
+  // spline has geometry behind the vehicle. The newest history entry is the previous planning start
+  // itself and is skipped; poses closer than a few centimetres to their successor are dropped.
+  std::vector<Eigen::Matrix4d> ego_history_prefix_for_snap(int64_t max_count) const;
+
+  std::optional<SnappedEgo> snap_ego_to_previous_trajectory(
     const nav_msgs::msg::Odometry & kinematic_state) const;
 
   // Lanelet map

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -122,6 +122,14 @@ struct FrameContext
  * consistent trajectory instead of re-planning from a slightly drifted localization pose. The
  * error limits reject the snap when the previous trajectory no longer reflects reality.
  */
+// Upper limit applied to snap_strength. At exactly 1 no part of the localized pose enters the
+// virtual pose, so once the vehicle sits against the position clamp the reference is regenerated
+// at the clamp distance every cycle and nothing pulls it back onto the vehicle; the gap to the
+// trajectory then depends entirely on the controller removing a standing lateral offset, which the
+// stock MPC weights do only slowly. Keeping at least 5% of the localized pose in the blend closes
+// that gap by itself with a time constant of about 20 planning cycles.
+inline constexpr double kMaxSnapStrength = 0.95;
+
 struct EgoSnapParams
 {
   // When false, the raw ego pose is used as-is.
@@ -143,6 +151,7 @@ struct EgoSnapParams
   // How far from the raw pose toward the snapped pose the virtual pose is placed, in [0, 1].
   // 0 is the raw pose, so the feature has no effect; 1 is the snapped pose, fully on the previous
   // plan; values in between sit on the segment between the two. Only used with limit_mode "bound".
+  // Values above kMaxSnapStrength are clipped to it (see the constant).
   double snap_strength;
 
   // Number of leading segments of the previous trajectory searched for the closest one. The

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -151,9 +151,9 @@ struct BoundedPose
  * @brief Bounds a snapped pose by the real pose so the two can never drift apart by more than the
  *        given limits, without a discontinuity.
  *
- * The residual (real - snapped) is first shrunk by (1 - correction_gain): a gain of 0 keeps the
- * snapped pose, a gain of 1 returns the real pose, anything in between leaks the residual back
- * into the virtual pose over successive frames (time constant ~ 1 / gain frames). The shrunk
+ * The residual (real - snapped) is scaled by snap_strength: a strength of 0 returns the real pose
+ * and so disables the feature, a strength of 1 returns the snapped pose, and anything in between
+ * places the virtual pose on the segment between them. The scaled
  * residual is then saturated at max_position_error_m and max_yaw_error_rad, so the returned pose
  * is always within those limits of the real pose. Unlike rejecting the snap when a limit is
  * exceeded, this is continuous in the inputs: the virtual pose tracks the plan while it is close
@@ -163,14 +163,15 @@ struct BoundedPose
  * @param real_yaw Real yaw [rad].
  * @param snapped_position Snapped xy position.
  * @param snapped_yaw Snapped yaw [rad].
- * @param correction_gain Fraction of the residual re-injected per call, in [0, 1].
+ * @param snap_strength How far from the real pose toward the snapped pose the virtual pose is
+ *        placed, in [0, 1]. 0 is the real pose (feature off), 1 is the snapped pose.
  * @param max_position_error_m Saturation of the position residual [m] (> 0).
  * @param max_yaw_error_rad Saturation of the yaw residual [rad] (> 0).
- * @throw std::runtime_error on an out-of-range gain or a non-positive limit.
+ * @throw std::runtime_error on an out-of-range strength or a non-positive limit.
  */
 BoundedPose bound_snapped_pose(
   const Eigen::Vector2d & real_position, double real_yaw, const Eigen::Vector2d & snapped_position,
-  double snapped_yaw, double correction_gain, double max_position_error_m,
+  double snapped_yaw, double snap_strength, double max_position_error_m,
   double max_yaw_error_rad);
 
 /**

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -76,11 +76,19 @@ geometry_msgs::msg::Pose shift_x(const geometry_msgs::msg::Pose & pose, const do
  */
 struct TrajectorySnapOptions
 {
-  //! Number of leading segments of the trajectory the closest point is searched in. A planning
-  //! cycle only advances the ego by about one segment, so a small window is enough and it keeps a
-  //! far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected.
+  //! Number of leading vertices of the polyline that precede the trajectory proper (e.g. the ego
+  //! poses of earlier frames). They extend the spline backwards so the tangent window can stay
+  //! symmetric and long close to the trajectory start, but are never selected as the closest point
+  //! and do not count in interpolation_index (vertex prefix_count is index 0).
+  int64_t prefix_count;
+  //! Number of leading segments of the trajectory (after the prefix) the closest point is searched
+  //! in. A planning cycle only advances the ego by about one segment, so a small window is enough
+  //! and it keeps a far-away part of the trajectory (e.g. the return leg of a U-turn) from being
+  //! selected.
   int64_t max_search_segment_count;
   //! Arc length [m] on each side of the snapped point over which the spline tangent is averaged.
+  //! The window is kept symmetric around the snapped point (shrunk when it would run past either
+  //! end of the trajectory) so the averaged heading is not biased toward the future path.
   double yaw_fit_half_window_m;
   //! Minimum total arc length [m] of that window for the tangent to be considered reliable.
   double yaw_fit_min_length_m;
@@ -118,15 +126,52 @@ struct TrajectorySnap
  *
  * @param query_x X coordinate of the query point.
  * @param query_y Y coordinate of the query point.
- * @param polyline Sequence of poses (4x4 transforms) forming the trajectory.
+ * @param polyline Sequence of poses (4x4 transforms): options.prefix_count leading poses followed
+ *        by the trajectory.
  * @param options See TrajectorySnapOptions.
- * @return The snap result, or std::nullopt when fewer than two distinct leading vertices exist or
- *         the spline could not be built.
- * @throw std::runtime_error if options.max_search_segment_count is less than one.
+ * @return The snap result, or std::nullopt when fewer than two distinct vertices remain past the
+ *         prefix or the spline could not be built.
+ * @throw std::runtime_error if options.max_search_segment_count is less than one or
+ *        options.prefix_count is negative.
  */
 std::optional<TrajectorySnap> snap_point_to_trajectory(
   double query_x, double query_y, const std::vector<Eigen::Matrix4d> & polyline,
   const TrajectorySnapOptions & options);
+
+/**
+ * @brief Pose (xy + yaw) resulting from bounding a snapped pose to the real one.
+ */
+struct BoundedPose
+{
+  Eigen::Vector2d position;
+  double yaw;
+};
+
+/**
+ * @brief Bounds a snapped pose by the real pose so the two can never drift apart by more than the
+ *        given limits, without a discontinuity.
+ *
+ * The residual (real - snapped) is first shrunk by (1 - correction_gain): a gain of 0 keeps the
+ * snapped pose, a gain of 1 returns the real pose, anything in between leaks the residual back
+ * into the virtual pose over successive frames (time constant ~ 1 / gain frames). The shrunk
+ * residual is then saturated at max_position_error_m and max_yaw_error_rad, so the returned pose
+ * is always within those limits of the real pose. Unlike rejecting the snap when a limit is
+ * exceeded, this is continuous in the inputs: the virtual pose tracks the plan while it is close
+ * to reality and slides along with reality when it is not, instead of jumping between the two.
+ *
+ * @param real_position Real (localized) xy position.
+ * @param real_yaw Real yaw [rad].
+ * @param snapped_position Snapped xy position.
+ * @param snapped_yaw Snapped yaw [rad].
+ * @param correction_gain Fraction of the residual re-injected per call, in [0, 1].
+ * @param max_position_error_m Saturation of the position residual [m] (> 0).
+ * @param max_yaw_error_rad Saturation of the yaw residual [rad] (> 0).
+ * @throw std::runtime_error on an out-of-range gain or a non-positive limit.
+ */
+BoundedPose bound_snapped_pose(
+  const Eigen::Vector2d & real_position, double real_yaw, const Eigen::Vector2d & snapped_position,
+  double snapped_yaw, double correction_gain, double max_position_error_m,
+  double max_yaw_error_rad);
 
 /**
  * @brief Computes the inverse of a 4x4 transformation matrix.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -20,6 +20,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -71,43 +72,61 @@ std::pair<float, float> rotation_matrix_to_cos_sin(const Eigen::Matrix3d & rotat
 geometry_msgs::msg::Pose shift_x(const geometry_msgs::msg::Pose & pose, const double shift_length);
 
 /**
- * @brief Result of projecting a query point onto a polyline.
+ * @brief Options for snap_point_to_trajectory.
  */
-struct PolylineProjection
+struct TrajectorySnapOptions
 {
-  //! Projected pose (foot of the perpendicular) as a 4x4 transformation matrix.
-  Eigen::Matrix4d pose;
-  //! Position of the foot along the polyline, expressed as (closest segment index +
-  //! intra-segment ratio in [0, 1]). Multiplying by the per-segment time step yields the
-  //! interpolation time of the foot along the polyline.
-  double interpolation_index;
+  //! Number of leading segments of the trajectory the closest point is searched in. A planning
+  //! cycle only advances the ego by about one segment, so a small window is enough and it keeps a
+  //! far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected.
+  int64_t max_search_segment_count;
+  //! Arc length [m] on each side of the snapped point over which the spline tangent is averaged.
+  double yaw_fit_half_window_m;
+  //! Minimum total arc length [m] of that window for the tangent to be considered reliable.
+  double yaw_fit_min_length_m;
 };
 
 /**
- * @brief Projects a 2D query point onto a polyline and returns the pose at the foot of the
- *        perpendicular to the closest line segment.
+ * @brief Result of snapping a query point onto a trajectory.
+ */
+struct TrajectorySnap
+{
+  //! Closest point on the spline through the trajectory vertices (xy, same frame as the input).
+  Eigen::Vector2d position;
+  //! Position of the snapped point along the trajectory, expressed as (segment index +
+  //! intra-segment ratio in [0, 1]). Multiplying by the per-segment time step yields the
+  //! interpolation time of the snapped point along the trajectory.
+  double interpolation_index;
+  //! Heading [rad] spherically interpolated from the vertex orientations at the snapped point.
+  double heading_yaw;
+  //! Heading [rad] from the geometry: circular mean of the spline tangent over
+  //! +-yaw_fit_half_window_m of arc length around the snapped point. std::nullopt when the
+  //! available window is shorter than yaw_fit_min_length_m (no reliable heading information).
+  std::optional<double> tangent_yaw;
+};
+
+/**
+ * @brief Snaps a 2D query point onto a trajectory given as a sequence of poses.
  *
- * The polyline is treated as (polyline.size() - 1) line segments in the xy-plane. For each
- * segment, the foot of the perpendicular from the query point (clamped to the segment endpoints)
- * is computed, and the segment with the smallest distance is selected. The returned pose has the
- * foot position as (x, y) and an orientation obtained by spherically interpolating (slerp) the two
- * endpoint orientations by the projection ratio. The z component is left at 0.
- *
- * @note Only the leading max_search_segment_count segments are searched; segments beyond that are
- *       never selected, which keeps a far-away part of the polyline (e.g. the return leg of a
- *       U-turn) from being picked as the closest segment.
+ * A cubic-spline trajectory (autoware::experimental::trajectory) is built through the leading
+ * vertices of the polyline, stopping at the first pair of (almost) coincident consecutive vertices
+ * so a stop at the end of a prediction does not degenerate the spline. The closest point on the
+ * spline within the first max_search_segment_count segments is returned, together with two
+ * headings: the interpolated vertex heading and the geometric tangent averaged over a window of
+ * arc length (robust to noise in the individual vertex headings and to jitter of the short leading
+ * segments of a predicted trajectory).
  *
  * @param query_x X coordinate of the query point.
  * @param query_y Y coordinate of the query point.
- * @param polyline Sequence of poses (must contain at least two elements) forming the polyline.
- * @param max_search_segment_count Number of leading segments to search (must be at least one).
- * @return The projected pose together with the interpolation index of the foot along the polyline.
- * @throw std::runtime_error if the polyline has fewer than two poses, or if
- *        max_search_segment_count is less than one.
+ * @param polyline Sequence of poses (4x4 transforms) forming the trajectory.
+ * @param options See TrajectorySnapOptions.
+ * @return The snap result, or std::nullopt when fewer than two distinct leading vertices exist or
+ *         the spline could not be built.
+ * @throw std::runtime_error if options.max_search_segment_count is less than one.
  */
-PolylineProjection project_pose_onto_polyline(
+std::optional<TrajectorySnap> snap_point_to_trajectory(
   double query_x, double query_y, const std::vector<Eigen::Matrix4d> & polyline,
-  int64_t max_search_segment_count);
+  const TrajectorySnapOptions & options);
 
 /**
  * @brief Computes the inverse of a 4x4 transformation matrix.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -173,8 +173,7 @@ struct BoundedPose
  */
 BoundedPose bound_snapped_pose(
   const Eigen::Vector2d & real_position, double real_yaw, const Eigen::Vector2d & snapped_position,
-  double snapped_yaw, double snap_strength, double max_position_error_m,
-  double max_yaw_error_rad);
+  double snapped_yaw, double snap_strength, double max_position_error_m, double max_yaw_error_rad);
 
 /**
  * @brief Computes the inverse of a 4x4 transformation matrix.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -134,6 +134,8 @@ struct TrajectorySnap
  * @throw std::runtime_error if options.max_search_segment_count is less than one or
  *        options.prefix_count is negative.
  */
+// Planar: vertex z is ignored (the geometry is flattened before the spline is built), so the
+// result is the same for a trajectory on a slope or at elevation as for one on the ground plane.
 std::optional<TrajectorySnap> snap_point_to_trajectory(
   double query_x, double query_y, const std::vector<Eigen::Matrix4d> & polyline,
   const TrajectorySnapOptions & options);

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -231,6 +231,19 @@
               "minimum": 0,
               "description": "Ego speed [m/s] below which the snap is skipped and the raw ego pose is kept. When nearly stopped the leading segments of the previous trajectory are only centimetres long and their direction is dominated by model noise."
             },
+            "limit_mode": {
+              "type": "string",
+              "default": "bound",
+              "enum": ["bound", "reject"],
+              "description": "Behaviour at the error limits. 'bound': the snapped pose is pulled toward the raw pose so it never differs by more than max_position_error_m / max_yaw_error_deg (continuous, no step). 'reject': the snap is skipped for the frame and the raw pose is used."
+            },
+            "correction_gain": {
+              "type": "number",
+              "default": 0.1,
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Bound mode only. Fraction of the (raw - snapped) residual re-injected into the snapped pose every frame. 0 keeps the pose exactly on the previous plan; 0.1 lets the virtual pose follow reality with a time constant of about 10 frames."
+            },
             "yaw_source": {
               "type": "string",
               "default": "polyline_tangent",
@@ -248,6 +261,12 @@
               "default": 0.2,
               "minimum": 0,
               "description": "Minimum total arc length [m] of the tangent fit window. Below it the geometry carries no reliable heading and the raw localization heading is used for the snapped pose instead."
+            },
+            "history_prefix_count": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 0,
+              "description": "Number of earlier ego poses (the virtual poses of the previous frames) prepended to the previous trajectory before snapping. They extend the spline behind the snapped point so the tangent window stays symmetric and long although the ego is always within the first metre of the previous trajectory."
             }
           },
           "required": [
@@ -256,9 +275,12 @@
             "max_yaw_error_deg",
             "max_search_segment_count",
             "min_speed_mps",
+            "limit_mode",
+            "correction_gain",
             "yaw_source",
             "yaw_fit_half_window_m",
-            "yaw_fit_min_length_m"
+            "yaw_fit_min_length_m",
+            "history_prefix_count"
           ]
         },
         "guidance": {

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -223,14 +223,42 @@
               "type": "integer",
               "default": 5,
               "minimum": 1,
-              "description": "Number of leading segments of the previous trajectory searched for the closest one. A planning cycle only advances the ego by about one segment, so a small window is enough and it keeps a far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected."
+              "description": "Number of leading segments of the previous trajectory the closest point is searched in. A planning cycle only advances the ego by about one segment, so a small window is enough and it keeps a far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected."
+            },
+            "min_speed_mps": {
+              "type": "number",
+              "default": 1.0,
+              "minimum": 0,
+              "description": "Ego speed [m/s] below which the snap is skipped and the raw ego pose is kept. When nearly stopped the leading segments of the previous trajectory are only centimetres long and their direction is dominated by model noise."
+            },
+            "yaw_source": {
+              "type": "string",
+              "default": "polyline_tangent",
+              "enum": ["polyline_tangent", "predicted_heading"],
+              "description": "Heading of the snapped pose. 'polyline_tangent': tangent of the spline through the previous trajectory's xy positions, averaged over +-yaw_fit_half_window_m of arc length around the snapped point (robust to noise in the model's heading channel). 'predicted_heading': the vertex headings interpolated at the snapped point."
+            },
+            "yaw_fit_half_window_m": {
+              "type": "number",
+              "default": 1.0,
+              "minimum": 0,
+              "description": "Arc length [m] on each side of the snapped point over which the spline tangent is averaged when yaw_source is 'polyline_tangent'."
+            },
+            "yaw_fit_min_length_m": {
+              "type": "number",
+              "default": 0.2,
+              "minimum": 0,
+              "description": "Minimum total arc length [m] of the tangent fit window. Below it the geometry carries no reliable heading and the raw localization heading is used for the snapped pose instead."
             }
           },
           "required": [
             "enable",
             "max_position_error_m",
             "max_yaw_error_deg",
-            "max_search_segment_count"
+            "max_search_segment_count",
+            "min_speed_mps",
+            "yaw_source",
+            "yaw_fit_half_window_m",
+            "yaw_fit_min_length_m"
           ]
         },
         "guidance": {

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -227,9 +227,9 @@
             },
             "min_speed_mps": {
               "type": "number",
-              "default": 1.0,
+              "default": 0.0,
               "minimum": 0,
-              "description": "Ego speed [m/s] below which the snap is skipped and the raw ego pose is kept. When nearly stopped the leading segments of the previous trajectory are only centimetres long and their direction is dominated by model noise."
+              "description": "Ego speed [m/s] below which the snap is skipped and the raw ego pose is kept. Defaults to 0 (no gate): each entry into and exit from the gate is a step in the pose fed to the model, which measured worse in closed loop than leaving the gate off. The tangent-heading fallback already covers the stopped case."
             },
             "limit_mode": {
               "type": "string",

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -237,12 +237,12 @@
               "enum": ["bound", "reject"],
               "description": "Behaviour at the error limits. 'bound': the snapped pose is pulled toward the raw pose so it never differs by more than max_position_error_m / max_yaw_error_deg (continuous, no step). 'reject': the snap is skipped for the frame and the raw pose is used."
             },
-            "correction_gain": {
+            "snap_strength": {
               "type": "number",
-              "default": 0.1,
+              "default": 0.9,
               "minimum": 0,
               "maximum": 1,
-              "description": "Bound mode only. Fraction of the (raw - snapped) residual re-injected into the snapped pose every frame. 0 keeps the pose exactly on the previous plan; 0.1 lets the virtual pose follow reality with a time constant of about 10 frames."
+              "description": "Bound mode only. How far from the raw pose toward the snapped pose the virtual pose is placed. 0 is the raw pose, so the feature has no effect; 1 is the snapped pose, fully on the previous plan."
             },
             "yaw_source": {
               "type": "string",
@@ -276,7 +276,7 @@
             "max_search_segment_count",
             "min_speed_mps",
             "limit_mode",
-            "correction_gain",
+            "snap_strength",
             "yaw_source",
             "yaw_fit_half_window_m",
             "yaw_fit_min_length_m",

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -225,12 +225,6 @@
               "minimum": 1,
               "description": "Number of leading segments of the previous trajectory the closest point is searched in. A planning cycle only advances the ego by about one segment, so a small window is enough and it keeps a far-away part of the trajectory (e.g. the return leg of a U-turn) from being selected."
             },
-            "min_speed_mps": {
-              "type": "number",
-              "default": 0.0,
-              "minimum": 0,
-              "description": "Ego speed [m/s] below which the snap is skipped and the raw ego pose is kept. Defaults to 0 (no gate): each entry into and exit from the gate is a step in the pose fed to the model, which measured worse in closed loop than leaving the gate off. The tangent-heading fallback already covers the stopped case."
-            },
             "limit_mode": {
               "type": "string",
               "default": "bound",
@@ -274,7 +268,6 @@
             "max_position_error_m",
             "max_yaw_error_deg",
             "max_search_segment_count",
-            "min_speed_mps",
             "limit_mode",
             "snap_strength",
             "yaw_source",

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -242,7 +242,7 @@
               "default": 0.9,
               "minimum": 0,
               "maximum": 1,
-              "description": "Bound mode only. How far from the raw pose toward the snapped pose the virtual pose is placed. 0 is the raw pose, so the feature has no effect; 1 is the snapped pose, fully on the previous plan."
+              "description": "Bound mode only. How far from the raw pose toward the snapped pose the virtual pose is placed. 0 is the raw pose, so the feature has no effect; 1 is the snapped pose, fully on the previous plan. Values above 0.95 are clipped to 0.95 with a warning, so at least 5% of the localized pose always enters the blend."
             },
             "yaw_source": {
               "type": "string",

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -436,7 +436,7 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
   utils::BoundedPose virtual_pose{snap->position, snapped_yaw};
   if (snap_params.limit_mode == "bound") {
     virtual_pose = utils::bound_snapped_pose(
-      real_position, current_yaw, snap->position, snapped_yaw, snap_params.correction_gain,
+      real_position, current_yaw, snap->position, snapped_yaw, snap_params.snap_strength,
       snap_params.max_position_error_m, max_yaw_error_rad);
   } else {
     const double position_error_m = (real_position - snap->position).norm();

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -26,6 +26,9 @@
 #include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ONNXRUNTIME
 #include "autoware/diffusion_planner/inference/onnxruntime_inference.hpp"
 #endif
@@ -288,68 +291,23 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
       utils::shift_x(kinematic_state.pose.pose, vehicle_spec_.base_link_to_center);
   }
 
-  // Snap the ego pose onto the previous planning trajectory. The previous trajectory is the
-  // polyline formed by the previous planning start pose (last_ego_to_map_transform_) followed by
-  // the previous prediction (last_agent_poses_map_[0][0]), i.e. OUTPUT_T + 1 points forming
-  // OUTPUT_T segments. The foot of the perpendicular to the closest segment becomes the next ego
-  // pose. Note that kinematic_state here is already in the model frame (center frame when shift_x
-  // is enabled), which matches the frame the previous trajectory was generated in.
+  // Snap the ego pose onto the previous planning trajectory so consecutive frames plan from one
+  // consistent trajectory instead of a slightly drifted localization pose. Note that
+  // kinematic_state here is already in the model frame (center frame when shift_x is enabled),
+  // which matches the frame the previous trajectory was generated in.
   std::optional<Eigen::Matrix4d> snapped_pose_opt;
   std::optional<double> snapped_interpolation_time_s_opt;
-  if (
-    params_.ego_snap_to_prev_trajectory.enable && last_ego_to_map_transform_.has_value() &&
-    !last_agent_poses_map_.empty() && !last_agent_poses_map_[0].empty() &&
-    !last_agent_poses_map_[0][0].empty()) {
-    constexpr int64_t batch_idx = 0;
-    constexpr int64_t agent_idx = 0;
-    const auto & prev_poses = last_agent_poses_map_[batch_idx][agent_idx];
-
-    std::vector<Eigen::Matrix4d> prev_trajectory;
-    prev_trajectory.reserve(prev_poses.size() + 1);
-    prev_trajectory.push_back(last_ego_to_map_transform_.value());
-    prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
-
-    const utils::PolylineProjection projection = utils::project_pose_onto_polyline(
-      kinematic_state.pose.pose.position.x, kinematic_state.pose.pose.position.y, prev_trajectory,
-      params_.ego_snap_to_prev_trajectory.max_search_segment_count);
-    const Eigen::Matrix4d & snapped_pose = projection.pose;
-
-    // Reject the snap when the actual ego pose is too far (in position or heading) from the
-    // snapped pose. In that case the previous planning trajectory no longer reflects reality
-    // (e.g. large tracking error or a disturbance), so keeping the raw ego pose is safer than
-    // forcing it onto a stale trajectory.
-    const double position_error_m = std::hypot(
-      kinematic_state.pose.pose.position.x - snapped_pose(0, 3),
-      kinematic_state.pose.pose.position.y - snapped_pose(1, 3));
-    const Eigen::Quaterniond current_q(
-      kinematic_state.pose.pose.orientation.w, kinematic_state.pose.pose.orientation.x,
-      kinematic_state.pose.pose.orientation.y, kinematic_state.pose.pose.orientation.z);
-    const double current_yaw =
-      std::atan2(current_q.toRotationMatrix()(1, 0), current_q.toRotationMatrix()(0, 0));
-    const double snapped_yaw = std::atan2(snapped_pose(1, 0), snapped_pose(0, 0));
-    const double yaw_error_rad = std::abs(
-      std::atan2(std::sin(current_yaw - snapped_yaw), std::cos(current_yaw - snapped_yaw)));
-
-    const double yaw_error_deg = yaw_error_rad * 180.0 / M_PI;
-
-    if (
-      position_error_m <= params_.ego_snap_to_prev_trajectory.max_position_error_m &&
-      yaw_error_deg <= params_.ego_snap_to_prev_trajectory.max_yaw_error_deg) {
-      kinematic_state.pose.pose.position.x = snapped_pose(0, 3);
-      kinematic_state.pose.pose.position.y = snapped_pose(1, 3);
-      const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
-      kinematic_state.pose.pose.orientation.x = q.x();
-      kinematic_state.pose.pose.orientation.y = q.y();
-      kinematic_state.pose.pose.orientation.z = q.z();
-      kinematic_state.pose.pose.orientation.w = q.w();
-
-      // The polyline's first vertex is the previous planning start (t = 0) and each subsequent
-      // vertex advances by one prediction time step, so the interpolation index (segment index +
-      // intra-segment ratio) maps to time via the per-step duration.
-      snapped_pose_opt = snapped_pose;
-      snapped_interpolation_time_s_opt =
-        projection.interpolation_index * constants::PREDICTION_TIME_STEP_S;
-    }
+  if (const auto snapped = snap_ego_to_previous_trajectory(kinematic_state)) {
+    const auto & [snapped_pose, interpolation_time_s] = *snapped;
+    kinematic_state.pose.pose.position.x = snapped_pose(0, 3);
+    kinematic_state.pose.pose.position.y = snapped_pose(1, 3);
+    const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
+    kinematic_state.pose.pose.orientation.x = q.x();
+    kinematic_state.pose.pose.orientation.y = q.y();
+    kinematic_state.pose.pose.orientation.z = q.z();
+    kinematic_state.pose.pose.orientation.w = q.w();
+    snapped_pose_opt = snapped_pose;
+    snapped_interpolation_time_s_opt = interpolation_time_s;
   }
 
   // Get transforms
@@ -406,6 +364,75 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
     snapped_interpolation_time_s_opt};
 
   return frame_context;
+}
+
+std::optional<std::pair<Eigen::Matrix4d, double>>
+DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic_state) const
+{
+  const auto & snap_params = params_.ego_snap_to_prev_trajectory;
+  const bool has_previous_trajectory =
+    last_ego_to_map_transform_.has_value() && !last_agent_poses_map_.empty() &&
+    !last_agent_poses_map_[0].empty() && !last_agent_poses_map_[0][0].empty();
+  // When (nearly) stopped the leading segments of the previous trajectory are only centimetres
+  // long, so their direction is dominated by model noise: snapping would inject heading jitter.
+  const double ego_speed_mps =
+    std::hypot(kinematic_state.twist.twist.linear.x, kinematic_state.twist.twist.linear.y);
+  if (
+    !snap_params.enable || !has_previous_trajectory || ego_speed_mps < snap_params.min_speed_mps) {
+    return std::nullopt;
+  }
+
+  // The previous trajectory is the polyline formed by the previous planning start pose followed
+  // by the previous ego prediction (batch 0, agent 0), i.e. OUTPUT_T + 1 vertices spaced by one
+  // prediction time step.
+  const auto & prev_poses = last_agent_poses_map_[0][0];
+  std::vector<Eigen::Matrix4d> prev_trajectory;
+  prev_trajectory.reserve(prev_poses.size() + 1);
+  prev_trajectory.push_back(last_ego_to_map_transform_.value());
+  prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
+
+  const auto & position = kinematic_state.pose.pose.position;
+  const std::optional<utils::TrajectorySnap> snap = utils::snap_point_to_trajectory(
+    position.x, position.y, prev_trajectory,
+    utils::TrajectorySnapOptions{
+      snap_params.max_search_segment_count, snap_params.yaw_fit_half_window_m,
+      snap_params.yaw_fit_min_length_m});
+  if (!snap) {
+    return std::nullopt;
+  }
+
+  // The model's heading channel is not tied to its xy output: at the first prediction steps it
+  // disagrees with the path by several degrees and, fed back as the next ego frame, that error
+  // propagates to the following frames. The geometric tangent does not have this problem. When the
+  // tangent is unreliable (too short a window) keep the localization heading.
+  const double current_yaw =
+    autoware_utils_geometry::get_rpy(kinematic_state.pose.pose.orientation).z;
+  const double snapped_yaw = snap_params.yaw_source == "polyline_tangent"
+                               ? snap->tangent_yaw.value_or(current_yaw)
+                               : snap->heading_yaw;
+
+  // Reject the snap when the actual ego pose is too far (in position or heading) from the snapped
+  // pose: the previous planning trajectory then no longer reflects reality (e.g. large tracking
+  // error or a disturbance) and keeping the raw ego pose is safer than forcing it onto a stale
+  // trajectory.
+  const double position_error_m =
+    std::hypot(position.x - snap->position.x(), position.y - snap->position.y());
+  const double yaw_error_deg =
+    std::abs(autoware_utils_math::normalize_radian(current_yaw - snapped_yaw)) * 180.0 / M_PI;
+  if (
+    position_error_m > snap_params.max_position_error_m ||
+    yaw_error_deg > snap_params.max_yaw_error_deg) {
+    return std::nullopt;
+  }
+
+  Eigen::Matrix4d snapped_pose = Eigen::Matrix4d::Identity();
+  snapped_pose.block<3, 3>(0, 0) =
+    Eigen::AngleAxisd(snapped_yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  snapped_pose(0, 3) = snap->position.x();
+  snapped_pose(1, 3) = snap->position.y();
+  snapped_pose(2, 3) = kinematic_state.pose.pose.position.z;
+  return std::make_pair(
+    snapped_pose, snap->interpolation_index * constants::PREDICTION_TIME_STEP_S);
 }
 
 InputDataMap DiffusionPlannerCore::create_input_data(const FrameContext & frame_context)

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -28,6 +28,7 @@
 
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
 
 #ifdef AUTOWARE_DIFFUSION_PLANNER_USE_ONNXRUNTIME
 #include "autoware/diffusion_planner/inference/onnxruntime_inference.hpp"
@@ -385,9 +386,25 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
   // The previous trajectory is the polyline formed by the previous planning start pose followed
   // by the previous ego prediction (batch 0, agent 0), i.e. OUTPUT_T + 1 vertices spaced by one
   // prediction time step.
+  // It is preceded by up to history_prefix_count distinct earlier ego poses (newest of them is the
+  // previous planning start itself, so it is skipped) to extend the spline behind the ego.
   const auto & prev_poses = last_agent_poses_map_[0][0];
-  std::vector<Eigen::Matrix4d> prev_trajectory;
-  prev_trajectory.reserve(prev_poses.size() + 1);
+  std::vector<Eigen::Matrix4d> prefix;
+  for (auto it = ego_history_.rbegin(); it != ego_history_.rend(); ++it) {
+    if (static_cast<int64_t>(prefix.size()) >= snap_params.history_prefix_count) {
+      break;
+    }
+    const Eigen::Matrix4d pose = utils::pose_to_matrix4d(it->pose.pose);
+    const Eigen::Matrix4d & next =
+      prefix.empty() ? last_ego_to_map_transform_.value() : prefix.back();
+    constexpr double MIN_SPACING_M = 0.05;
+    if ((pose.block<2, 1>(0, 3) - next.block<2, 1>(0, 3)).norm() < MIN_SPACING_M) {
+      continue;
+    }
+    prefix.push_back(pose);
+  }
+  std::vector<Eigen::Matrix4d> prev_trajectory(prefix.rbegin(), prefix.rend());
+  prev_trajectory.reserve(prefix.size() + prev_poses.size() + 1);
   prev_trajectory.push_back(last_ego_to_map_transform_.value());
   prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
 
@@ -395,8 +412,8 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
   const std::optional<utils::TrajectorySnap> snap = utils::snap_point_to_trajectory(
     position.x, position.y, prev_trajectory,
     utils::TrajectorySnapOptions{
-      snap_params.max_search_segment_count, snap_params.yaw_fit_half_window_m,
-      snap_params.yaw_fit_min_length_m});
+      static_cast<int64_t>(prefix.size()), snap_params.max_search_segment_count,
+      snap_params.yaw_fit_half_window_m, snap_params.yaw_fit_min_length_m});
   if (!snap) {
     return std::nullopt;
   }
@@ -411,25 +428,30 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
                                ? snap->tangent_yaw.value_or(current_yaw)
                                : snap->heading_yaw;
 
-  // Reject the snap when the actual ego pose is too far (in position or heading) from the snapped
-  // pose: the previous planning trajectory then no longer reflects reality (e.g. large tracking
-  // error or a disturbance) and keeping the raw ego pose is safer than forcing it onto a stale
-  // trajectory.
-  const double position_error_m =
-    std::hypot(position.x - snap->position.x(), position.y - snap->position.y());
-  const double yaw_error_deg =
-    std::abs(autoware_utils_math::normalize_radian(current_yaw - snapped_yaw)) * 180.0 / M_PI;
-  if (
-    position_error_m > snap_params.max_position_error_m ||
-    yaw_error_deg > snap_params.max_yaw_error_deg) {
-    return std::nullopt;
+  // The previous planning trajectory may no longer reflect reality (large tracking error, a
+  // disturbance): the snapped pose is kept within max_position_error_m / max_yaw_error_deg of the
+  // raw pose, either by skipping the snap ("reject") or by bounding it continuously ("bound").
+  const Eigen::Vector2d real_position(position.x, position.y);
+  const double max_yaw_error_rad = autoware_utils_math::deg2rad(snap_params.max_yaw_error_deg);
+  utils::BoundedPose virtual_pose{snap->position, snapped_yaw};
+  if (snap_params.limit_mode == "bound") {
+    virtual_pose = utils::bound_snapped_pose(
+      real_position, current_yaw, snap->position, snapped_yaw, snap_params.correction_gain,
+      snap_params.max_position_error_m, max_yaw_error_rad);
+  } else {
+    const double position_error_m = (real_position - snap->position).norm();
+    const double yaw_error_rad =
+      std::abs(autoware_utils_math::normalize_radian(current_yaw - snapped_yaw));
+    if (position_error_m > snap_params.max_position_error_m || yaw_error_rad > max_yaw_error_rad) {
+      return std::nullopt;
+    }
   }
 
   Eigen::Matrix4d snapped_pose = Eigen::Matrix4d::Identity();
   snapped_pose.block<3, 3>(0, 0) =
-    Eigen::AngleAxisd(snapped_yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
-  snapped_pose(0, 3) = snap->position.x();
-  snapped_pose(1, 3) = snap->position.y();
+    Eigen::AngleAxisd(virtual_pose.yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  snapped_pose(0, 3) = virtual_pose.position.x();
+  snapped_pose(1, 3) = virtual_pose.position.y();
   snapped_pose(2, 3) = kinematic_state.pose.pose.position.z;
   return std::make_pair(
     snapped_pose, snap->interpolation_index * constants::PREDICTION_TIME_STEP_S);

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -402,13 +402,21 @@ std::string validate_ego_snap_params(const EgoSnapParams & p)
   const auto finite_non_negative = [&](const double v, const char * name) -> std::string {
     return std::isfinite(v) && v >= 0.0 ? "" : prefix + name + " must be a finite number >= 0";
   };
-  if (auto r = finite_positive(p.max_position_error_m, "max_position_error_m"); !r.empty()) return r;
-  if (auto r = finite_positive(p.max_yaw_error_deg, "max_yaw_error_deg"); !r.empty()) return r;
-  if (auto r = finite_non_negative(p.min_speed_mps, "min_speed_mps"); !r.empty()) return r;
-  if (auto r = finite_non_negative(p.yaw_fit_half_window_m, "yaw_fit_half_window_m"); !r.empty())
+  if (auto r = finite_positive(p.max_position_error_m, "max_position_error_m"); !r.empty()) {
     return r;
-  if (auto r = finite_non_negative(p.yaw_fit_min_length_m, "yaw_fit_min_length_m"); !r.empty())
+  }
+  if (auto r = finite_positive(p.max_yaw_error_deg, "max_yaw_error_deg"); !r.empty()) {
     return r;
+  }
+  if (auto r = finite_non_negative(p.min_speed_mps, "min_speed_mps"); !r.empty()) {
+    return r;
+  }
+  if (auto r = finite_non_negative(p.yaw_fit_half_window_m, "yaw_fit_half_window_m"); !r.empty()) {
+    return r;
+  }
+  if (auto r = finite_non_negative(p.yaw_fit_min_length_m, "yaw_fit_min_length_m"); !r.empty()) {
+    return r;
+  }
   if (!std::isfinite(p.snap_strength) || p.snap_strength < 0.0 || p.snap_strength > 1.0) {
     return prefix + "snap_strength must be in [0, 1] (values above 0.95 are clipped to 0.95)";
   }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -447,9 +447,19 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
     }
   }
 
+  // Rotate the real orientation about the map z axis by the yaw change, rather than rebuilding the
+  // orientation from the yaw alone: the trajectory carries no roll or pitch, so building a yaw-only
+  // rotation would silently flatten the vehicle's real attitude (measured at ~1 deg of pitch on a
+  // sloped route) in the frame the model and every transformed input see.
+  const auto & real_orientation = kinematic_state.pose.pose.orientation;
+  const Eigen::Quaterniond real_q(
+    real_orientation.w, real_orientation.x, real_orientation.y, real_orientation.z);
+  const double yaw_change = autoware_utils_math::normalize_radian(virtual_pose.yaw - current_yaw);
+  const Eigen::Quaterniond virtual_q =
+    Eigen::Quaterniond(Eigen::AngleAxisd(yaw_change, Eigen::Vector3d::UnitZ())) * real_q;
+
   Eigen::Matrix4d snapped_pose = Eigen::Matrix4d::Identity();
-  snapped_pose.block<3, 3>(0, 0) =
-    Eigen::AngleAxisd(virtual_pose.yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  snapped_pose.block<3, 3>(0, 0) = virtual_q.normalized().toRotationMatrix();
   snapped_pose(0, 3) = virtual_pose.position.x();
   snapped_pose(1, 3) = virtual_pose.position.y();
   snapped_pose(2, 3) = kinematic_state.pose.pose.position.z;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -299,7 +299,8 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   std::optional<Eigen::Matrix4d> snapped_pose_opt;
   std::optional<double> snapped_interpolation_time_s_opt;
   if (const auto snapped = snap_ego_to_previous_trajectory(kinematic_state)) {
-    const auto & [snapped_pose, interpolation_time_s] = *snapped;
+    const Eigen::Matrix4d & snapped_pose = snapped->pose;
+    const double interpolation_time_s = snapped->interpolation_time_s;
     kinematic_state.pose.pose.position.x = snapped_pose(0, 3);
     kinematic_state.pose.pose.position.y = snapped_pose(1, 3);
     const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
@@ -367,8 +368,87 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   return frame_context;
 }
 
-std::optional<std::pair<Eigen::Matrix4d, double>>
-DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic_state) const
+namespace
+{
+// Applies the error limits to the snapped pose. "bound" blends toward the real pose and clamps the
+// result, so it always returns a pose. "reject" returns nullopt when either limit is exceeded, and
+// the caller keeps the raw pose for this frame.
+std::optional<utils::BoundedPose> limit_snapped_pose(
+  const EgoSnapParams & params, const Eigen::Vector2d & real_position, const double real_yaw,
+  const Eigen::Vector2d & snapped_position, const double snapped_yaw)
+{
+  const double max_yaw_error_rad = autoware_utils_math::deg2rad(params.max_yaw_error_deg);
+  if (params.limit_mode == "bound") {
+    return utils::bound_snapped_pose(
+      real_position, real_yaw, snapped_position, snapped_yaw, params.snap_strength,
+      params.max_position_error_m, max_yaw_error_rad);
+  }
+  const double position_error_m = (real_position - snapped_position).norm();
+  const double yaw_error_rad =
+    std::abs(autoware_utils_math::normalize_radian(real_yaw - snapped_yaw));
+  if (position_error_m > params.max_position_error_m || yaw_error_rad > max_yaw_error_rad) {
+    return std::nullopt;
+  }
+  return utils::BoundedPose{snapped_position, snapped_yaw};
+}
+}  // namespace
+
+std::string validate_ego_snap_params(const EgoSnapParams & p)
+{
+  const std::string prefix = "ego_snap_to_prev_trajectory.";
+  const auto finite_positive = [&](const double v, const char * name) -> std::string {
+    return std::isfinite(v) && v > 0.0 ? "" : prefix + name + " must be a finite number > 0";
+  };
+  const auto finite_non_negative = [&](const double v, const char * name) -> std::string {
+    return std::isfinite(v) && v >= 0.0 ? "" : prefix + name + " must be a finite number >= 0";
+  };
+  if (auto r = finite_positive(p.max_position_error_m, "max_position_error_m"); !r.empty()) return r;
+  if (auto r = finite_positive(p.max_yaw_error_deg, "max_yaw_error_deg"); !r.empty()) return r;
+  if (auto r = finite_non_negative(p.min_speed_mps, "min_speed_mps"); !r.empty()) return r;
+  if (auto r = finite_non_negative(p.yaw_fit_half_window_m, "yaw_fit_half_window_m"); !r.empty())
+    return r;
+  if (auto r = finite_non_negative(p.yaw_fit_min_length_m, "yaw_fit_min_length_m"); !r.empty())
+    return r;
+  if (!std::isfinite(p.snap_strength) || p.snap_strength < 0.0 || p.snap_strength > 1.0) {
+    return prefix + "snap_strength must be in [0, 1] (values above 0.95 are clipped to 0.95)";
+  }
+  if (p.max_search_segment_count < 1) {
+    return prefix + "max_search_segment_count must be >= 1";
+  }
+  if (p.history_prefix_count < 0) {
+    return prefix + "history_prefix_count must be >= 0";
+  }
+  if (p.limit_mode != "reject" && p.limit_mode != "bound") {
+    return prefix + "limit_mode must be 'reject' or 'bound'";
+  }
+  if (p.yaw_source != "predicted_heading" && p.yaw_source != "polyline_tangent") {
+    return prefix + "yaw_source must be 'predicted_heading' or 'polyline_tangent'";
+  }
+  return "";
+}
+
+std::vector<Eigen::Matrix4d> DiffusionPlannerCore::ego_history_prefix_for_snap(
+  const int64_t max_count) const
+{
+  constexpr double MIN_SPACING_M = 0.05;
+  std::vector<Eigen::Matrix4d> newest_first;
+  for (auto it = ego_history_.rbegin(); it != ego_history_.rend(); ++it) {
+    if (static_cast<int64_t>(newest_first.size()) >= max_count) {
+      break;
+    }
+    const Eigen::Matrix4d pose = utils::pose_to_matrix4d(it->pose.pose);
+    const Eigen::Matrix4d & successor =
+      newest_first.empty() ? last_ego_to_map_transform_.value() : newest_first.back();
+    if ((pose.block<2, 1>(0, 3) - successor.block<2, 1>(0, 3)).norm() < MIN_SPACING_M) {
+      continue;
+    }
+    newest_first.push_back(pose);
+  }
+  return {newest_first.rbegin(), newest_first.rend()};
+}
+
+std::optional<SnappedEgo> DiffusionPlannerCore::snap_ego_to_previous_trajectory(
+  const Odometry & kinematic_state) const
 {
   const auto & snap_params = params_.ego_snap_to_prev_trajectory;
   const bool has_previous_trajectory =
@@ -383,28 +463,14 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
     return std::nullopt;
   }
 
-  // The previous trajectory is the polyline formed by the previous planning start pose followed
-  // by the previous ego prediction (batch 0, agent 0), i.e. OUTPUT_T + 1 vertices spaced by one
-  // prediction time step.
-  // It is preceded by up to history_prefix_count distinct earlier ego poses (newest of them is the
-  // previous planning start itself, so it is skipped) to extend the spline behind the ego.
+  // The previous trajectory is the previous planning start pose followed by the previous ego
+  // prediction (batch 0, agent 0): OUTPUT_T + 1 vertices spaced by one prediction time step,
+  // preceded by recent ego poses so the spline extends behind the vehicle.
+  std::vector<Eigen::Matrix4d> prev_trajectory =
+    ego_history_prefix_for_snap(snap_params.history_prefix_count);
+  const size_t prefix_count = prev_trajectory.size();
   const auto & prev_poses = last_agent_poses_map_[0][0];
-  std::vector<Eigen::Matrix4d> prefix;
-  for (auto it = ego_history_.rbegin(); it != ego_history_.rend(); ++it) {
-    if (static_cast<int64_t>(prefix.size()) >= snap_params.history_prefix_count) {
-      break;
-    }
-    const Eigen::Matrix4d pose = utils::pose_to_matrix4d(it->pose.pose);
-    const Eigen::Matrix4d & next =
-      prefix.empty() ? last_ego_to_map_transform_.value() : prefix.back();
-    constexpr double MIN_SPACING_M = 0.05;
-    if ((pose.block<2, 1>(0, 3) - next.block<2, 1>(0, 3)).norm() < MIN_SPACING_M) {
-      continue;
-    }
-    prefix.push_back(pose);
-  }
-  std::vector<Eigen::Matrix4d> prev_trajectory(prefix.rbegin(), prefix.rend());
-  prev_trajectory.reserve(prefix.size() + prev_poses.size() + 1);
+  prev_trajectory.reserve(prefix_count + prev_poses.size() + 1);
   prev_trajectory.push_back(last_ego_to_map_transform_.value());
   prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
 
@@ -412,7 +478,7 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
   const std::optional<utils::TrajectorySnap> snap = utils::snap_point_to_trajectory(
     position.x, position.y, prev_trajectory,
     utils::TrajectorySnapOptions{
-      static_cast<int64_t>(prefix.size()), snap_params.max_search_segment_count,
+      static_cast<int64_t>(prefix_count), snap_params.max_search_segment_count,
       snap_params.yaw_fit_half_window_m, snap_params.yaw_fit_min_length_m});
   if (!snap) {
     return std::nullopt;
@@ -428,43 +494,30 @@ DiffusionPlannerCore::snap_ego_to_previous_trajectory(const Odometry & kinematic
                                ? snap->tangent_yaw.value_or(current_yaw)
                                : snap->heading_yaw;
 
-  // The previous planning trajectory may no longer reflect reality (large tracking error, a
-  // disturbance): the snapped pose is kept within max_position_error_m / max_yaw_error_deg of the
-  // raw pose, either by skipping the snap ("reject") or by bounding it continuously ("bound").
   const Eigen::Vector2d real_position(position.x, position.y);
-  const double max_yaw_error_rad = autoware_utils_math::deg2rad(snap_params.max_yaw_error_deg);
-  utils::BoundedPose virtual_pose{snap->position, snapped_yaw};
-  if (snap_params.limit_mode == "bound") {
-    virtual_pose = utils::bound_snapped_pose(
-      real_position, current_yaw, snap->position, snapped_yaw, snap_params.snap_strength,
-      snap_params.max_position_error_m, max_yaw_error_rad);
-  } else {
-    const double position_error_m = (real_position - snap->position).norm();
-    const double yaw_error_rad =
-      std::abs(autoware_utils_math::normalize_radian(current_yaw - snapped_yaw));
-    if (position_error_m > snap_params.max_position_error_m || yaw_error_rad > max_yaw_error_rad) {
-      return std::nullopt;
-    }
+  const std::optional<utils::BoundedPose> virtual_pose =
+    limit_snapped_pose(snap_params, real_position, current_yaw, snap->position, snapped_yaw);
+  if (!virtual_pose) {
+    return std::nullopt;
   }
 
   // Rotate the real orientation about the map z axis by the yaw change, rather than rebuilding the
   // orientation from the yaw alone: the trajectory carries no roll or pitch, so building a yaw-only
   // rotation would silently flatten the vehicle's real attitude (measured at ~1 deg of pitch on a
-  // sloped route) in the frame the model and every transformed input see.
+  // sloped route) in the frame the model and every transformed input see. Height is the real one.
   const auto & real_orientation = kinematic_state.pose.pose.orientation;
   const Eigen::Quaterniond real_q(
     real_orientation.w, real_orientation.x, real_orientation.y, real_orientation.z);
-  const double yaw_change = autoware_utils_math::normalize_radian(virtual_pose.yaw - current_yaw);
+  const double yaw_change = autoware_utils_math::normalize_radian(virtual_pose->yaw - current_yaw);
   const Eigen::Quaterniond virtual_q =
     Eigen::Quaterniond(Eigen::AngleAxisd(yaw_change, Eigen::Vector3d::UnitZ())) * real_q;
 
   Eigen::Matrix4d snapped_pose = Eigen::Matrix4d::Identity();
   snapped_pose.block<3, 3>(0, 0) = virtual_q.normalized().toRotationMatrix();
-  snapped_pose(0, 3) = virtual_pose.position.x();
-  snapped_pose(1, 3) = virtual_pose.position.y();
-  snapped_pose(2, 3) = kinematic_state.pose.pose.position.z;
-  return std::make_pair(
-    snapped_pose, snap->interpolation_index * constants::PREDICTION_TIME_STEP_S);
+  snapped_pose(0, 3) = virtual_pose->position.x();
+  snapped_pose(1, 3) = virtual_pose->position.y();
+  snapped_pose(2, 3) = position.z;
+  return SnappedEgo{snapped_pose, snap->interpolation_index * constants::PREDICTION_TIME_STEP_S};
 }
 
 InputDataMap DiffusionPlannerCore::create_input_data(const FrameContext & frame_context)

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -408,9 +408,6 @@ std::string validate_ego_snap_params(const EgoSnapParams & p)
   if (auto r = finite_positive(p.max_yaw_error_deg, "max_yaw_error_deg"); !r.empty()) {
     return r;
   }
-  if (auto r = finite_non_negative(p.min_speed_mps, "min_speed_mps"); !r.empty()) {
-    return r;
-  }
   if (auto r = finite_non_negative(p.yaw_fit_half_window_m, "yaw_fit_half_window_m"); !r.empty()) {
     return r;
   }
@@ -462,12 +459,7 @@ std::optional<SnappedEgo> DiffusionPlannerCore::snap_ego_to_previous_trajectory(
   const bool has_previous_trajectory =
     last_ego_to_map_transform_.has_value() && !last_agent_poses_map_.empty() &&
     !last_agent_poses_map_[0].empty() && !last_agent_poses_map_[0][0].empty();
-  // When (nearly) stopped the leading segments of the previous trajectory are only centimetres
-  // long, so their direction is dominated by model noise: snapping would inject heading jitter.
-  const double ego_speed_mps =
-    std::hypot(kinematic_state.twist.twist.linear.x, kinematic_state.twist.twist.linear.y);
-  if (
-    !snap_params.enable || !has_previous_trajectory || ego_speed_mps < snap_params.min_speed_mps) {
+  if (!snap_params.enable || !has_previous_trajectory) {
     return std::nullopt;
   }
 

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -233,11 +233,22 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
   params_.ego_snap_to_prev_trajectory.snap_strength =
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.snap_strength", 0.9);
+  // Reject an out-of-range or non-finite value before the cap can turn it into something valid.
+  {
+    const double raw = params_.ego_snap_to_prev_trajectory.snap_strength;
+    if (!std::isfinite(raw) || raw < 0.0 || raw > 1.0) {
+      throw std::runtime_error(
+        "ego_snap_to_prev_trajectory.snap_strength must be in [0, 1] (values above 0.95 are "
+        "clipped to 0.95)");
+    }
+  }
   if (params_.ego_snap_to_prev_trajectory.snap_strength > kMaxSnapStrength) {
     RCLCPP_WARN(
       get_logger(),
-      "ego_snap_to_prev_trajectory.snap_strength=%.3f exceeds %.2f; clipping to %.2f. Above this the "
-      "virtual pose carries none of the localized pose and the gap to the trajectory is not closed.",
+      "ego_snap_to_prev_trajectory.snap_strength=%.3f exceeds %.2f; clipping to %.2f. Above this "
+      "the "
+      "virtual pose carries none of the localized pose and the gap to the trajectory is not "
+      "closed.",
       params_.ego_snap_to_prev_trajectory.snap_strength, kMaxSnapStrength, kMaxSnapStrength);
     params_.ego_snap_to_prev_trajectory.snap_strength = kMaxSnapStrength;
     this->set_parameter(
@@ -446,7 +457,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "guidance.centerline_guidance.start_time_s",
       temp_params.centerline_guidance_start_time_s);
-    if (const std::string reason = validate_ego_snap_params(temp_params.ego_snap_to_prev_trajectory);
+    if (const std::string reason =
+          validate_ego_snap_params(temp_params.ego_snap_to_prev_trajectory);
         !reason.empty()) {
       SetParametersResult result;
       result.successful = false;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -261,6 +261,12 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.yaw_fit_half_window_m", 1.0);
   params_.ego_snap_to_prev_trajectory.yaw_fit_min_length_m =
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.yaw_fit_min_length_m", 0.2);
+  // The parameter callback is registered after this function returns, so startup values would
+  // otherwise bypass the checks it applies to runtime updates.
+  if (const std::string reason = validate_ego_snap_params(params_.ego_snap_to_prev_trajectory);
+      !reason.empty()) {
+    throw std::runtime_error(reason);
+  }
   params_.start_guidance_reference_distance_m =
     this->declare_parameter<double>("guidance.start_guidance.reference_distance_m", 10.0);
   params_.start_guidance_max_scale =
@@ -440,27 +446,12 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "guidance.centerline_guidance.start_time_s",
       temp_params.centerline_guidance_start_time_s);
-    {
-      const auto & snap = temp_params.ego_snap_to_prev_trajectory;
-      std::string reason;
-      if (snap.yaw_source != "predicted_heading" && snap.yaw_source != "polyline_tangent") {
-        reason =
-          "ego_snap_to_prev_trajectory.yaw_source must be 'predicted_heading' or "
-          "'polyline_tangent'";
-      } else if (snap.limit_mode != "reject" && snap.limit_mode != "bound") {
-        reason = "ego_snap_to_prev_trajectory.limit_mode must be 'reject' or 'bound'";
-      } else if (snap.snap_strength < 0.0 || snap.snap_strength > 1.0) {
-        reason = "ego_snap_to_prev_trajectory.snap_strength must be in [0, 1] (values above 0.95 "
-                 "are clipped to 0.95)";
-      } else if (snap.history_prefix_count < 0) {
-        reason = "ego_snap_to_prev_trajectory.history_prefix_count must be >= 0";
-      }
-      if (!reason.empty()) {
-        SetParametersResult result;
-        result.successful = false;
-        result.reason = reason;
-        return result;
-      }
+    if (const std::string reason = validate_ego_snap_params(temp_params.ego_snap_to_prev_trajectory);
+        !reason.empty()) {
+      SetParametersResult result;
+      result.successful = false;
+      result.reason = reason;
+      return result;
     }
     if (temp_params.trt_precision != "fp32" && temp_params.trt_precision != "fp16") {
       SetParametersResult result;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -227,8 +227,6 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.max_yaw_error_deg", 5.0);
   params_.ego_snap_to_prev_trajectory.max_search_segment_count =
     this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.max_search_segment_count", 5);
-  params_.ego_snap_to_prev_trajectory.min_speed_mps =
-    this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 0.0);
   params_.ego_snap_to_prev_trajectory.limit_mode =
     this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
   params_.ego_snap_to_prev_trajectory.snap_strength =
@@ -413,9 +411,6 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<int64_t>(
       parameters, "ego_snap_to_prev_trajectory.max_search_segment_count",
       temp_params.ego_snap_to_prev_trajectory.max_search_segment_count);
-    update_param<double>(
-      parameters, "ego_snap_to_prev_trajectory.min_speed_mps",
-      temp_params.ego_snap_to_prev_trajectory.min_speed_mps);
     update_param<std::string>(
       parameters, "ego_snap_to_prev_trajectory.limit_mode",
       temp_params.ego_snap_to_prev_trajectory.limit_mode);

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -228,7 +228,7 @@ void DiffusionPlanner::set_up_params()
   params_.ego_snap_to_prev_trajectory.max_search_segment_count =
     this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.max_search_segment_count", 5);
   params_.ego_snap_to_prev_trajectory.min_speed_mps =
-    this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 1.0);
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 0.0);
   params_.ego_snap_to_prev_trajectory.limit_mode =
     this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
   params_.ego_snap_to_prev_trajectory.snap_strength =

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -25,13 +25,16 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <fstream>
 #include <functional>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -228,8 +231,18 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 1.0);
   params_.ego_snap_to_prev_trajectory.limit_mode =
     this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
-  params_.ego_snap_to_prev_trajectory.correction_gain =
-    this->declare_parameter<double>("ego_snap_to_prev_trajectory.correction_gain", 0.1);
+  params_.ego_snap_to_prev_trajectory.snap_strength =
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.snap_strength", 0.9);
+  // `correction_gain` was this parameter under an inverted meaning: gain 1 was the raw pose and
+  // gain 0 the strongest snap, which reads backwards and was misconfigured in practice. Fail
+  // loudly on the old name rather than silently running at a different strength.
+  if (!std::isnan(this->declare_parameter<double>(
+        "ego_snap_to_prev_trajectory.correction_gain", std::numeric_limits<double>::quiet_NaN()))) {
+    throw std::runtime_error(
+      "ego_snap_to_prev_trajectory.correction_gain has been replaced by "
+      "ego_snap_to_prev_trajectory.snap_strength with the opposite sense: set "
+      "snap_strength = 1 - correction_gain (0 disables the snap, 1 stays on the previous plan).");
+  }
   params_.ego_snap_to_prev_trajectory.history_prefix_count =
     this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.history_prefix_count", 10);
   params_.ego_snap_to_prev_trajectory.yaw_source = this->declare_parameter<std::string>(
@@ -380,8 +393,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
       parameters, "ego_snap_to_prev_trajectory.limit_mode",
       temp_params.ego_snap_to_prev_trajectory.limit_mode);
     update_param<double>(
-      parameters, "ego_snap_to_prev_trajectory.correction_gain",
-      temp_params.ego_snap_to_prev_trajectory.correction_gain);
+      parameters, "ego_snap_to_prev_trajectory.snap_strength",
+      temp_params.ego_snap_to_prev_trajectory.snap_strength);
     update_param<int64_t>(
       parameters, "ego_snap_to_prev_trajectory.history_prefix_count",
       temp_params.ego_snap_to_prev_trajectory.history_prefix_count);
@@ -417,8 +430,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
           "'polyline_tangent'";
       } else if (snap.limit_mode != "reject" && snap.limit_mode != "bound") {
         reason = "ego_snap_to_prev_trajectory.limit_mode must be 'reject' or 'bound'";
-      } else if (snap.correction_gain < 0.0 || snap.correction_gain > 1.0) {
-        reason = "ego_snap_to_prev_trajectory.correction_gain must be in [0, 1]";
+      } else if (snap.snap_strength < 0.0 || snap.snap_strength > 1.0) {
+        reason = "ego_snap_to_prev_trajectory.snap_strength must be in [0, 1]";
       } else if (snap.history_prefix_count < 0) {
         reason = "ego_snap_to_prev_trajectory.history_prefix_count must be >= 0";
       }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -224,6 +224,14 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.max_yaw_error_deg", 5.0);
   params_.ego_snap_to_prev_trajectory.max_search_segment_count =
     this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.max_search_segment_count", 5);
+  params_.ego_snap_to_prev_trajectory.min_speed_mps =
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 1.0);
+  params_.ego_snap_to_prev_trajectory.yaw_source = this->declare_parameter<std::string>(
+    "ego_snap_to_prev_trajectory.yaw_source", "polyline_tangent");
+  params_.ego_snap_to_prev_trajectory.yaw_fit_half_window_m =
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.yaw_fit_half_window_m", 1.0);
+  params_.ego_snap_to_prev_trajectory.yaw_fit_min_length_m =
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.yaw_fit_min_length_m", 0.2);
   params_.start_guidance_reference_distance_m =
     this->declare_parameter<double>("guidance.start_guidance.reference_distance_m", 10.0);
   params_.start_guidance_max_scale =
@@ -360,6 +368,18 @@ SetParametersResult DiffusionPlanner::on_parameter(
       parameters, "ego_snap_to_prev_trajectory.max_search_segment_count",
       temp_params.ego_snap_to_prev_trajectory.max_search_segment_count);
     update_param<double>(
+      parameters, "ego_snap_to_prev_trajectory.min_speed_mps",
+      temp_params.ego_snap_to_prev_trajectory.min_speed_mps);
+    update_param<std::string>(
+      parameters, "ego_snap_to_prev_trajectory.yaw_source",
+      temp_params.ego_snap_to_prev_trajectory.yaw_source);
+    update_param<double>(
+      parameters, "ego_snap_to_prev_trajectory.yaw_fit_half_window_m",
+      temp_params.ego_snap_to_prev_trajectory.yaw_fit_half_window_m);
+    update_param<double>(
+      parameters, "ego_snap_to_prev_trajectory.yaw_fit_min_length_m",
+      temp_params.ego_snap_to_prev_trajectory.yaw_fit_min_length_m);
+    update_param<double>(
       parameters, "object_motion_resampling.max_extrapolation_time",
       temp_params.object_motion_resampling.max_extrapolation_time);
     update_param<double>(
@@ -373,6 +393,14 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "guidance.centerline_guidance.start_time_s",
       temp_params.centerline_guidance_start_time_s);
+    if (const auto & yaw_source = temp_params.ego_snap_to_prev_trajectory.yaw_source;
+        yaw_source != "predicted_heading" && yaw_source != "polyline_tangent") {
+      SetParametersResult result;
+      result.successful = false;
+      result.reason =
+        "ego_snap_to_prev_trajectory.yaw_source must be 'predicted_heading' or 'polyline_tangent'";
+      return result;
+    }
     if (temp_params.trt_precision != "fp32" && temp_params.trt_precision != "fp16") {
       SetParametersResult result;
       result.successful = false;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -233,6 +233,16 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
   params_.ego_snap_to_prev_trajectory.snap_strength =
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.snap_strength", 0.9);
+  if (params_.ego_snap_to_prev_trajectory.snap_strength > kMaxSnapStrength) {
+    RCLCPP_WARN(
+      get_logger(),
+      "ego_snap_to_prev_trajectory.snap_strength=%.3f exceeds %.2f; clipping to %.2f. Above this the "
+      "virtual pose carries none of the localized pose and the gap to the trajectory is not closed.",
+      params_.ego_snap_to_prev_trajectory.snap_strength, kMaxSnapStrength, kMaxSnapStrength);
+    params_.ego_snap_to_prev_trajectory.snap_strength = kMaxSnapStrength;
+    this->set_parameter(
+      rclcpp::Parameter("ego_snap_to_prev_trajectory.snap_strength", kMaxSnapStrength));
+  }
   // `correction_gain` was this parameter under an inverted meaning: gain 1 was the raw pose and
   // gain 0 the strongest snap, which reads backwards and was misconfigured in practice. Fail
   // loudly on the old name rather than silently running at a different strength.
@@ -395,6 +405,15 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "ego_snap_to_prev_trajectory.snap_strength",
       temp_params.ego_snap_to_prev_trajectory.snap_strength);
+    if (
+      temp_params.ego_snap_to_prev_trajectory.snap_strength > kMaxSnapStrength &&
+      temp_params.ego_snap_to_prev_trajectory.snap_strength <= 1.0) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "ego_snap_to_prev_trajectory.snap_strength=%.3f exceeds %.2f; running at %.2f.",
+        temp_params.ego_snap_to_prev_trajectory.snap_strength, kMaxSnapStrength, kMaxSnapStrength);
+      temp_params.ego_snap_to_prev_trajectory.snap_strength = kMaxSnapStrength;
+    }
     update_param<int64_t>(
       parameters, "ego_snap_to_prev_trajectory.history_prefix_count",
       temp_params.ego_snap_to_prev_trajectory.history_prefix_count);
@@ -431,7 +450,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
       } else if (snap.limit_mode != "reject" && snap.limit_mode != "bound") {
         reason = "ego_snap_to_prev_trajectory.limit_mode must be 'reject' or 'bound'";
       } else if (snap.snap_strength < 0.0 || snap.snap_strength > 1.0) {
-        reason = "ego_snap_to_prev_trajectory.snap_strength must be in [0, 1]";
+        reason = "ego_snap_to_prev_trajectory.snap_strength must be in [0, 1] (values above 0.95 "
+                 "are clipped to 0.95)";
       } else if (snap.history_prefix_count < 0) {
         reason = "ego_snap_to_prev_trajectory.history_prefix_count must be >= 0";
       }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -226,6 +226,12 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.max_search_segment_count", 5);
   params_.ego_snap_to_prev_trajectory.min_speed_mps =
     this->declare_parameter<double>("ego_snap_to_prev_trajectory.min_speed_mps", 1.0);
+  params_.ego_snap_to_prev_trajectory.limit_mode =
+    this->declare_parameter<std::string>("ego_snap_to_prev_trajectory.limit_mode", "bound");
+  params_.ego_snap_to_prev_trajectory.correction_gain =
+    this->declare_parameter<double>("ego_snap_to_prev_trajectory.correction_gain", 0.1);
+  params_.ego_snap_to_prev_trajectory.history_prefix_count =
+    this->declare_parameter<int64_t>("ego_snap_to_prev_trajectory.history_prefix_count", 10);
   params_.ego_snap_to_prev_trajectory.yaw_source = this->declare_parameter<std::string>(
     "ego_snap_to_prev_trajectory.yaw_source", "polyline_tangent");
   params_.ego_snap_to_prev_trajectory.yaw_fit_half_window_m =
@@ -371,6 +377,15 @@ SetParametersResult DiffusionPlanner::on_parameter(
       parameters, "ego_snap_to_prev_trajectory.min_speed_mps",
       temp_params.ego_snap_to_prev_trajectory.min_speed_mps);
     update_param<std::string>(
+      parameters, "ego_snap_to_prev_trajectory.limit_mode",
+      temp_params.ego_snap_to_prev_trajectory.limit_mode);
+    update_param<double>(
+      parameters, "ego_snap_to_prev_trajectory.correction_gain",
+      temp_params.ego_snap_to_prev_trajectory.correction_gain);
+    update_param<int64_t>(
+      parameters, "ego_snap_to_prev_trajectory.history_prefix_count",
+      temp_params.ego_snap_to_prev_trajectory.history_prefix_count);
+    update_param<std::string>(
       parameters, "ego_snap_to_prev_trajectory.yaw_source",
       temp_params.ego_snap_to_prev_trajectory.yaw_source);
     update_param<double>(
@@ -393,13 +408,26 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<double>(
       parameters, "guidance.centerline_guidance.start_time_s",
       temp_params.centerline_guidance_start_time_s);
-    if (const auto & yaw_source = temp_params.ego_snap_to_prev_trajectory.yaw_source;
-        yaw_source != "predicted_heading" && yaw_source != "polyline_tangent") {
-      SetParametersResult result;
-      result.successful = false;
-      result.reason =
-        "ego_snap_to_prev_trajectory.yaw_source must be 'predicted_heading' or 'polyline_tangent'";
-      return result;
+    {
+      const auto & snap = temp_params.ego_snap_to_prev_trajectory;
+      std::string reason;
+      if (snap.yaw_source != "predicted_heading" && snap.yaw_source != "polyline_tangent") {
+        reason =
+          "ego_snap_to_prev_trajectory.yaw_source must be 'predicted_heading' or "
+          "'polyline_tangent'";
+      } else if (snap.limit_mode != "reject" && snap.limit_mode != "bound") {
+        reason = "ego_snap_to_prev_trajectory.limit_mode must be 'reject' or 'bound'";
+      } else if (snap.correction_gain < 0.0 || snap.correction_gain > 1.0) {
+        reason = "ego_snap_to_prev_trajectory.correction_gain must be in [0, 1]";
+      } else if (snap.history_prefix_count < 0) {
+        reason = "ego_snap_to_prev_trajectory.history_prefix_count must be >= 0";
+      }
+      if (!reason.empty()) {
+        SetParametersResult result;
+        result.successful = false;
+        result.reason = reason;
+        return result;
+      }
     }
     if (temp_params.trt_precision != "fp32" && temp_params.trt_precision != "fp16") {
       SetParametersResult result;

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -14,11 +14,20 @@
 
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
+#include "autoware/trajectory/interpolator/cubic_spline.hpp"
+#include "autoware/trajectory/pose.hpp"
+#include "autoware/trajectory/threshold.hpp"
+#include "autoware/trajectory/utils/closest.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <iterator>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -125,75 +134,115 @@ geometry_msgs::msg::Pose shift_x(const geometry_msgs::msg::Pose & pose, const do
   return shifted_pose;
 }
 
-PolylineProjection project_pose_onto_polyline(
-  const double query_x, const double query_y, const std::vector<Eigen::Matrix4d> & polyline,
-  const int64_t max_search_segment_count)
+namespace
 {
-  if (polyline.size() < 2) {
-    throw std::runtime_error("project_pose_onto_polyline requires at least two poses");
-  }
-  if (max_search_segment_count < 1) {
-    throw std::runtime_error("project_pose_onto_polyline requires max_search_segment_count >= 1");
-  }
+geometry_msgs::msg::Pose matrix4d_to_pose(const Eigen::Matrix4d & matrix)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = matrix(0, 3);
+  pose.position.y = matrix(1, 3);
+  pose.position.z = matrix(2, 3);
+  const Eigen::Quaterniond q(matrix.block<3, 3>(0, 0));
+  pose.orientation.x = q.x();
+  pose.orientation.y = q.y();
+  pose.orientation.z = q.z();
+  pose.orientation.w = q.w();
+  return pose;
+}
 
-  const Eigen::Vector2d query(query_x, query_y);
-
-  double best_dist_sq = std::numeric_limits<double>::max();
-  Eigen::Vector2d best_foot = query;
-  Eigen::Quaterniond best_orientation = Eigen::Quaterniond::Identity();
-  // (closest segment index + intra-segment ratio); position of the foot along the polyline.
-  double best_interpolation_index = 0.0;
-
-  // Because the diffusion planner runs at 10Hz and the polyline vertices are spaced by one
-  // prediction step (0.1s), the foot always lands within the first few segments. Limiting the
-  // search keeps a far-away part of the trajectory (e.g. the return leg of a U-turn) from being
-  // selected as the closest segment.
-  const size_t segment_count = static_cast<size_t>(max_search_segment_count);
-
-  for (size_t i = 0; i < segment_count && i + 1 < polyline.size(); ++i) {
-    // Endpoints of the i-th line segment in the xy-plane.
-    const Eigen::Vector2d segment_start(polyline[i](0, 3), polyline[i](1, 3));
-    const Eigen::Vector2d segment_end(polyline[i + 1](0, 3), polyline[i + 1](1, 3));
-
-    // Direction vector of the segment (start -> end) and the vector from the start to the query.
-    const Eigen::Vector2d segment_vector = segment_end - segment_start;
-    const Eigen::Vector2d start_to_query = query - segment_start;
-
-    // Squared length of the segment. Also used to guard against a degenerate (zero-length) segment.
-    const double segment_length_sq = segment_vector.squaredNorm();
-
-    // Projection ratio of the query point onto the infinite line through the segment:
-    //   raw_ratio = dot(start_to_query, segment_vector) / |segment_vector|^2
-    // raw_ratio == 0 -> foot at segment_start, raw_ratio == 1 -> foot at segment_end.
-    // Clamping to [0, 1] keeps the foot ON the segment: if the perpendicular foot would land beyond
-    // an endpoint (raw_ratio < 0 or > 1), it is pulled back to the nearest endpoint.
-    constexpr double EPS = 1e-9;
-    double ratio = 0.0;
-    if (segment_length_sq >= EPS) {
-      const double projection = start_to_query.dot(segment_vector);
-      const double raw_ratio = projection / segment_length_sq;
-      ratio = std::clamp(raw_ratio, 0.0, 1.0);
+// Leading vertices of the polyline up to (excluding) the first vertex that coincides with its
+// predecessor. Coincident vertices would give the spline (near) zero-length bases.
+std::vector<geometry_msgs::msg::Pose> leading_distinct_poses(
+  const std::vector<Eigen::Matrix4d> & polyline)
+{
+  std::vector<geometry_msgs::msg::Pose> poses;
+  poses.reserve(polyline.size());
+  for (const auto & matrix : polyline) {
+    const geometry_msgs::msg::Pose pose = matrix4d_to_pose(matrix);
+    if (
+      !poses.empty() &&
+      autoware::experimental::trajectory::is_almost_same(poses.back().position, pose.position)) {
+      break;
     }
+    poses.push_back(pose);
+  }
+  return poses;
+}
 
-    // Foot of the perpendicular (already clamped onto the segment) and its distance to the query.
-    const Eigen::Vector2d foot = segment_start + ratio * segment_vector;
-    const double dist_sq = (query - foot).squaredNorm();
+// (segment index + intra-segment ratio) of arc length s given the vertex arc lengths.
+double arc_length_to_interpolation_index(const std::vector<double> & bases, const double s)
+{
+  const auto upper = std::upper_bound(bases.begin(), bases.end(), s);
+  const int64_t segment = std::clamp<int64_t>(
+    static_cast<int64_t>(std::distance(bases.begin(), upper)) - 1, 0,
+    static_cast<int64_t>(bases.size()) - 2);
+  const double segment_length = bases[segment + 1] - bases[segment];
+  const double ratio = std::clamp((s - bases[segment]) / segment_length, 0.0, 1.0);
+  return static_cast<double>(segment) + ratio;
+}
 
-    if (dist_sq < best_dist_sq) {
-      best_dist_sq = dist_sq;
-      best_foot = foot;
-      const Eigen::Quaterniond start_orientation(polyline[i].block<3, 3>(0, 0));
-      const Eigen::Quaterniond end_orientation(polyline[i + 1].block<3, 3>(0, 0));
-      best_orientation = start_orientation.slerp(ratio, end_orientation);
-      best_interpolation_index = static_cast<double>(i) + ratio;
-    }
+std::optional<double> windowed_tangent_yaw(
+  const autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Pose> & trajectory,
+  const double s, const double half_window_m, const double min_length_m)
+{
+  const double lo = std::max(0.0, s - half_window_m);
+  const double hi = std::min(trajectory.length(), s + half_window_m);
+  if (hi - lo < min_length_m) {
+    return std::nullopt;
+  }
+  constexpr double SAMPLE_TICK_M = 0.05;
+  const std::vector<double> azimuths =
+    trajectory.azimuth(trajectory.base_arange({lo, hi}, SAMPLE_TICK_M));
+  double sum_cos = 0.0;
+  double sum_sin = 0.0;
+  for (const double yaw : azimuths) {
+    sum_cos += std::cos(yaw);
+    sum_sin += std::sin(yaw);
+  }
+  return std::atan2(sum_sin, sum_cos);
+}
+}  // namespace
+
+std::optional<TrajectorySnap> snap_point_to_trajectory(
+  const double query_x, const double query_y, const std::vector<Eigen::Matrix4d> & polyline,
+  const TrajectorySnapOptions & options)
+{
+  using autoware::experimental::trajectory::Trajectory;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+
+  if (options.max_search_segment_count < 1) {
+    throw std::runtime_error("snap_point_to_trajectory requires max_search_segment_count >= 1");
   }
 
-  Eigen::Matrix4d projected = Eigen::Matrix4d::Identity();
-  projected.block<3, 3>(0, 0) = best_orientation.normalized().toRotationMatrix();
-  projected(0, 3) = best_foot.x();
-  projected(1, 3) = best_foot.y();
-  return PolylineProjection{projected, best_interpolation_index};
+  const std::vector<geometry_msgs::msg::Pose> poses = leading_distinct_poses(polyline);
+  if (poses.size() < 2) {
+    return std::nullopt;
+  }
+  const auto trajectory =
+    Trajectory<geometry_msgs::msg::Pose>::Builder{}.set_xy_interpolator<CubicSpline>().build(poses);
+  if (!trajectory) {
+    return std::nullopt;
+  }
+
+  const std::vector<double> bases = trajectory->get_underlying_bases();
+  const double search_end_s = bases[std::min<size_t>(
+    static_cast<size_t>(options.max_search_segment_count), bases.size() - 1)];
+  geometry_msgs::msg::Point query;
+  query.x = query_x;
+  query.y = query_y;
+  const std::optional<double> s = autoware::experimental::trajectory::closest_with_constraint(
+    *trajectory, query, [search_end_s](const double & s) { return s <= search_end_s; });
+  if (!s) {
+    return std::nullopt;
+  }
+
+  const geometry_msgs::msg::Pose snapped = trajectory->compute(*s);
+  return TrajectorySnap{
+    Eigen::Vector2d(snapped.position.x, snapped.position.y),
+    arc_length_to_interpolation_index(bases, *s),
+    autoware_utils_geometry::get_rpy(snapped.orientation).z,
+    windowed_tangent_yaw(
+      *trajectory, *s, options.yaw_fit_half_window_m, options.yaw_fit_min_length_m)};
 }
 
 Eigen::Matrix4d inverse(const Eigen::Matrix4d & mat)

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -261,25 +261,24 @@ std::optional<TrajectorySnap> snap_point_to_trajectory(
 
 BoundedPose bound_snapped_pose(
   const Eigen::Vector2d & real_position, const double real_yaw,
-  const Eigen::Vector2d & snapped_position, const double snapped_yaw, const double correction_gain,
+  const Eigen::Vector2d & snapped_position, const double snapped_yaw, const double snap_strength,
   const double max_position_error_m, const double max_yaw_error_rad)
 {
-  if (correction_gain < 0.0 || correction_gain > 1.0) {
-    throw std::runtime_error("bound_snapped_pose requires correction_gain in [0, 1]");
+  if (snap_strength < 0.0 || snap_strength > 1.0) {
+    throw std::runtime_error("bound_snapped_pose requires snap_strength in [0, 1]");
   }
   if (max_position_error_m <= 0.0 || max_yaw_error_rad <= 0.0) {
     throw std::runtime_error("bound_snapped_pose requires positive error limits");
   }
-  const double keep = 1.0 - correction_gain;
-
-  Eigen::Vector2d residual = keep * (real_position - snapped_position);
+  Eigen::Vector2d residual = snap_strength * (real_position - snapped_position);
   const double norm = residual.norm();
   if (norm > max_position_error_m) {
     residual *= max_position_error_m / norm;
   }
 
   const double yaw_residual = std::clamp(
-    keep * autoware_utils_math::normalize_radian(real_yaw - snapped_yaw), -max_yaw_error_rad,
+    snap_strength * autoware_utils_math::normalize_radian(real_yaw - snapped_yaw),
+    -max_yaw_error_rad,
     max_yaw_error_rad);
 
   return BoundedPose{

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -20,6 +20,7 @@
 #include "autoware/trajectory/utils/closest.hpp"
 
 #include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -185,8 +186,11 @@ std::optional<double> windowed_tangent_yaw(
   const autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Pose> & trajectory,
   const double s, const double half_window_m, const double min_length_m)
 {
-  const double lo = std::max(0.0, s - half_window_m);
-  const double hi = std::min(trajectory.length(), s + half_window_m);
+  // Symmetric window: shrink it when it would run past either end so the mean is not biased
+  // toward one side of the snapped point (the point sits close to the start of a prediction).
+  const double half = std::min({half_window_m, s, trajectory.length() - s});
+  const double lo = s - half;
+  const double hi = s + half;
   if (hi - lo < min_length_m) {
     return std::nullopt;
   }
@@ -213,9 +217,13 @@ std::optional<TrajectorySnap> snap_point_to_trajectory(
   if (options.max_search_segment_count < 1) {
     throw std::runtime_error("snap_point_to_trajectory requires max_search_segment_count >= 1");
   }
+  if (options.prefix_count < 0) {
+    throw std::runtime_error("snap_point_to_trajectory requires prefix_count >= 0");
+  }
 
   const std::vector<geometry_msgs::msg::Pose> poses = leading_distinct_poses(polyline);
-  if (poses.size() < 2) {
+  const size_t prefix = static_cast<size_t>(options.prefix_count);
+  if (poses.size() < prefix + 2) {
     return std::nullopt;
   }
   const auto trajectory =
@@ -224,14 +232,19 @@ std::optional<TrajectorySnap> snap_point_to_trajectory(
     return std::nullopt;
   }
 
-  const std::vector<double> bases = trajectory->get_underlying_bases();
+  // Bases of the trajectory proper: vertex `prefix` is the trajectory start (s_start).
+  const std::vector<double> all_bases = trajectory->get_underlying_bases();
+  const std::vector<double> bases(all_bases.begin() + prefix, all_bases.end());
+  const double search_start_s = bases.front();
   const double search_end_s = bases[std::min<size_t>(
     static_cast<size_t>(options.max_search_segment_count), bases.size() - 1)];
   geometry_msgs::msg::Point query;
   query.x = query_x;
   query.y = query_y;
   const std::optional<double> s = autoware::experimental::trajectory::closest_with_constraint(
-    *trajectory, query, [search_end_s](const double & s) { return s <= search_end_s; });
+    *trajectory, query, [search_start_s, search_end_s](const double & s) {
+      return search_start_s <= s && s <= search_end_s;
+    });
   if (!s) {
     return std::nullopt;
   }
@@ -243,6 +256,34 @@ std::optional<TrajectorySnap> snap_point_to_trajectory(
     autoware_utils_geometry::get_rpy(snapped.orientation).z,
     windowed_tangent_yaw(
       *trajectory, *s, options.yaw_fit_half_window_m, options.yaw_fit_min_length_m)};
+  ;
+}
+
+BoundedPose bound_snapped_pose(
+  const Eigen::Vector2d & real_position, const double real_yaw,
+  const Eigen::Vector2d & snapped_position, const double snapped_yaw, const double correction_gain,
+  const double max_position_error_m, const double max_yaw_error_rad)
+{
+  if (correction_gain < 0.0 || correction_gain > 1.0) {
+    throw std::runtime_error("bound_snapped_pose requires correction_gain in [0, 1]");
+  }
+  if (max_position_error_m <= 0.0 || max_yaw_error_rad <= 0.0) {
+    throw std::runtime_error("bound_snapped_pose requires positive error limits");
+  }
+  const double keep = 1.0 - correction_gain;
+
+  Eigen::Vector2d residual = keep * (real_position - snapped_position);
+  const double norm = residual.norm();
+  if (norm > max_position_error_m) {
+    residual *= max_position_error_m / norm;
+  }
+
+  const double yaw_residual = std::clamp(
+    keep * autoware_utils_math::normalize_radian(real_yaw - snapped_yaw), -max_yaw_error_rad,
+    max_yaw_error_rad);
+
+  return BoundedPose{
+    real_position - residual, autoware_utils_math::normalize_radian(real_yaw - yaw_residual)};
 }
 
 Eigen::Matrix4d inverse(const Eigen::Matrix4d & mat)

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -285,8 +285,7 @@ BoundedPose bound_snapped_pose(
 
   const double yaw_residual = std::clamp(
     snap_strength * autoware_utils_math::normalize_radian(real_yaw - snapped_yaw),
-    -max_yaw_error_rad,
-    max_yaw_error_rad);
+    -max_yaw_error_rad, max_yaw_error_rad);
 
   return BoundedPose{
     real_position - residual, autoware_utils_math::normalize_radian(real_yaw - yaw_residual)};

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -221,7 +221,14 @@ std::optional<TrajectorySnap> snap_point_to_trajectory(
     throw std::runtime_error("snap_point_to_trajectory requires prefix_count >= 0");
   }
 
-  const std::vector<geometry_msgs::msg::Pose> poses = leading_distinct_poses(polyline);
+  std::vector<geometry_msgs::msg::Pose> poses = leading_distinct_poses(polyline);
+  // This is an xy operation, but closest_with_constraint measures 3D distance and the spline's arc
+  // length includes z. A trajectory at elevation, or one climbing a slope, would otherwise be
+  // compared against a query at z = 0 and the closest point would be wrong. Flatten the geometry;
+  // the caller keeps the vehicle's real height.
+  for (auto & pose : poses) {
+    pose.position.z = 0.0;
+  }
   const size_t prefix = static_cast<size_t>(options.prefix_count);
   if (poses.size() < prefix + 2) {
     return std::nullopt;

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -194,7 +194,7 @@ std::vector<Eigen::Matrix4d> straight_polyline(const size_t count, const double 
   return polyline;
 }
 
-constexpr utils::TrajectorySnapOptions default_options{5, 1.0, 0.2};
+constexpr utils::TrajectorySnapOptions default_options{0, 5, 1.0, 0.2};
 }  // namespace
 
 // A query point lying exactly on a vertex of a straight polyline is a no-op: same position, same
@@ -233,7 +233,7 @@ TEST_F(UtilsTest, SnapPointToTrajectoryLateralOffset)
 TEST_F(UtilsTest, SnapPointToTrajectoryRespectsSearchWindow)
 {
   const auto polyline = straight_polyline(10, 1.0);
-  const utils::TrajectorySnapOptions options{3, 1.0, 0.2};
+  const utils::TrajectorySnapOptions options{0, 3, 1.0, 0.2};
 
   const auto snap = utils::snap_point_to_trajectory(8.0, 0.0, polyline, options);
 
@@ -273,7 +273,9 @@ TEST_F(UtilsTest, SnapPointToTrajectoryTangentIsRobustToPositionJitter)
     polyline.push_back(make_pose(static_cast<double>(i) * 0.1, jitter_y, 0.0));
   }
 
-  const auto snap = utils::snap_point_to_trajectory(0.35, 0.0, polyline, default_options);
+  // 1.35 m from the start so the symmetric +-1 m window is not clipped.
+  const auto snap = utils::snap_point_to_trajectory(
+    1.35, 0.0, polyline, utils::TrajectorySnapOptions{0, 20, 1.0, 0.2});
 
   ASSERT_TRUE(snap.has_value());
   ASSERT_TRUE(snap->tangent_yaw.has_value());
@@ -307,7 +309,7 @@ TEST_F(UtilsTest, SnapPointToTrajectoryTangentOnArc)
 TEST_F(UtilsTest, SnapPointToTrajectoryNoTangentOnTooShortWindow)
 {
   const auto polyline = straight_polyline(3, 0.05);  // 10 cm in total
-  const utils::TrajectorySnapOptions options{5, 1.0, 0.2};
+  const utils::TrajectorySnapOptions options{0, 5, 1.0, 0.2};
 
   const auto snap = utils::snap_point_to_trajectory(0.05, 0.0, polyline, options);
 
@@ -340,10 +342,108 @@ TEST_F(UtilsTest, SnapPointToTrajectoryReturnsNulloptOnDegeneratePolyline)
   EXPECT_FALSE(utils::snap_point_to_trajectory(0.0, 0.0, {}, default_options).has_value());
 }
 
+// The tangent window is symmetric around the snapped point: close to the start of the polyline it
+// shrinks instead of extending forward only, so a curve does not bias the heading into the turn.
+TEST_F(UtilsTest, SnapPointToTrajectoryTangentWindowIsSymmetricNearStart)
+{
+  constexpr double radius = 10.0;
+  std::vector<Eigen::Matrix4d> polyline;
+  for (size_t i = 0; i < 40; ++i) {
+    const double theta = static_cast<double>(i) * 0.25 / radius;  // 0.25 m arc steps
+    polyline.push_back(
+      make_pose(radius * std::sin(theta), radius * (1.0 - std::cos(theta)), theta));
+  }
+  const double query_theta = 0.5 / radius;  // 0.5 m from the start; a +-1 m window would clip
+  const auto snap = utils::snap_point_to_trajectory(
+    radius * std::sin(query_theta), radius * (1.0 - std::cos(query_theta)), polyline,
+    utils::TrajectorySnapOptions{0, 5, 1.0, 0.2});
+
+  ASSERT_TRUE(snap.has_value());
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  // A forward-only window [0, 1.5] would average to ~0.075 rad; symmetric [0, 1.0] gives 0.05.
+  EXPECT_NEAR(*snap->tangent_yaw, query_theta, 2e-3);
+}
+
+// Prefix vertices extend the spline behind the trajectory start: the closest point is still
+// searched from the trajectory start, interpolation_index stays relative to it, and the tangent
+// window can now reach behind the snapped point instead of shrinking.
+TEST_F(UtilsTest, SnapPointToTrajectoryPrefixExtendsWindowBackwards)
+{
+  std::vector<Eigen::Matrix4d> polyline;
+  for (int i = -10; i < 20; ++i) {  // 10 prefix vertices at x<0, trajectory from x=0
+    const double jitter_y = (i % 2 == 0) ? 0.01 : -0.01;
+    polyline.push_back(make_pose(static_cast<double>(i) * 0.1, jitter_y, 0.0));
+  }
+  const utils::TrajectorySnapOptions options{10, 5, 1.0, 0.2};
+
+  // Query behind the trajectory start: must clamp onto the start, not onto the prefix.
+  const auto behind = utils::snap_point_to_trajectory(-0.5, 0.0, polyline, options);
+  ASSERT_TRUE(behind.has_value());
+  EXPECT_NEAR(behind->position.x(), 0.0, 1e-6);
+  EXPECT_NEAR(behind->interpolation_index, 0.0, 1e-6);
+
+  // Query 0.35 m in: a symmetric +-1 m window is available thanks to the prefix, so the jittered
+  // headings average out where a prefix-less polyline would only offer +-0.35 m.
+  const auto snap = utils::snap_point_to_trajectory(0.35, 0.0, polyline, options);
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->interpolation_index, 3.5, 0.2);
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  EXPECT_NEAR(*snap->tangent_yaw, 0.0, 0.02);
+}
+
+TEST_F(UtilsTest, BoundSnappedPoseKeepsSnappedPoseWhenGainIsZero)
+{
+  const auto b = utils::bound_snapped_pose(
+    Eigen::Vector2d(0.1, 0.2), 0.05, Eigen::Vector2d(0.0, 0.0), 0.0, 0.0, 0.3, 0.1);
+  EXPECT_NEAR(b.position.x(), 0.0, 1e-9);
+  EXPECT_NEAR(b.position.y(), 0.0, 1e-9);
+  EXPECT_NEAR(b.yaw, 0.0, 1e-9);
+}
+
+TEST_F(UtilsTest, BoundSnappedPoseLeaksResidualByGain)
+{
+  const auto b = utils::bound_snapped_pose(
+    Eigen::Vector2d(0.2, 0.0), 0.04, Eigen::Vector2d(0.0, 0.0), 0.0, 0.25, 0.3, 0.1);
+  // virtual = snapped + gain * (real - snapped)
+  EXPECT_NEAR(b.position.x(), 0.05, 1e-9);
+  EXPECT_NEAR(b.yaw, 0.01, 1e-9);
+}
+
+// Beyond the limits the pose is saturated at the limit from the real pose instead of being
+// rejected, so the output is continuous in the residual.
+TEST_F(UtilsTest, BoundSnappedPoseSaturatesAtLimits)
+{
+  const auto b = utils::bound_snapped_pose(
+    Eigen::Vector2d(0.0, 1.0), 0.5, Eigen::Vector2d(0.0, 0.0), 0.0, 0.0, 0.3, 0.1);
+  EXPECT_NEAR(b.position.x(), 0.0, 1e-9);
+  EXPECT_NEAR(b.position.y(), 0.7, 1e-9);  // 0.3 m from the real pose toward the snapped one
+  EXPECT_NEAR(b.yaw, 0.4, 1e-9);           // 0.1 rad from the real yaw toward the snapped one
+}
+
+TEST_F(UtilsTest, BoundSnappedPoseWrapsYaw)
+{
+  const auto b = utils::bound_snapped_pose(
+    Eigen::Vector2d::Zero(), M_PI - 0.01, Eigen::Vector2d::Zero(), -M_PI + 0.01, 0.0, 0.3, 0.1);
+  // The residual across the +-pi seam is 0.02 rad, not 2 pi - 0.02.
+  EXPECT_NEAR(std::abs(b.yaw), M_PI - 0.01, 1e-9);
+}
+
+TEST_F(UtilsTest, BoundSnappedPoseThrowsOnBadArguments)
+{
+  EXPECT_THROW(
+    utils::bound_snapped_pose(
+      Eigen::Vector2d::Zero(), 0.0, Eigen::Vector2d::Zero(), 0.0, 1.5, 0.3, 0.1),
+    std::runtime_error);
+  EXPECT_THROW(
+    utils::bound_snapped_pose(
+      Eigen::Vector2d::Zero(), 0.0, Eigen::Vector2d::Zero(), 0.0, 0.1, 0.0, 0.1),
+    std::runtime_error);
+}
+
 TEST_F(UtilsTest, SnapPointToTrajectoryThrowsOnNonPositiveSearchWindow)
 {
   const auto polyline = straight_polyline(3, 1.0);
-  const utils::TrajectorySnapOptions options{0, 1.0, 0.2};
+  const utils::TrajectorySnapOptions options{0, 0, 1.0, 0.2};
 
   EXPECT_THROW(utils::snap_point_to_trajectory(0.0, 0.0, polyline, options), std::runtime_error);
 }

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -391,20 +391,20 @@ TEST_F(UtilsTest, SnapPointToTrajectoryPrefixExtendsWindowBackwards)
   EXPECT_NEAR(*snap->tangent_yaw, 0.0, 0.02);
 }
 
-TEST_F(UtilsTest, BoundSnappedPoseKeepsSnappedPoseWhenGainIsZero)
+TEST_F(UtilsTest, BoundSnappedPoseKeepsSnappedPoseWhenStrengthIsOne)
 {
   const auto b = utils::bound_snapped_pose(
-    Eigen::Vector2d(0.1, 0.2), 0.05, Eigen::Vector2d(0.0, 0.0), 0.0, 0.0, 0.3, 0.1);
+    Eigen::Vector2d(0.1, 0.2), 0.05, Eigen::Vector2d(0.0, 0.0), 0.0, 1.0, 0.3, 0.1);
   EXPECT_NEAR(b.position.x(), 0.0, 1e-9);
   EXPECT_NEAR(b.position.y(), 0.0, 1e-9);
   EXPECT_NEAR(b.yaw, 0.0, 1e-9);
 }
 
-TEST_F(UtilsTest, BoundSnappedPoseLeaksResidualByGain)
+TEST_F(UtilsTest, BoundSnappedPoseBlendsByStrength)
 {
   const auto b = utils::bound_snapped_pose(
-    Eigen::Vector2d(0.2, 0.0), 0.04, Eigen::Vector2d(0.0, 0.0), 0.0, 0.25, 0.3, 0.1);
-  // virtual = snapped + gain * (real - snapped)
+    Eigen::Vector2d(0.2, 0.0), 0.04, Eigen::Vector2d(0.0, 0.0), 0.0, 0.75, 0.3, 0.1);
+  // virtual = real - strength * (real - snapped)
   EXPECT_NEAR(b.position.x(), 0.05, 1e-9);
   EXPECT_NEAR(b.yaw, 0.01, 1e-9);
 }
@@ -414,7 +414,7 @@ TEST_F(UtilsTest, BoundSnappedPoseLeaksResidualByGain)
 TEST_F(UtilsTest, BoundSnappedPoseSaturatesAtLimits)
 {
   const auto b = utils::bound_snapped_pose(
-    Eigen::Vector2d(0.0, 1.0), 0.5, Eigen::Vector2d(0.0, 0.0), 0.0, 0.0, 0.3, 0.1);
+    Eigen::Vector2d(0.0, 1.0), 0.5, Eigen::Vector2d(0.0, 0.0), 0.0, 1.0, 0.3, 0.1);
   EXPECT_NEAR(b.position.x(), 0.0, 1e-9);
   EXPECT_NEAR(b.position.y(), 0.7, 1e-9);  // 0.3 m from the real pose toward the snapped one
   EXPECT_NEAR(b.yaw, 0.4, 1e-9);           // 0.1 rad from the real yaw toward the snapped one
@@ -423,7 +423,7 @@ TEST_F(UtilsTest, BoundSnappedPoseSaturatesAtLimits)
 TEST_F(UtilsTest, BoundSnappedPoseWrapsYaw)
 {
   const auto b = utils::bound_snapped_pose(
-    Eigen::Vector2d::Zero(), M_PI - 0.01, Eigen::Vector2d::Zero(), -M_PI + 0.01, 0.0, 0.3, 0.1);
+    Eigen::Vector2d::Zero(), M_PI - 0.01, Eigen::Vector2d::Zero(), -M_PI + 0.01, 1.0, 0.3, 0.1);
   // The residual across the +-pi seam is 0.02 rad, not 2 pi - 0.02.
   EXPECT_NEAR(std::abs(b.yaw), M_PI - 0.01, 1e-9);
 }

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -180,116 +180,172 @@ Eigen::Matrix4d make_pose(const double x, const double y, const double yaw)
   pose(1, 3) = y;
   return pose;
 }
-
-double yaw_of(const Eigen::Matrix4d & pose)
-{
-  return std::atan2(pose(1, 0), pose(0, 0));
-}
 }  // namespace
 
-// A query point lying exactly on a vertex of the polyline must be a no-op: the returned pose
-// equals that vertex (position and heading). This mirrors the Perfect-Tracker invariant where the
-// ego lands exactly on the previous prediction.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineOnVertexIsNoOp)
+namespace
 {
-  const std::vector<Eigen::Matrix4d> polyline{
-    make_pose(0.0, 0.0, 0.0), make_pose(1.0, 0.0, 0.0), make_pose(2.0, 0.0, 0.0)};
-
-  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.0, 0.0, polyline, 5).pose;
-
-  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
-  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
-  EXPECT_NEAR(yaw_of(projected), 0.0, 1e-9);
-}
-
-// A query point offset laterally from a straight polyline snaps to the foot of the perpendicular.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineLateralOffset)
+// Straight polyline along +x with the given spacing and constant heading 0.
+std::vector<Eigen::Matrix4d> straight_polyline(const size_t count, const double spacing)
 {
-  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
-
-  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(3.0, 2.0, polyline, 5).pose;
-
-  EXPECT_NEAR(projected(0, 3), 3.0, 1e-9);
-  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
-  EXPECT_NEAR(yaw_of(projected), 0.0, 1e-9);
-}
-
-// A query point past the end of the polyline is clamped to the closest endpoint.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineClampsToEndpoint)
-{
-  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
-
-  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(15.0, 5.0, polyline, 5).pose;
-
-  EXPECT_NEAR(projected(0, 3), 10.0, 1e-9);
-  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
-}
-
-// The heading is slerp-interpolated between the endpoints of the closest segment. Projecting the
-// midpoint of a segment whose endpoints face 0 and pi/2 yields a heading of pi/4.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineInterpolatesHeading)
-{
-  const std::vector<Eigen::Matrix4d> polyline{
-    make_pose(0.0, 0.0, 0.0), make_pose(2.0, 0.0, M_PI_2)};
-
-  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.0, 0.0, polyline, 5).pose;
-
-  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
-  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
-  EXPECT_NEAR(yaw_of(projected), M_PI_4, 1e-9);
-}
-
-// The closest segment is selected among the searched segments of the polyline.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineSelectsClosestSegment)
-{
-  const std::vector<Eigen::Matrix4d> polyline{
-    make_pose(0.0, 0.0, 0.0), make_pose(1.0, 0.0, 0.0), make_pose(1.0, 5.0, M_PI_2)};
-
-  // Closest to the second (vertical) segment, at ratio 3.0 / 5.0 along it.
-  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.3, 3.0, polyline, 5).pose;
-
-  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
-  EXPECT_NEAR(projected(1, 3), 3.0, 1e-9);
-  // The heading is slerp-interpolated between the segment endpoints (0 and pi/2) by that same
-  // ratio, not taken from the end vertex.
-  EXPECT_NEAR(yaw_of(projected), 0.6 * M_PI_2, 1e-9);
-}
-
-// Segments beyond max_search_segment_count are never selected, even when one of them is much
-// closer to the query point than anything inside the window.
-TEST_F(UtilsTest, ProjectPoseOntoPolylineIgnoresSegmentsBeyondSearchWindow)
-{
-  // A straight run along +x, then a vertex that comes back right next to the query point.
   std::vector<Eigen::Matrix4d> polyline;
-  for (size_t i = 0; i < 6; ++i) {
-    polyline.push_back(make_pose(static_cast<double>(i), 0.0, 0.0));
+  for (size_t i = 0; i < count; ++i) {
+    polyline.push_back(make_pose(static_cast<double>(i) * spacing, 0.0, 0.0));
   }
-  polyline.push_back(make_pose(5.0, 20.0, M_PI_2));
-  polyline.push_back(make_pose(5.0, 21.0, M_PI_2));
-
-  // The query sits on the last segment, which is the 7th one and therefore outside a window of 5.
-  const auto windowed = utils::project_pose_onto_polyline(5.0, 20.5, polyline, 5);
-  EXPECT_NEAR(windowed.pose(0, 3), 5.0, 1e-9);
-  EXPECT_NEAR(windowed.pose(1, 3), 0.0, 1e-9);
-  EXPECT_NEAR(windowed.interpolation_index, 5.0, 1e-9);
-
-  // Widening the window lets the same query reach the far segment.
-  const auto full = utils::project_pose_onto_polyline(5.0, 20.5, polyline, 7);
-  EXPECT_NEAR(full.pose(0, 3), 5.0, 1e-9);
-  EXPECT_NEAR(full.pose(1, 3), 20.5, 1e-9);
-  EXPECT_NEAR(yaw_of(full.pose), M_PI_2, 1e-9);
+  return polyline;
 }
 
-TEST_F(UtilsTest, ProjectPoseOntoPolylineThrowsOnTooFewPoints)
+constexpr utils::TrajectorySnapOptions default_options{5, 1.0, 0.2};
+}  // namespace
+
+// A query point lying exactly on a vertex of a straight polyline is a no-op: same position, same
+// heading (both the interpolated vertex heading and the geometric tangent), integer interpolation
+// index. This mirrors the Perfect-Tracker invariant where the ego lands on the previous prediction.
+TEST_F(UtilsTest, SnapPointToTrajectoryOnVertexIsNoOp)
 {
-  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0)};
-  EXPECT_THROW(utils::project_pose_onto_polyline(0.0, 0.0, polyline, 5), std::runtime_error);
+  const auto polyline = straight_polyline(10, 1.0);
+
+  const auto snap = utils::snap_point_to_trajectory(3.0, 0.0, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->position.x(), 3.0, 1e-6);
+  EXPECT_NEAR(snap->position.y(), 0.0, 1e-6);
+  EXPECT_NEAR(snap->interpolation_index, 3.0, 1e-6);
+  EXPECT_NEAR(snap->heading_yaw, 0.0, 1e-6);
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  EXPECT_NEAR(*snap->tangent_yaw, 0.0, 1e-6);
 }
 
-TEST_F(UtilsTest, ProjectPoseOntoPolylineThrowsOnNonPositiveSearchWindow)
+// A query point offset laterally from a straight polyline snaps to the foot of the perpendicular,
+// and the interpolation index reflects the fraction along the segment.
+TEST_F(UtilsTest, SnapPointToTrajectoryLateralOffset)
 {
-  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0), make_pose(1.0, 0.0, 0.0)};
-  EXPECT_THROW(utils::project_pose_onto_polyline(0.0, 0.0, polyline, 0), std::runtime_error);
+  const auto polyline = straight_polyline(10, 1.0);
+
+  const auto snap = utils::snap_point_to_trajectory(2.5, 0.3, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->position.x(), 2.5, 1e-6);
+  EXPECT_NEAR(snap->position.y(), 0.0, 1e-6);
+  EXPECT_NEAR(snap->interpolation_index, 2.5, 1e-6);
+}
+
+// The closest point is only searched within the leading max_search_segment_count segments.
+TEST_F(UtilsTest, SnapPointToTrajectoryRespectsSearchWindow)
+{
+  const auto polyline = straight_polyline(10, 1.0);
+  const utils::TrajectorySnapOptions options{3, 1.0, 0.2};
+
+  const auto snap = utils::snap_point_to_trajectory(8.0, 0.0, polyline, options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->position.x(), 3.0, 1e-6);
+  EXPECT_NEAR(snap->interpolation_index, 3.0, 1e-6);
+}
+
+// The vertex headings of a predicted trajectory can be noisy while its positions trace a clean
+// path. The interpolated vertex heading inherits that noise; the geometric tangent does not.
+TEST_F(UtilsTest, SnapPointToTrajectoryTangentIgnoresNoisyVertexHeadings)
+{
+  std::vector<Eigen::Matrix4d> polyline;
+  for (size_t i = 0; i < 20; ++i) {
+    const double noisy_yaw = (i % 2 == 0) ? 0.2 : -0.2;
+    polyline.push_back(make_pose(static_cast<double>(i) * 0.3, 0.0, noisy_yaw));
+  }
+
+  // Midway between two vertices, where the slerp of +-0.2 gives exactly 0 by symmetry, so query a
+  // point closer to one vertex instead.
+  const auto snap = utils::snap_point_to_trajectory(0.9 + 0.06, 0.0, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_GT(std::abs(snap->heading_yaw), 0.05);
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  EXPECT_NEAR(*snap->tangent_yaw, 0.0, 1e-3);
+}
+
+// Small position jitter of the vertices (as produced by the first, very short prediction steps)
+// barely moves the averaged tangent, while a single segment's direction would swing by tens of
+// degrees.
+TEST_F(UtilsTest, SnapPointToTrajectoryTangentIsRobustToPositionJitter)
+{
+  std::vector<Eigen::Matrix4d> polyline;
+  for (size_t i = 0; i < 30; ++i) {
+    const double jitter_y = (i % 2 == 0) ? 0.01 : -0.01;  // +-1 cm on 10 cm segments (~11 deg)
+    polyline.push_back(make_pose(static_cast<double>(i) * 0.1, jitter_y, 0.0));
+  }
+
+  const auto snap = utils::snap_point_to_trajectory(0.35, 0.0, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  EXPECT_NEAR(*snap->tangent_yaw, 0.0, 0.02);
+}
+
+// On a circular arc the averaged tangent matches the analytic tangent at the snapped point.
+TEST_F(UtilsTest, SnapPointToTrajectoryTangentOnArc)
+{
+  constexpr double radius = 20.0;
+  std::vector<Eigen::Matrix4d> polyline;
+  for (size_t i = 0; i < 40; ++i) {
+    const double theta = static_cast<double>(i) * 0.5 / radius;  // 0.5 m arc steps
+    polyline.push_back(
+      make_pose(radius * std::sin(theta), radius * (1.0 - std::cos(theta)), theta));
+  }
+
+  const double query_theta = 1.25 / radius;  // between vertices 2 and 3
+  const auto snap = utils::snap_point_to_trajectory(
+    radius * std::sin(query_theta), radius * (1.0 - std::cos(query_theta)), polyline,
+    default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->heading_yaw, query_theta, 1e-3);
+  ASSERT_TRUE(snap->tangent_yaw.has_value());
+  EXPECT_NEAR(*snap->tangent_yaw, query_theta, 1e-3);
+}
+
+// When the trajectory around the snapped point is shorter than yaw_fit_min_length_m the geometry
+// carries no reliable heading, so no tangent heading is reported (the caller falls back).
+TEST_F(UtilsTest, SnapPointToTrajectoryNoTangentOnTooShortWindow)
+{
+  const auto polyline = straight_polyline(3, 0.05);  // 10 cm in total
+  const utils::TrajectorySnapOptions options{5, 1.0, 0.2};
+
+  const auto snap = utils::snap_point_to_trajectory(0.05, 0.0, polyline, options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_FALSE(snap->tangent_yaw.has_value());
+}
+
+// A prediction that comes to a stop repeats its last position. Those coincident vertices must not
+// break the spline: the leading distinct vertices are used and the snap still succeeds.
+TEST_F(UtilsTest, SnapPointToTrajectoryIgnoresCoincidentTail)
+{
+  auto polyline = straight_polyline(6, 1.0);
+  for (size_t i = 0; i < 10; ++i) {
+    polyline.push_back(make_pose(5.0, 0.0, 0.0));
+  }
+
+  const auto snap = utils::snap_point_to_trajectory(2.0, 0.1, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->position.x(), 2.0, 1e-6);
+  EXPECT_NEAR(snap->position.y(), 0.0, 1e-6);
+}
+
+// Fewer than two distinct vertices (e.g. a fully stopped prediction) cannot be snapped onto.
+TEST_F(UtilsTest, SnapPointToTrajectoryReturnsNulloptOnDegeneratePolyline)
+{
+  const std::vector<Eigen::Matrix4d> polyline(5, make_pose(1.0, 1.0, 0.0));
+
+  EXPECT_FALSE(utils::snap_point_to_trajectory(1.0, 1.0, polyline, default_options).has_value());
+  EXPECT_FALSE(utils::snap_point_to_trajectory(0.0, 0.0, {}, default_options).has_value());
+}
+
+TEST_F(UtilsTest, SnapPointToTrajectoryThrowsOnNonPositiveSearchWindow)
+{
+  const auto polyline = straight_polyline(3, 1.0);
+  const utils::TrajectorySnapOptions options{0, 1.0, 0.2};
+
+  EXPECT_THROW(utils::snap_point_to_trajectory(0.0, 0.0, polyline, options), std::runtime_error);
 }
 
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -229,6 +229,24 @@ TEST_F(UtilsTest, SnapPointToTrajectoryLateralOffset)
   EXPECT_NEAR(snap->interpolation_index, 2.5, 1e-6);
 }
 
+// The snap is an xy operation. A trajectory at 100 m elevation and climbing must snap exactly as
+// the same trajectory on the ground plane; measuring the 3D distance from a z = 0 query would
+// otherwise pick the vertex with the lowest z instead of the laterally closest point.
+TEST_F(UtilsTest, SnapPointToTrajectoryIgnoresElevation)
+{
+  auto polyline = straight_polyline(10, 1.0);
+  for (size_t i = 0; i < polyline.size(); ++i) {
+    polyline[i](2, 3) = 100.0 + 0.5 * static_cast<double>(i);
+  }
+
+  const auto snap = utils::snap_point_to_trajectory(2.5, 0.3, polyline, default_options);
+
+  ASSERT_TRUE(snap.has_value());
+  EXPECT_NEAR(snap->position.x(), 2.5, 1e-6);
+  EXPECT_NEAR(snap->position.y(), 0.0, 1e-6);
+  EXPECT_NEAR(snap->interpolation_index, 2.5, 1e-6);
+}
+
 // The closest point is only searched within the leading max_search_segment_count segments.
 TEST_F(UtilsTest, SnapPointToTrajectoryRespectsSearchWindow)
 {


### PR DESCRIPTION
## Description

Backport of the `ego_snap_to_prev_trajectory` rework in autowarefoundation/autoware_universe#13320 to the e2e branch, for testing on a vehicle. Same nine commits, cherry-picked onto `feat/v0.64/e2e` (`-x` trailers carry the upstream hashes).

The snap feeds the diffusion planner a virtual ego pose taken from its own previous trajectory instead of the localized pose, so consecutive plans continue one line. The rework:

1. Heading from the tangent of a spline through the previous trajectory instead of the model's heading channel, which jittered by degrees at the first prediction steps.
2. `limit_mode: bound` (new default): the virtual pose is blended toward the localized pose and kept within `max_position_error_m` / `max_yaw_error_deg` continuously, instead of discarding the snap for the frame whenever a limit is exceeded (which stepped the reference by up to 30 cm every 10 to 15 m). `limit_mode: reject` names the existing behaviour (reproducing it in full also needs `yaw_source: predicted_heading` and `history_prefix_count: 0`).
3. Roll and pitch of the localized pose are preserved.
4. `snap_strength` is a new parameter for bound mode (0 = off, 1 = on the previous plan), default 0.9, capped at 0.95 with a warning.

Also: the snap is computed in the xy plane (the spline search this PR introduces measures 3D distance, so without the flattening a trajectory at elevation snapped to the wrong point; the merged segment projection was already 2D), and one validator checks every parameter at startup and on runtime updates.

**The feature stays disabled by default** (`enable: false`). With it disabled the snap helper returns nothing and the frame is built from the localized pose exactly as before this change; no other code path is touched. Full design, measurements and clips: upstream PR body and the internal page linked below.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_universe#13320 (upstream PR, draft)
- autowarefoundation/autoware_universe#13234 (the snap as merged)

Companion parameter-file change for `autoware_launch.x2` (`feat/v4.4/e2e`): adds the new keys to `config/planning/neural_net_planner/diffusion_planner.param.yaml`, all at the code defaults, `enable: false`. Not required for the node to start (every new parameter has a code default) but needed to configure the feature from the launch config.

<!-- ⬇️🟢
**Private Links:**

- T4DEV-57353
- T4DEV-52321
- Confluence: https://tier4.atlassian.net/wiki/spaces/ATT/pages/5546246256
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_diffusion_planner` and `colcon test` on this branch: 5 test executables, all passing (18 unit tests for the snap: bounding, yaw wrap, clamp, degenerate trajectory, null case, elevation).
- **PSIM simulation results, not vehicle recordings.** Closed-loop planning simulator (psim) on the e2e workspace, two urban routes, two planner checkpoints, about 80 drives, all documented on the internal page:
  - Feature off: unchanged against the pre-PR node (the `snap_strength: 0` null test reproduces the feature-off drive on all six pose components to the last digit; `enable: false` skips the snap block entirely).
  - Reject mode (the merged behaviour): 30 cm sawtooth in the gap between vehicle and its own trajectory on both checkpoints; left the road at the same bend in 2 of 4 drives on one checkpoint. Bound mode: 0 border crossings in every drive at every strength.
  - Bound mode at 0.9 against feature off: lateral error against the trajectory's own 0.5 s prediction 5 cm against 0.4 cm; lane offset, lateral acceleration, jerk and border distance unchanged or better; mean lane offset over the second route 0.36 m against 0.45 to 0.48 m on one checkpoint, 0.29 to 0.31 against 0.30 m on the other.
- Not tested on a vehicle yet. That is what this PR is for. Suggested arms: `enable: true`, `snap_strength: 0.9` (default) then `0.7`, at least three repeats each, with the MPC debug topics recorded.

## Notes for reviewers

- Identical to the upstream PR apart from clang-format differences and the tier4-only lines already on this branch (`ignore_neighbors` log, processing-time publish).
- The simulator has no localization noise, so it measures the feature's cost, not the benefit it exists for (continuity of plans under localization error). Only the vehicle can measure that.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Added | `ego_snap_to_prev_trajectory.limit_mode` | `string` | `bound` | `bound`: continuous blend within the error limits. `reject`: skip the snap for the frame when a limit is exceeded (previous behaviour). |
| Added | `ego_snap_to_prev_trajectory.snap_strength` | `double` | `0.9` | Bound mode. `virtual = real + s·(snapped − real)`; 0 = off, 1 = on the previous plan. Values above 0.95 are clipped to 0.95 with a warning. |
| Added | `ego_snap_to_prev_trajectory.yaw_source` | `string` | `polyline_tangent` | `polyline_tangent`: spline tangent of the previous trajectory. `predicted_heading`: model heading channel (previous behaviour). |
| Added | `ego_snap_to_prev_trajectory.yaw_fit_half_window_m` | `double` | `1.0` | Arc length each side of the snapped point over which the tangent is averaged. |
| Added | `ego_snap_to_prev_trajectory.yaw_fit_min_length_m` | `double` | `0.2` | Below this fit length the localized heading is used. |
| Added | `ego_snap_to_prev_trajectory.history_prefix_count` | `int` | `10` | Earlier ego poses prepended to the previous trajectory so the tangent window extends behind the vehicle. |

Unchanged: `enable` (false), `max_position_error_m` (0.3), `max_yaw_error_deg` (5.0), `max_search_segment_count` (5). No low-speed gate: the snap applies at every speed. In bound mode the two error limits act as the clamp instead of as reject thresholds.

Topics: none.

## Effects on system behavior

None while disabled (the default). Enabled: the pose fed to the model is continuous at the error limits, keeps roll and pitch, and takes its heading from the trajectory geometry.
