### PR TITLE
feat(vehicle_cmd_gate): apply agnocast_wrapper::Node

### DIFF
--- a/control/autoware_vehicle_cmd_gate/CMakeLists.txt
+++ b/control/autoware_vehicle_cmd_gate/CMakeLists.txt
@@ -11,9 +11,13 @@ ament_auto_add_library(vehicle_cmd_gate_node SHARED
   src/moderate_stop_interface.cpp
 )
 
-rclcpp_components_register_node(vehicle_cmd_gate_node
+# VehicleCmdGate derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor.
+autoware_agnocast_wrapper_register_node(vehicle_cmd_gate_node
   PLUGIN "autoware::vehicle_cmd_gate::VehicleCmdGate"
   EXECUTABLE vehicle_cmd_gate_exe
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlySingleThreadedExecutor
 )
 
 rosidl_generate_interfaces(

--- a/control/autoware_vehicle_cmd_gate/package.xml
+++ b/control/autoware_vehicle_cmd_gate/package.xml
@@ -17,6 +17,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>

--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
@@ -17,9 +17,9 @@
 namespace autoware::vehicle_cmd_gate
 {
 
-AdapiPauseInterface::AdapiPauseInterface(rclcpp::Node * node) : node_(node)
+AdapiPauseInterface::AdapiPauseInterface(NodeT * node) : node_(node)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(node);
   adaptor.init_srv(srv_set_pause_, this, &AdapiPauseInterface::on_pause);
   adaptor.init_pub(pub_is_paused_);
   adaptor.init_pub(pub_is_start_requested_);

--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef ADAPI_PAUSE_INTERFACE_HPP_
 #define ADAPI_PAUSE_INTERFACE_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/control.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -27,6 +28,7 @@ namespace autoware::vehicle_cmd_gate
 class AdapiPauseInterface
 {
 private:
+  using NodeT = autoware::agnocast_wrapper::Node;
   static constexpr double eps = 1e-3;
   using Control = autoware_control_msgs::msg::Control;
   using SetPause = autoware::component_interface_specs_universe::control::SetPause;
@@ -34,7 +36,7 @@ private:
   using IsStartRequested = autoware::component_interface_specs_universe::control::IsStartRequested;
 
 public:
-  explicit AdapiPauseInterface(rclcpp::Node * node);
+  explicit AdapiPauseInterface(NodeT * node);
   bool is_paused() const;
   void publish();
   void update(const Control & control);
@@ -45,10 +47,10 @@ private:
   std::optional<bool> prev_is_paused_;
   std::optional<bool> prev_is_start_requested_;
 
-  rclcpp::Node * node_;
-  autoware::component_interface_utils::Service<SetPause>::SharedPtr srv_set_pause_;
-  autoware::component_interface_utils::Publisher<IsPaused>::SharedPtr pub_is_paused_;
-  autoware::component_interface_utils::Publisher<IsStartRequested>::SharedPtr
+  NodeT * node_;
+  autoware::component_interface_utils::Service<SetPause, NodeT>::SharedPtr srv_set_pause_;
+  autoware::component_interface_utils::Publisher<IsPaused, NodeT>::SharedPtr pub_is_paused_;
+  autoware::component_interface_utils::Publisher<IsStartRequested, NodeT>::SharedPtr
     pub_is_start_requested_;
 
   void on_pause(

--- a/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.cpp
@@ -17,9 +17,9 @@
 namespace autoware::vehicle_cmd_gate
 {
 
-ModerateStopInterface::ModerateStopInterface(rclcpp::Node * node) : node_(node)
+ModerateStopInterface::ModerateStopInterface(NodeT * node) : node_(node)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(node);
   adaptor.init_srv(srv_set_stop_, this, &ModerateStopInterface::on_stop_request);
   adaptor.init_pub(pub_is_stopped_);
 

--- a/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef MODERATE_STOP_INTERFACE_HPP_
 #define MODERATE_STOP_INTERFACE_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/control.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -28,12 +29,13 @@ namespace autoware::vehicle_cmd_gate
 class ModerateStopInterface
 {
 private:
+  using NodeT = autoware::agnocast_wrapper::Node;
   using SetStop = autoware::component_interface_specs_universe::control::SetStop;
   using IsStopped = autoware::component_interface_specs_universe::control::IsStopped;
   using IsStartRequested = autoware::component_interface_specs_universe::control::IsStartRequested;
 
 public:
-  explicit ModerateStopInterface(rclcpp::Node * node);
+  explicit ModerateStopInterface(NodeT * node);
   bool is_stop_requested() const;
   void publish();
 
@@ -42,9 +44,9 @@ private:
   std::unordered_map<std::string, bool> stop_map_;
   std::optional<std::unordered_map<std::string, bool>> prev_stop_map_;
 
-  rclcpp::Node * node_;
-  autoware::component_interface_utils::Service<SetStop>::SharedPtr srv_set_stop_;
-  autoware::component_interface_utils::Publisher<IsStopped>::SharedPtr pub_is_stopped_;
+  NodeT * node_;
+  autoware::component_interface_utils::Service<SetStop, NodeT>::SharedPtr srv_set_stop_;
+  autoware::component_interface_utils::Publisher<IsStopped, NodeT>::SharedPtr pub_is_stopped_;
 
   void on_stop_request(
     const SetStop::Service::Request::SharedPtr req,

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -47,11 +47,12 @@ const char * getGateModeName(const GateMode::_data_type & gate_mode)
 }  // namespace
 
 VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
-: Node("vehicle_cmd_gate", node_options), is_engaged_(false), updater_(this)
+: autoware::agnocast_wrapper::Node("vehicle_cmd_gate", node_options),
+  is_engaged_(false),
+  updater_(this)
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
-  using std::placeholders::_3;
 
   prev_turn_indicator_ = nullptr;
   prev_hazard_light_ = nullptr;
@@ -60,8 +61,10 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
 
-  // Stop Checker
-  vehicle_stop_checker_ = std::make_unique<VehicleStopChecker>(this);
+  // Stop Checker. The buffer VehicleStopChecker keeps, reproduced here because its base takes it
+  // as an argument.
+  constexpr double velocity_buffer_time_sec = 10.0;
+  vehicle_stop_checker_ = std::make_unique<VehicleStopCheckerBase>(this, velocity_buffer_time_sec);
 
   // Publisher
   vehicle_cmd_emergency_pub_ =
@@ -98,18 +101,23 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   engage_sub_ = create_subscription<EngageMsg>(
     "input/engage", 1, std::bind(&VehicleCmdGate::onEngage, this, _1));
   kinematics_sub_ = create_subscription<Odometry>(
-    "/localization/kinematic_state", 1,
-    [this](Odometry::SharedPtr msg) { current_kinematics_ = *msg; });
+    "/localization/kinematic_state", 1, [this](Odometry::ConstSharedPtr msg) {
+      current_kinematics_ = *msg;
+      geometry_msgs::msg::TwistStamped twist;
+      twist.header = msg->header;
+      twist.twist = msg->twist.twist;
+      vehicle_stop_checker_->addTwist(twist);
+    });
   acc_sub_ = create_subscription<AccelWithCovarianceStamped>(
-    "input/acceleration", 1, [this](AccelWithCovarianceStamped::SharedPtr msg) {
+    "input/acceleration", 1, [this](AccelWithCovarianceStamped::ConstSharedPtr msg) {
       current_acceleration_ = msg->accel.accel.linear.x;
     });
   steer_sub_ = create_subscription<SteeringReport>(
     "input/steering", 1,
-    [this](SteeringReport::SharedPtr msg) { current_steer_ = msg->steering_tire_angle; });
+    [this](SteeringReport::ConstSharedPtr msg) { current_steer_ = msg->steering_tire_angle; });
   operation_mode_sub_ = create_subscription<OperationModeState>(
     "input/operation_mode", rclcpp::QoS(1).transient_local(),
-    [this](const OperationModeState::SharedPtr msg) { current_operation_mode_ = *msg; });
+    [this](OperationModeState::ConstSharedPtr msg) { current_operation_mode_ = *msg; });
   mrm_state_sub_ = create_subscription<MrmState>(
     "input/mrm_state", 1, std::bind(&VehicleCmdGate::onMrmState, this, _1));
 
@@ -124,6 +132,25 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   // Subscriber for emergency
   emergency_control_cmd_sub_ = create_subscription<Control>(
     "input/emergency/control_cmd", 1, std::bind(&VehicleCmdGate::onEmergencyCtrlCmd, this, _1));
+
+  namespace polling = autoware::agnocast_wrapper::polling;
+  auto_turn_indicator_cmd_sub_ = polling::create_polling_subscriber<TurnIndicatorsCommand>(
+    this, "input/auto/turn_indicators_cmd");
+  auto_hazard_light_cmd_sub_ =
+    polling::create_polling_subscriber<HazardLightsCommand>(this, "input/auto/hazard_lights_cmd");
+  auto_gear_cmd_sub_ = polling::create_polling_subscriber<GearCommand>(this, "input/auto/gear_cmd");
+  remote_turn_indicator_cmd_sub_ = polling::create_polling_subscriber<TurnIndicatorsCommand>(
+    this, "input/external/turn_indicators_cmd");
+  remote_hazard_light_cmd_sub_ = polling::create_polling_subscriber<HazardLightsCommand>(
+    this, "input/external/hazard_lights_cmd");
+  remote_gear_cmd_sub_ =
+    polling::create_polling_subscriber<GearCommand>(this, "input/external/gear_cmd");
+  emergency_turn_indicator_cmd_sub_ = polling::create_polling_subscriber<TurnIndicatorsCommand>(
+    this, "input/emergency/turn_indicators_cmd");
+  emergency_hazard_light_cmd_sub_ = polling::create_polling_subscriber<HazardLightsCommand>(
+    this, "input/emergency/hazard_lights_cmd");
+  emergency_gear_cmd_sub_ =
+    polling::create_polling_subscriber<GearCommand>(this, "input/emergency/gear_cmd");
 
   // Parameter
   use_emergency_handling_ = declare_parameter<bool>("use_emergency_handling");
@@ -202,13 +229,13 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
     "~/service/engage", std::bind(&VehicleCmdGate::onEngageService, this, _1, _2));
   srv_external_emergency_ = create_service<SetEmergency>(
     "~/service/external_emergency",
-    std::bind(&VehicleCmdGate::onExternalEmergencyStopService, this, _1, _2, _3));
+    std::bind(&VehicleCmdGate::onExternalEmergencyStopService, this, _1, _2));
   srv_external_emergency_stop_ = create_service<Trigger>(
     "~/service/external_emergency_stop",
-    std::bind(&VehicleCmdGate::onSetExternalEmergencyStopService, this, _1, _2, _3));
+    std::bind(&VehicleCmdGate::onSetExternalEmergencyStopService, this, _1, _2));
   srv_clear_external_emergency_stop_ = create_service<Trigger>(
     "~/service/clear_external_emergency_stop",
-    std::bind(&VehicleCmdGate::onClearExternalEmergencyStopService, this, _1, _2, _3));
+    std::bind(&VehicleCmdGate::onClearExternalEmergencyStopService, this, _1, _2));
 
   // Diagnostics Updater
   updater_.setHardwareID("vehicle_cmd_gate");
@@ -225,14 +252,15 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   const auto update_period = 1.0 / declare_parameter<double>("update_rate");
   const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(update_period));
-  timer_ =
-    rclcpp::create_timer(this, get_clock(), period_ns, std::bind(&VehicleCmdGate::onTimer, this));
-  timer_pub_status_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), period_ns, std::bind(&VehicleCmdGate::onTimer, this));
+  timer_pub_status_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), period_ns, std::bind(&VehicleCmdGate::publishStatus, this));
 
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<autoware_utils::BasicLoggerLevelConfigure<NodeT>>(this);
 
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ =
+    std::make_unique<autoware_utils::BasicPublishedTimePublisher<NodeT>>(this);
 
   // Parameter Callback
   set_param_res_ =
@@ -412,38 +440,38 @@ void VehicleCmdGate::onTimer()
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
   // Subscriber for auto
-  const auto msg_auto_command_turn_indicator = auto_turn_indicator_cmd_sub_.take_data();
+  const auto msg_auto_command_turn_indicator = auto_turn_indicator_cmd_sub_->take_data();
   if (msg_auto_command_turn_indicator)
     auto_commands_.turn_indicator = *msg_auto_command_turn_indicator;
 
-  const auto msg_auto_command_hazard_light = auto_hazard_light_cmd_sub_.take_data();
+  const auto msg_auto_command_hazard_light = auto_hazard_light_cmd_sub_->take_data();
   if (msg_auto_command_hazard_light) auto_commands_.hazard_light = *msg_auto_command_hazard_light;
 
-  const auto msg_auto_command_gear = auto_gear_cmd_sub_.take_data();
+  const auto msg_auto_command_gear = auto_gear_cmd_sub_->take_data();
   if (msg_auto_command_gear) auto_commands_.gear = *msg_auto_command_gear;
 
   // Subscribe for external
-  const auto msg_remote_command_turn_indicator = remote_turn_indicator_cmd_sub_.take_data();
+  const auto msg_remote_command_turn_indicator = remote_turn_indicator_cmd_sub_->take_data();
   if (msg_remote_command_turn_indicator)
     remote_commands_.turn_indicator = *msg_remote_command_turn_indicator;
 
-  const auto msg_remote_command_hazard_light = remote_hazard_light_cmd_sub_.take_data();
+  const auto msg_remote_command_hazard_light = remote_hazard_light_cmd_sub_->take_data();
   if (msg_remote_command_hazard_light)
     remote_commands_.hazard_light = *msg_remote_command_hazard_light;
 
-  const auto msg_remote_command_gear = remote_gear_cmd_sub_.take_data();
+  const auto msg_remote_command_gear = remote_gear_cmd_sub_->take_data();
   if (msg_remote_command_gear) remote_commands_.gear = *msg_remote_command_gear;
 
   // Subscribe for emergency
-  const auto msg_emergency_command_hazard_light = emergency_hazard_light_cmd_sub_.take_data();
+  const auto msg_emergency_command_hazard_light = emergency_hazard_light_cmd_sub_->take_data();
   if (msg_emergency_command_hazard_light)
     emergency_commands_.hazard_light = *msg_emergency_command_hazard_light;
 
-  const auto msg_emergency_command_turn_indicator = emergency_turn_indicator_cmd_sub_.take_data();
+  const auto msg_emergency_command_turn_indicator = emergency_turn_indicator_cmd_sub_->take_data();
   if (msg_emergency_command_turn_indicator)
     emergency_commands_.turn_indicator = *msg_emergency_command_turn_indicator;
 
-  const auto msg_emergency_command_gear = emergency_gear_cmd_sub_.take_data();
+  const auto msg_emergency_command_gear = emergency_gear_cmd_sub_->take_data();
   if (msg_emergency_command_gear) emergency_commands_.gear = *msg_emergency_command_gear;
 
   updater_.force_update();
@@ -848,15 +876,14 @@ Control VehicleCmdGate::getActualStatusAsCommand()
 }
 
 void VehicleCmdGate::onExternalEmergencyStopService(
-  const std::shared_ptr<rmw_request_id_t> request_header,
   const SetEmergency::Request::SharedPtr request, const SetEmergency::Response::SharedPtr response)
 {
   auto req = std::make_shared<Trigger::Request>();
   auto res = std::make_shared<Trigger::Response>();
   if (request->emergency) {
-    onSetExternalEmergencyStopService(request_header, req, res);
+    onSetExternalEmergencyStopService(req, res);
   } else {
-    onClearExternalEmergencyStopService(request_header, req, res);
+    onClearExternalEmergencyStopService(req, res);
   }
 
   if (res->success) {
@@ -867,7 +894,6 @@ void VehicleCmdGate::onExternalEmergencyStopService(
 }
 
 bool VehicleCmdGate::onSetExternalEmergencyStopService(
-  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> req_header,
   [[maybe_unused]] const Trigger::Request::SharedPtr req, const Trigger::Response::SharedPtr res)
 {
   is_external_emergency_stop_ = true;
@@ -878,7 +904,6 @@ bool VehicleCmdGate::onSetExternalEmergencyStopService(
 }
 
 bool VehicleCmdGate::onClearExternalEmergencyStopService(
-  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> req_header,
   [[maybe_unused]] const Trigger::Request::SharedPtr req, const Trigger::Response::SharedPtr res)
 {
   if (is_external_emergency_stop_) {

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -20,13 +20,15 @@
 #include "moderate_stop_interface.hpp"
 #include "vehicle_cmd_filter.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_vehicle_cmd_gate/msg/is_filter_activated.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/manual_operator_heartbeat.hpp>
@@ -84,7 +86,7 @@ using Heartbeat = autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat;
 using EngageMsg = autoware_vehicle_msgs::msg::Engage;
 using EngageSrv = tier4_external_api_msgs::srv::Engage;
 
-using autoware::motion_utils::VehicleStopChecker;
+using autoware::motion_utils::VehicleStopCheckerBase;
 struct Commands
 {
   Control control;
@@ -97,39 +99,42 @@ struct Commands
   }
 };
 
-class VehicleCmdGate : public rclcpp::Node
+class VehicleCmdGate : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleCmdGate(const rclcpp::NodeOptions & node_options);
 
 private:
+  using NodeT = autoware::agnocast_wrapper::Node;
+  template <class T>
+  using PollingSubscriber = autoware::agnocast_wrapper::polling::PollingSubscriber<T>;
+
   // Publisher
-  rclcpp::Publisher<VehicleEmergencyStamped>::SharedPtr vehicle_cmd_emergency_pub_;
-  rclcpp::Publisher<Control>::SharedPtr control_cmd_pub_;
-  rclcpp::Publisher<GearCommand>::SharedPtr gear_cmd_pub_;
-  rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr turn_indicator_cmd_pub_;
-  rclcpp::Publisher<HazardLightsCommand>::SharedPtr hazard_light_cmd_pub_;
-  rclcpp::Publisher<GateMode>::SharedPtr gate_mode_pub_;
-  rclcpp::Publisher<EngageMsg>::SharedPtr engage_pub_;
-  rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_pub_;
-  rclcpp::Publisher<IsFilterActivated>::SharedPtr is_filter_activated_pub_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr filter_activated_marker_pub_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr filter_activated_marker_raw_pub_;
-  rclcpp::Publisher<BoolStamped>::SharedPtr filter_activated_flag_pub_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    processing_time_pub_;
+  AUTOWARE_PUBLISHER_PTR(VehicleEmergencyStamped) vehicle_cmd_emergency_pub_;
+  AUTOWARE_PUBLISHER_PTR(Control) control_cmd_pub_;
+  AUTOWARE_PUBLISHER_PTR(GearCommand) gear_cmd_pub_;
+  AUTOWARE_PUBLISHER_PTR(TurnIndicatorsCommand) turn_indicator_cmd_pub_;
+  AUTOWARE_PUBLISHER_PTR(HazardLightsCommand) hazard_light_cmd_pub_;
+  AUTOWARE_PUBLISHER_PTR(GateMode) gate_mode_pub_;
+  AUTOWARE_PUBLISHER_PTR(EngageMsg) engage_pub_;
+  AUTOWARE_PUBLISHER_PTR(OperationModeState) operation_mode_pub_;
+  AUTOWARE_PUBLISHER_PTR(IsFilterActivated) is_filter_activated_pub_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) filter_activated_marker_pub_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) filter_activated_marker_raw_pub_;
+  AUTOWARE_PUBLISHER_PTR(BoolStamped) filter_activated_flag_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped) processing_time_pub_;
   // Parameter callback
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);
   // Subscription
-  rclcpp::Subscription<Heartbeat>::SharedPtr external_emergency_stop_heartbeat_sub_;
-  rclcpp::Subscription<GateMode>::SharedPtr gate_mode_sub_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr operation_mode_sub_;
-  rclcpp::Subscription<MrmState>::SharedPtr mrm_state_sub_;
-  rclcpp::Subscription<Odometry>::SharedPtr kinematics_sub_;             // for filter
-  rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr acc_sub_;  // for filter
-  rclcpp::Subscription<SteeringReport>::SharedPtr steer_sub_;            // for filter
+  AUTOWARE_SUBSCRIPTION_PTR(Heartbeat) external_emergency_stop_heartbeat_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(GateMode) gate_mode_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(OperationModeState) operation_mode_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(MrmState) mrm_state_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(Odometry) kinematics_sub_;             // for filter and stop checker
+  AUTOWARE_SUBSCRIPTION_PTR(AccelWithCovarianceStamped) acc_sub_;  // for filter
+  AUTOWARE_SUBSCRIPTION_PTR(SteeringReport) steer_sub_;            // for filter
 
   void onGateMode(GateMode::ConstSharedPtr msg);
   void onExternalEmergencyStopHeartbeat(Heartbeat::ConstSharedPtr msg);
@@ -158,35 +163,26 @@ private:
 
   // Subscriber for auto
   Commands auto_commands_;
-  rclcpp::Subscription<Control>::SharedPtr auto_control_cmd_sub_;
-  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsCommand> auto_turn_indicator_cmd_sub_{
-    this, "input/auto/turn_indicators_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<HazardLightsCommand> auto_hazard_light_cmd_sub_{
-    this, "input/auto/hazard_lights_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<GearCommand> auto_gear_cmd_sub_{
-    this, "input/auto/gear_cmd"};
+  AUTOWARE_SUBSCRIPTION_PTR(Control) auto_control_cmd_sub_;
+  PollingSubscriber<TurnIndicatorsCommand>::SharedPtr auto_turn_indicator_cmd_sub_;
+  PollingSubscriber<HazardLightsCommand>::SharedPtr auto_hazard_light_cmd_sub_;
+  PollingSubscriber<GearCommand>::SharedPtr auto_gear_cmd_sub_;
   void onAutoCtrlCmd(Control::ConstSharedPtr msg);
 
   // Subscription for external
   Commands remote_commands_;
-  rclcpp::Subscription<Control>::SharedPtr remote_control_cmd_sub_;
-  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsCommand>
-    remote_turn_indicator_cmd_sub_{this, "input/external/turn_indicators_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<HazardLightsCommand> remote_hazard_light_cmd_sub_{
-    this, "input/external/hazard_lights_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<GearCommand> remote_gear_cmd_sub_{
-    this, "input/external/gear_cmd"};
+  AUTOWARE_SUBSCRIPTION_PTR(Control) remote_control_cmd_sub_;
+  PollingSubscriber<TurnIndicatorsCommand>::SharedPtr remote_turn_indicator_cmd_sub_;
+  PollingSubscriber<HazardLightsCommand>::SharedPtr remote_hazard_light_cmd_sub_;
+  PollingSubscriber<GearCommand>::SharedPtr remote_gear_cmd_sub_;
   void onRemoteCtrlCmd(Control::ConstSharedPtr msg);
 
   // Subscription for emergency
   Commands emergency_commands_;
-  rclcpp::Subscription<Control>::SharedPtr emergency_control_cmd_sub_;
-  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsCommand>
-    emergency_turn_indicator_cmd_sub_{this, "input/emergency/turn_indicators_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<HazardLightsCommand>
-    emergency_hazard_light_cmd_sub_{this, "input/emergency/hazard_lights_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<GearCommand> emergency_gear_cmd_sub_{
-    this, "input/emergency/gear_cmd"};
+  AUTOWARE_SUBSCRIPTION_PTR(Control) emergency_control_cmd_sub_;
+  PollingSubscriber<TurnIndicatorsCommand>::SharedPtr emergency_turn_indicator_cmd_sub_;
+  PollingSubscriber<HazardLightsCommand>::SharedPtr emergency_hazard_light_cmd_sub_;
+  PollingSubscriber<GearCommand>::SharedPtr emergency_gear_cmd_sub_;
   void onEmergencyCtrlCmd(Control::ConstSharedPtr msg);
 
   // Previous Turn Indicators, Hazard Lights and Gear
@@ -207,31 +203,28 @@ private:
   double filter_activated_velocity_threshold_;
 
   // Service
-  rclcpp::Service<EngageSrv>::SharedPtr srv_engage_;
-  rclcpp::Service<SetEmergency>::SharedPtr srv_external_emergency_;
-  rclcpp::Publisher<Emergency>::SharedPtr pub_external_emergency_;
+  AUTOWARE_SERVICE_PTR(EngageSrv) srv_engage_;
+  AUTOWARE_SERVICE_PTR(SetEmergency) srv_external_emergency_;
+  AUTOWARE_PUBLISHER_PTR(Emergency) pub_external_emergency_;
   void onEngageService(
     const EngageSrv::Request::SharedPtr request, const EngageSrv::Response::SharedPtr response);
   void onExternalEmergencyStopService(
-    const std::shared_ptr<rmw_request_id_t> request_header,
     const SetEmergency::Request::SharedPtr request,
     const SetEmergency::Response::SharedPtr response);
 
   // TODO(Takagi, Isamu): deprecated
-  rclcpp::Subscription<EngageMsg>::SharedPtr engage_sub_;
-  rclcpp::Service<Trigger>::SharedPtr srv_external_emergency_stop_;
-  rclcpp::Service<Trigger>::SharedPtr srv_clear_external_emergency_stop_;
+  AUTOWARE_SUBSCRIPTION_PTR(EngageMsg) engage_sub_;
+  AUTOWARE_SERVICE_PTR(Trigger) srv_external_emergency_stop_;
+  AUTOWARE_SERVICE_PTR(Trigger) srv_clear_external_emergency_stop_;
   void onEngage(EngageMsg::ConstSharedPtr msg);
   bool onSetExternalEmergencyStopService(
-    const std::shared_ptr<rmw_request_id_t> req_header, const Trigger::Request::SharedPtr req,
-    const Trigger::Response::SharedPtr res);
+    const Trigger::Request::SharedPtr req, const Trigger::Response::SharedPtr res);
   bool onClearExternalEmergencyStopService(
-    const std::shared_ptr<rmw_request_id_t> req_header, const Trigger::Request::SharedPtr req,
-    const Trigger::Response::SharedPtr res);
+    const Trigger::Request::SharedPtr req, const Trigger::Response::SharedPtr res);
 
   // Timer / Event
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::TimerBase::SharedPtr timer_pub_status_;
+  AUTOWARE_TIMER_PTR timer_;
+  AUTOWARE_TIMER_PTR timer_pub_status_;
 
   void onTimer();
   void publishControlCommands(const Commands & commands);
@@ -239,7 +232,7 @@ private:
   void publishStatus();
 
   // Diagnostics Updater
-  diagnostic_updater::Updater updater_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
 
   void checkExternalEmergencyStop(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
@@ -269,17 +262,18 @@ private:
   std::unique_ptr<AdapiPauseInterface> adapi_pause_;
   std::unique_ptr<ModerateStopInterface> moderate_stop_interface_;
 
-  // stop checker
-  std::unique_ptr<VehicleStopChecker> vehicle_stop_checker_;
+  // stop checker. VehicleStopChecker owns an rclcpp subscription, so only its node-agnostic base
+  // is used and the odometry is fed from kinematics_sub_, which covers the same topic and QoS.
+  std::unique_ptr<VehicleStopCheckerBase> vehicle_stop_checker_;
   double stop_check_duration_;
 
   // debug
   MarkerArray createMarkerArray(const IsFilterActivated & filter_activated);
   void publishMarkers(const IsFilterActivated & filter_activated);
 
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<autoware_utils::BasicLoggerLevelConfigure<NodeT>> logger_configure_;
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<NodeT>> published_time_publisher_;
 };
 
 }  // namespace autoware::vehicle_cmd_gate


### PR DESCRIPTION
  ## Description

  Migrate `VehicleCmdGate` from `rclcpp::Node` to `autoware::agnocast_wrapper::Node`. The backend is selected at build time by `ENABLE_AGNOCAST`; with `ENABLE_AGNOCAST=0` the node keeps the plain rclcpp behavior.

  ## Related links

  **Parent Issue:**

  - Link

  ## How was this PR tested?

  `logging_simulator.launch.xml` on a recorded x2 bag with `ENABLE_AGNOCAST=0` and `=1`. 

  ## Notes for reviewers

  ## Interface changes

  None.

  ## Effects on system behavior

  None with `ENABLE_AGNOCAST=0`. With `ENABLE_AGNOCAST=1` the node must run as a standalone process.
