### PR TITLE
feat(operation_mode_transition_manager): apply agnocast_wrapper::Node

### DIFF
--- a/control/autoware_operation_mode_transition_manager/CMakeLists.txt
+++ b/control/autoware_operation_mode_transition_manager/CMakeLists.txt
@@ -14,14 +14,19 @@ ament_auto_add_library(autoware_operation_mode_transition_manager_node SHARED
   src/autonomous_mode_transition_flag_node.cpp
 )
 
-rclcpp_components_register_node(autoware_operation_mode_transition_manager_node
+# These nodes derive from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly executor.
+autoware_agnocast_wrapper_register_node(autoware_operation_mode_transition_manager_node
   PLUGIN "autoware::operation_mode_transition_manager::OperationModeTransitionManager"
   EXECUTABLE autoware_operation_mode_transition_manager_exe
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlySingleThreadedExecutor
 )
 
-rclcpp_components_register_node(autoware_operation_mode_transition_manager_node
+autoware_agnocast_wrapper_register_node(autoware_operation_mode_transition_manager_node
   PLUGIN "autoware::operation_mode_transition_manager::AutonomousModeTransitionFlagNode"
   EXECUTABLE autonomous_mode_transition_flag_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlySingleThreadedExecutor
 )
 
 rosidl_generate_interfaces(

--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
@@ -27,6 +28,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_srvs</depend>
   <depend>tier4_control_msgs</depend>
+  <depend>tier4_system_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.cpp
@@ -21,10 +21,17 @@ namespace autoware::operation_mode_transition_manager
 
 AutonomousModeTransitionFlagNode::AutonomousModeTransitionFlagNode(
   const rclcpp::NodeOptions & options)
-: Node("autonomous_mode_transition_flag_node", options)
+: autoware::agnocast_wrapper::Node("autonomous_mode_transition_flag_node", options)
 {
   declare_parameter<double>("stable_check.duration");
   autonomous_mode_ = std::make_unique<AutonomousMode>(this);
+
+  namespace polling = autoware::agnocast_wrapper::polling;
+  sub_kinematics_ = polling::create_polling_subscriber<Odometry>(this, "kinematics");
+  sub_trajectory_ = polling::create_polling_subscriber<Trajectory>(this, "trajectory");
+  sub_control_cmd_ = polling::create_polling_subscriber<Control>(this, "control_cmd");
+  sub_trajectory_follower_control_cmd_ =
+    polling::create_polling_subscriber<Control>(this, "trajectory_follower_control_cmd");
 
   pub_transition_available_ =
     create_publisher<ModeChangeAvailable>("/system/command_mode/transition/available", 1);
@@ -34,7 +41,8 @@ AutonomousModeTransitionFlagNode::AutonomousModeTransitionFlagNode(
   pub_debug_ = create_publisher<ModeChangeBase::DebugInfo>("~/debug_info", 1);
 
   const auto period = rclcpp::Rate(declare_parameter<double>("frequency_hz")).period();
-  timer_ = rclcpp::create_timer(this, get_clock(), period, [this]() { on_timer(); });
+  timer_ =
+    autoware::agnocast_wrapper::create_timer(this, get_clock(), period, [this]() { on_timer(); });
 }
 
 void AutonomousModeTransitionFlagNode::on_timer()
@@ -63,22 +71,22 @@ InputData AutonomousModeTransitionFlagNode::take_data()
 {
   InputData data;
 
-  const auto kinematics = sub_kinematics_.take_data();
+  const auto kinematics = sub_kinematics_->take_data();
   if (kinematics) {
     data.kinematics = *kinematics;
   }
 
-  const auto trajectory = sub_trajectory_.take_data();
+  const auto trajectory = sub_trajectory_->take_data();
   if (trajectory) {
     data.trajectory = *trajectory;
   }
 
-  const auto control_cmd = sub_control_cmd_.take_data();
+  const auto control_cmd = sub_control_cmd_->take_data();
   if (control_cmd) {
     data.control_cmd = *control_cmd;
   }
 
-  const auto trajectory_follower_control_cmd = sub_trajectory_follower_control_cmd_.take_data();
+  const auto trajectory_follower_control_cmd = sub_trajectory_follower_control_cmd_->take_data();
   if (trajectory_follower_control_cmd) {
     data.trajectory_follower_control_cmd = *trajectory_follower_control_cmd;
   }

--- a/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.hpp
@@ -17,7 +17,9 @@
 
 #include "state.hpp"
 
-#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_system_msgs/msg/mode_change_available.hpp>
@@ -27,7 +29,7 @@
 namespace autoware::operation_mode_transition_manager
 {
 
-class AutonomousModeTransitionFlagNode : public rclcpp::Node
+class AutonomousModeTransitionFlagNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit AutonomousModeTransitionFlagNode(const rclcpp::NodeOptions & options);
@@ -37,18 +39,17 @@ private:
   void on_timer();
   InputData take_data();
 
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<ModeChangeAvailable>::SharedPtr pub_transition_available_;
-  rclcpp::Publisher<ModeChangeAvailable>::SharedPtr pub_transition_completed_;
-  rclcpp::Publisher<ModeChangeBase::DebugInfo>::SharedPtr pub_debug_;
+  AUTOWARE_TIMER_PTR timer_;
+  AUTOWARE_PUBLISHER_PTR(ModeChangeAvailable) pub_transition_available_;
+  AUTOWARE_PUBLISHER_PTR(ModeChangeAvailable) pub_transition_completed_;
+  AUTOWARE_PUBLISHER_PTR(ModeChangeBase::DebugInfo) pub_debug_;
 
   template <class T>
-  using PollingSubscriber = autoware_utils_rclcpp::InterProcessPollingSubscriber<T>;
-  PollingSubscriber<Odometry> sub_kinematics_{this, "kinematics"};
-  PollingSubscriber<Trajectory> sub_trajectory_{this, "trajectory"};
-  PollingSubscriber<Control> sub_control_cmd_{this, "control_cmd"};
-  PollingSubscriber<Control> sub_trajectory_follower_control_cmd_{
-    this, "trajectory_follower_control_cmd"};
+  using PollingSubscriber = autoware::agnocast_wrapper::polling::PollingSubscriber<T>;
+  PollingSubscriber<Odometry>::SharedPtr sub_kinematics_;
+  PollingSubscriber<Trajectory>::SharedPtr sub_trajectory_;
+  PollingSubscriber<Control>::SharedPtr sub_control_cmd_;
+  PollingSubscriber<Control>::SharedPtr sub_trajectory_follower_control_cmd_;
 
   std::unique_ptr<ModeChangeBase> autonomous_mode_;
 };

--- a/control/autoware_operation_mode_transition_manager/src/compatibility.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/compatibility.cpp
@@ -19,7 +19,7 @@
 namespace autoware::operation_mode_transition_manager
 {
 
-Compatibility::Compatibility(rclcpp::Node * node) : node_(node)
+Compatibility::Compatibility(autoware::agnocast_wrapper::Node * node) : node_(node)
 {
   sub_autoware_engage_ = node->create_subscription<AutowareEngage>(
     "/api/autoware/get/engage", 1,
@@ -118,7 +118,7 @@ void Compatibility::set_mode(const OperationMode mode)
       is_calling_service_ = true;
       cli_selector_mode_->async_send_request(
         req,
-        [this](rclcpp::Client<SelectorModeSrv>::SharedFuture) { is_calling_service_ = false; });
+        [this](AUTOWARE_CLIENT_SHARED_FUTURE(SelectorModeSrv)) { is_calling_service_ = false; });
     }
   }
 

--- a/control/autoware_operation_mode_transition_manager/src/compatibility.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/compatibility.hpp
@@ -17,6 +17,9 @@
 
 #include "data.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
@@ -28,7 +31,7 @@ namespace autoware::operation_mode_transition_manager
 class Compatibility
 {
 public:
-  explicit Compatibility(rclcpp::Node * node);
+  explicit Compatibility(autoware::agnocast_wrapper::Node * node);
   void set_mode(const OperationMode mode);
   std::optional<OperationMode> get_mode() const;
 
@@ -37,18 +40,18 @@ private:
   using GateMode = tier4_control_msgs::msg::GateMode;
   using SelectorModeMsg = tier4_control_msgs::msg::ExternalCommandSelectorMode;
   using SelectorModeSrv = tier4_control_msgs::srv::ExternalCommandSelect;
-  rclcpp::Subscription<AutowareEngage>::SharedPtr sub_autoware_engage_;
-  rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
-  rclcpp::Subscription<SelectorModeMsg>::SharedPtr sub_selector_mode_;
-  rclcpp::Publisher<AutowareEngage>::SharedPtr pub_autoware_engage_;
-  rclcpp::Publisher<GateMode>::SharedPtr pub_gate_mode_;
-  rclcpp::Client<SelectorModeSrv>::SharedPtr cli_selector_mode_;
+  AUTOWARE_SUBSCRIPTION_PTR(AutowareEngage) sub_autoware_engage_;
+  AUTOWARE_SUBSCRIPTION_PTR(GateMode) sub_gate_mode_;
+  AUTOWARE_SUBSCRIPTION_PTR(SelectorModeMsg) sub_selector_mode_;
+  AUTOWARE_PUBLISHER_PTR(AutowareEngage) pub_autoware_engage_;
+  AUTOWARE_PUBLISHER_PTR(GateMode) pub_gate_mode_;
+  AUTOWARE_CLIENT_PTR(SelectorModeSrv) cli_selector_mode_;
   void on_autoware_engage(const AutowareEngage::ConstSharedPtr msg);
   void on_gate_mode(const GateMode::ConstSharedPtr msg);
   void on_selector_mode(const SelectorModeMsg::ConstSharedPtr msg);
 
   bool is_calling_service_ = false;
-  rclcpp::Node * node_;
+  autoware::agnocast_wrapper::Node * node_;
   AutowareEngage::ConstSharedPtr autoware_engage_;
   GateMode::ConstSharedPtr gate_mode_;
   SelectorModeMsg::ConstSharedPtr selector_mode_;

--- a/control/autoware_operation_mode_transition_manager/src/node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.cpp
@@ -22,14 +22,26 @@ namespace autoware::operation_mode_transition_manager
 {
 
 OperationModeTransitionManager::OperationModeTransitionManager(const rclcpp::NodeOptions & options)
-: Node("autoware_operation_mode_transition_manager", options), compatibility_(this)
+: autoware::agnocast_wrapper::Node("autoware_operation_mode_transition_manager", options),
+  compatibility_(this)
 {
   cli_control_mode_ = create_client<ControlModeCommand>("control_mode_request");
   pub_debug_info_ = create_publisher<ModeChangeBase::DebugInfo>("~/debug_info", 1);
 
+  namespace polling = autoware::agnocast_wrapper::polling;
+  sub_kinematics_ = polling::create_polling_subscriber<Odometry>(this, "kinematics");
+  sub_trajectory_ = polling::create_polling_subscriber<Trajectory>(this, "trajectory");
+  sub_trajectory_follower_control_cmd_ =
+    polling::create_polling_subscriber<Control>(this, "trajectory_follower_control_cmd");
+  sub_control_cmd_ = polling::create_polling_subscriber<Control>(this, "control_cmd");
+  sub_gate_operation_mode_ =
+    polling::create_polling_subscriber<OperationModeState>(this, "gate_operation_mode");
+  sub_control_mode_report_ =
+    polling::create_polling_subscriber<ControlModeReport>(this, "control_mode_report");
+
   // component interface
   {
-    const auto node = autoware::component_interface_utils::NodeAdaptor(this);
+    const auto node = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
     node.init_srv(
       srv_autoware_control_, this, &OperationModeTransitionManager::onChangeAutowareControl);
     node.init_srv(
@@ -40,7 +52,7 @@ OperationModeTransitionManager::OperationModeTransitionManager(const rclcpp::Nod
   // timer
   {
     const auto period_ns = rclcpp::Rate(declare_parameter<double>("frequency_hz")).period();
-    timer_ = rclcpp::create_timer(
+    timer_ = autoware::agnocast_wrapper::create_timer(
       this, get_clock(), period_ns, std::bind(&OperationModeTransitionManager::onTimer, this));
   }
 
@@ -101,7 +113,7 @@ void OperationModeTransitionManager::onChangeOperationMode(
 
 void OperationModeTransitionManager::changeControlMode(ControlModeCommandType mode)
 {
-  const auto callback = [this](rclcpp::Client<ControlModeCommand>::SharedFuture future) {
+  const auto callback = [this](AUTOWARE_CLIENT_SHARED_FUTURE(ControlModeCommand) future) {
     if (!future.get()->success) {
       RCLCPP_WARN(get_logger(), "Autonomous mode change was rejected.");
       if (transition_) {
@@ -253,7 +265,7 @@ InputData OperationModeTransitionManager::subscribeData()
 {
   InputData input_data;
 
-  const auto kinematics_ptr = sub_kinematics_.take_data();
+  const auto kinematics_ptr = sub_kinematics_->take_data();
   if (kinematics_ptr) {
     if (input_timeout_ < (now() - kinematics_ptr->header.stamp).seconds()) {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 3000, "Subscribed kinematics is timed out.");
@@ -262,7 +274,7 @@ InputData OperationModeTransitionManager::subscribeData()
     }
   }
 
-  const auto trajectory_ptr = sub_trajectory_.take_data();
+  const auto trajectory_ptr = sub_trajectory_->take_data();
   if (trajectory_ptr) {
     if (input_timeout_ < (now() - trajectory_ptr->header.stamp).seconds()) {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 3000, "Subscribed trajectory is timed out.");
@@ -271,7 +283,8 @@ InputData OperationModeTransitionManager::subscribeData()
     }
   }
 
-  const auto trajectory_follower_control_cmd_ptr = sub_trajectory_follower_control_cmd_.take_data();
+  const auto trajectory_follower_control_cmd_ptr =
+    sub_trajectory_follower_control_cmd_->take_data();
   if (trajectory_follower_control_cmd_ptr) {
     if (input_timeout_ < (now() - trajectory_follower_control_cmd_ptr->stamp).seconds()) {
       RCLCPP_WARN_THROTTLE(
@@ -282,7 +295,7 @@ InputData OperationModeTransitionManager::subscribeData()
     }
   }
 
-  const auto control_cmd_ptr = sub_control_cmd_.take_data();
+  const auto control_cmd_ptr = sub_control_cmd_->take_data();
   if (control_cmd_ptr) {
     if (input_timeout_ < (now() - control_cmd_ptr->stamp).seconds()) {
       RCLCPP_WARN_THROTTLE(
@@ -294,7 +307,7 @@ InputData OperationModeTransitionManager::subscribeData()
 
   // NOTE: Do not check the timeout of gate_operation_mode since the timestamp of this node's output
   // is used in the vehicle_cmd_gate node, which is updated only when the state changes.
-  const auto gate_operation_mode_ptr = sub_gate_operation_mode_.take_data();
+  const auto gate_operation_mode_ptr = sub_gate_operation_mode_->take_data();
   if (gate_operation_mode_ptr) {
     input_data.gate_operation_mode = *gate_operation_mode_ptr;
   } else {
@@ -304,7 +317,7 @@ InputData OperationModeTransitionManager::subscribeData()
     input_data.gate_operation_mode.is_in_transition = false;
   }
 
-  const auto control_mode_report_ptr = sub_control_mode_report_.take_data();
+  const auto control_mode_report_ptr = sub_control_mode_report_->take_data();
   if (control_mode_report_ptr) {
     // NOTE: This will be used outside the onTimer function. Therefore, it
     // has to be a member variable

--- a/control/autoware_operation_mode_transition_manager/src/node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.hpp
@@ -18,9 +18,11 @@
 #include "compatibility.hpp"
 #include "state.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/component_interface_specs_universe/system.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
@@ -29,23 +31,24 @@
 namespace autoware::operation_mode_transition_manager
 {
 
-class OperationModeTransitionManager : public rclcpp::Node
+class OperationModeTransitionManager : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit OperationModeTransitionManager(const rclcpp::NodeOptions & options);
 
 private:
+  using NodeT = autoware::agnocast_wrapper::Node;
   using ChangeAutowareControlAPI =
     autoware::component_interface_specs_universe::system::ChangeAutowareControl;
   using ChangeOperationModeAPI =
     autoware::component_interface_specs_universe::system::ChangeOperationMode;
   using OperationModeStateAPI =
     autoware::component_interface_specs_universe::system::OperationModeState;
-  autoware::component_interface_utils::Service<ChangeAutowareControlAPI>::SharedPtr
+  autoware::component_interface_utils::Service<ChangeAutowareControlAPI, NodeT>::SharedPtr
     srv_autoware_control_;
-  autoware::component_interface_utils::Service<ChangeOperationModeAPI>::SharedPtr
+  autoware::component_interface_utils::Service<ChangeOperationModeAPI, NodeT>::SharedPtr
     srv_operation_mode_;
-  autoware::component_interface_utils::Publisher<OperationModeStateAPI>::SharedPtr
+  autoware::component_interface_utils::Publisher<OperationModeStateAPI, NodeT>::SharedPtr
     pub_operation_mode_;
   void onChangeAutowareControl(
     const ChangeAutowareControlAPI::Service::Request::SharedPtr request,
@@ -55,19 +58,19 @@ private:
     const ChangeOperationModeAPI::Service::Response::SharedPtr response);
 
   using ControlModeCommandType = ControlModeCommand::Request::_mode_type;
-  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{this, "kinematics"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_trajectory_{this, "trajectory"};
-  autoware_utils::InterProcessPollingSubscriber<Control> sub_trajectory_follower_control_cmd_{
-    this, "trajectory_follower_control_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<Control> sub_control_cmd_{this, "control_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_gate_operation_mode_{
-    this, "gate_operation_mode"};
-  autoware_utils::InterProcessPollingSubscriber<ControlModeReport> sub_control_mode_report_{
-    this, "control_mode_report"};
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr sub_kinematics_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Trajectory>::SharedPtr sub_trajectory_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Control>::SharedPtr
+    sub_trajectory_follower_control_cmd_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Control>::SharedPtr sub_control_cmd_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<OperationModeState>::SharedPtr
+    sub_gate_operation_mode_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<ControlModeReport>::SharedPtr
+    sub_control_mode_report_;
 
-  rclcpp::Client<ControlModeCommand>::SharedPtr cli_control_mode_;
-  rclcpp::Publisher<ModeChangeBase::DebugInfo>::SharedPtr pub_debug_info_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_CLIENT_PTR(ControlModeCommand) cli_control_mode_;
+  AUTOWARE_PUBLISHER_PTR(ModeChangeBase::DebugInfo) pub_debug_info_;
+  AUTOWARE_TIMER_PTR timer_;
   void onTimer();
   InputData subscribeData();
   void publishData();

--- a/control/autoware_operation_mode_transition_manager/src/state.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.cpp
@@ -32,7 +32,7 @@ using autoware::motion_utils::findNearestIndex;
 using autoware_utils::calc_distance2d;
 using autoware_utils::calc_yaw_deviation;
 
-AutonomousMode::AutonomousMode(rclcpp::Node * node)
+AutonomousMode::AutonomousMode(autoware::agnocast_wrapper::Node * node)
 : logger_(node->get_logger()), clock_(node->get_clock())
 {
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo();

--- a/control/autoware_operation_mode_transition_manager/src/state.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.hpp
@@ -18,6 +18,7 @@
 #include "autoware_operation_mode_transition_manager/msg/operation_mode_transition_manager_debug.hpp"
 #include "data.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -67,7 +68,7 @@ public:
 class AutonomousMode : public ModeChangeBase
 {
 public:
-  explicit AutonomousMode(rclcpp::Node * node);
+  explicit AutonomousMode(autoware::agnocast_wrapper::Node * node);
   void update(bool transition) override;
   bool isModeChangeCompleted(const InputData & input_data) override;
   bool isModeChangeAvailable(const InputData & input_data) override;


### PR DESCRIPTION
  ## Description

  Migrate `autoware_operation_mode_transition_manager` from `rclcpp::Node` to `autoware::agnocast_wrapper::Node`. Also declares the `tier4_system_msgs` dependency, which `autonomous_mode_transition_flag_node.hpp` already included but `package.xml` did not list.

  The backend is selected at build time by `ENABLE_AGNOCAST`; with `ENABLE_AGNOCAST=0` the nodes keep the plain rclcpp behavior.

  ## Related links

  **Parent Issue:**

  - Link

  ## How was this PR tested?

  `logging_simulator.launch.xml` on a recorded bag with `ENABLE_AGNOCAST=0` and `=1`. 
  ## Notes for reviewers

  ## Interface changes

  None.

  ## Effects on system behavior

  None with `ENABLE_AGNOCAST=0`. With `ENABLE_AGNOCAST=1` the nodes must run as standalone processes.
