### PR TITLE
feat(autoware_diffusion_planner): apply agnocast_wrapper::Node

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -149,7 +149,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     PLUGIN "autoware::diffusion_planner::DiffusionPlanner"
     EXECUTABLE autoware_diffusion_planner_node
     ROS2_EXECUTOR SingleThreadedExecutor
-    AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+    AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   )
 
   if(BUILD_TESTING)

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -18,6 +18,8 @@
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
 #include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
@@ -28,8 +30,6 @@
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/subscription.hpp>
-#include <rclcpp/timer.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -60,7 +60,10 @@ using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
-using autoware_utils_diagnostics::DiagnosticsInterface;
+using DiagnosticsInterface =
+  autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>;
+using PlanningFactorInterface =
+  autoware::planning_factor_interface::PlanningFactorInterfaceT<autoware::agnocast_wrapper::Node>;
 using geometry_msgs::msg::Pose;
 using rcl_interfaces::msg::SetParametersResult;
 using std_srvs::srv::SetBool;
@@ -117,7 +120,7 @@ struct DiffusionPlannerPlanningFactorParams
  * - generator_uuid_: Unique identifier for the planner instance.
  * - vehicle_info_: Vehicle-specific parameters.
  */
-class DiffusionPlanner : public rclcpp::Node
+class DiffusionPlanner : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit DiffusionPlanner(const rclcpp::NodeOptions & options);
@@ -214,68 +217,81 @@ private:
   void on_set_centerline_guidance_enabled(
     const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response);
 
+  // Node elements
+  AUTOWARE_TIMER_PTR timer_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) debug_processing_time_detail_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped)
+  debug_processing_time_pub_{nullptr};
+  AUTOWARE_PUBLISHER_PTR(Trajectory) pub_trajectory_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(CandidateTrajectories) pub_trajectories_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(PredictedObjects) pub_objects_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_lane_marker_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_linestring_marker_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_route_marker_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(TurnIndicatorsCommand) pub_turn_indicators_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrafficLightGroup)
+  pub_traffic_signal_{nullptr};
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseStamped) pub_snapped_pose_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped)
+  pub_snap_interpolation_time_{nullptr};
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64) pub_inference_time_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float32MultiArray) pub_denoising_steps_ { nullptr };
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::StringStamped)
+  pub_guidance_status_{nullptr};
+  AUTOWARE_SERVICE_PTR(SetBool) set_start_guidance_enabled_service_ { nullptr };
+  AUTOWARE_SERVICE_PTR(SetBool) set_stop_guidance_enabled_service_ { nullptr };
+  AUTOWARE_SERVICE_PTR(SetBool) set_centerline_guidance_enabled_service_ { nullptr };
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr
+    sub_current_odometry_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
+        this, "~/input/odometry", 1);
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+    sub_current_acceleration_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(
+        this, "~/input/acceleration", 1);
+  autoware::agnocast_wrapper::polling::PollingSubscriber<TrackedObjects>::SharedPtr
+    sub_tracked_objects_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<TrackedObjects>(
+        this, "~/input/tracked_objects", 1);
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    autoware_perception_msgs::msg::TrafficLightGroupArray,
+    autoware_utils::polling_policy::All>::SharedPtr sub_traffic_signals_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      autoware_perception_msgs::msg::TrafficLightGroupArray, autoware_utils::polling_policy::All>(
+      this, "~/input/traffic_signals", rclcpp::QoS{10});
+  autoware::agnocast_wrapper::polling::PollingSubscriber<TurnIndicatorsReport>::SharedPtr
+    sub_turn_indicators_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<TurnIndicatorsReport>(
+        this, "~/input/turn_indicators", 1);
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletRoute, autoware_utils::polling_policy::Newest>::SharedPtr route_subscriber_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletRoute, autoware_utils::polling_policy::Newest>(
+      this, "~/input/route", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletMapBin, autoware_utils::polling_policy::Newest>::SharedPtr vector_map_subscriber_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletMapBin, autoware_utils::polling_policy::Newest>(
+      this, "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_SUBSCRIPTION_PTR(HADMapBin) sub_map_;
+  UUID generator_uuid_;
+  VehicleInfo vehicle_info_;
+
   // Core logic instance
   std::unique_ptr<DiffusionPlannerCore> core_;
 
   // Node parameters
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   DiffusionPlannerParams params_;
   DiffusionPlannerDebugParams debug_params_;
-
-  // Node elements
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    debug_processing_time_pub_{nullptr};
-  rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_{nullptr};
-  rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_{nullptr};
-  rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_lane_marker_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_linestring_marker_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_route_marker_{nullptr};
-  rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr pub_turn_indicators_{nullptr};
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr
-    pub_traffic_signal_{nullptr};
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_snapped_pose_{nullptr};
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    pub_snap_interpolation_time_{nullptr};
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_inference_time_{nullptr};
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_denoising_steps_{nullptr};
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
-    pub_guidance_status_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_start_guidance_enabled_service_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_stop_guidance_enabled_service_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_centerline_guidance_enabled_service_{nullptr};
-  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
-  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
-    this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
-    sub_current_acceleration_{this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<TrackedObjects> sub_tracked_objects_{
-    this, "~/input/tracked_objects"};
-  autoware_utils::InterProcessPollingSubscriber<
-    autoware_perception_msgs::msg::TrafficLightGroupArray, autoware_utils::polling_policy::All>
-    sub_traffic_signals_{this, "~/input/traffic_signals", rclcpp::QoS{10}};
-  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsReport> sub_turn_indicators_{
-    this, "~/input/turn_indicators"};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletRoute, autoware_utils::polling_policy::Newest>
-    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletMapBin, autoware_utils::polling_policy::Newest>
-    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
-  UUID generator_uuid_;
-  VehicleInfo vehicle_info_;
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
 
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
-  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
-    planning_factor_interface_;
+  std::unique_ptr<PlanningFactorInterface> planning_factor_interface_;
   DiffusionPlannerPlanningFactorParams planning_factor_params_;
 };
 

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -18,7 +18,10 @@
   <arg name="input_turn_indicators" default="~/input/turn_indicators"/>
   <arg name="build_only" default="false" description="shutdown node after model initialization"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var diffusion_planner_param_path)" allow_substs="true"/>
     <param from="$(var vehicle_info_param_path)" allow_substs="true"/>
     <remap from="~/output/trajectory" to="$(var output_trajectory)"/>

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -131,9 +131,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
       &DiffusionPlanner::on_set_centerline_guidance_enabled, this, std::placeholders::_1,
       std::placeholders::_2));
 
-  planning_factor_interface_ =
-    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      this, "diffusion_planner");
+  planning_factor_interface_ = std::make_unique<PlanningFactorInterface>(this, "diffusion_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
   try {
@@ -152,7 +150,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     }
   }
 
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), rclcpp::Rate(params_.planning_frequency_hz).period(),
     std::bind(&DiffusionPlanner::on_timer, this));
 
@@ -573,12 +571,12 @@ void DiffusionPlanner::on_timer()
   }
 
   // Take data from subscribers
-  auto objects = sub_tracked_objects_.take_data();
-  auto ego_kinematic_state = sub_current_odometry_.take_data();
-  auto ego_acceleration = sub_current_acceleration_.take_data();
-  auto traffic_signals = sub_traffic_signals_.take_data();
-  auto temp_route_ptr = route_subscriber_.take_data();
-  auto turn_indicators_ptr = sub_turn_indicators_.take_data();
+  auto objects = sub_tracked_objects_->take_data();
+  auto ego_kinematic_state = sub_current_odometry_->take_data();
+  auto ego_acceleration = sub_current_acceleration_->take_data();
+  auto traffic_signals = sub_traffic_signals_->take_data();
+  auto temp_route_ptr = route_subscriber_->take_data();
+  auto turn_indicators_ptr = sub_turn_indicators_->take_data();
 
   // Prepare frame context using core
   const std::optional<FrameContext> frame_context = core_->create_frame_context(


### PR DESCRIPTION
## Description  
Change the base class of `autoware::diffusion_planner::DiffusionPlanner` from `rclcpp::Node` to `autoware::agnocast_wrapper::Node`, so that the node runs on  `agnocast::Node` when `ENABLE_AGNOCAST=1`.

  ## Main changes

  - Set `AGNOCAST_EXECUTOR` to `AgnocastOnlyCallbackIsolatedExecutor`.
  - Include `agnocast_env.launch.xml` from `diffusion_planner.launch.xml` and set the heaphook via `LD_PRELOAD`.
  - Reorder the member declarations (i.e. the initialization and destruction order). Under Agnocast a message smart pointer points into shared memory and therefore must not outlive the subscription it was received from. Because `DiffusionPlannerCore` holds a route message, the whole set of node elements — including the polling subscribers — is now declared before `core_`, so that the endpoints are destroyed last. This follows the PR template.
  
## Related links

Upstream PR: https://github.com/autowarefoundation/autoware_universe/pull/13363 (not merged yet)

`~/input/traffic_signals` keeps `polling_policy::All` with `QoS(10)`. That policy is available in the wrapper through autowarefoundation/autoware_core#1443, which is already present in this repository.

No companion change is needed on the launch side: the node is not loaded into a container, and its own launch file is part of this PR.

## How was this PR tested?

| | `ENABLE_AGNOCAST=1` | `ENABLE_AGNOCAST=0` |
|---|---|---|
| Build | 657 packages, 0 failed | OK (separate build tree) |
| `colcon test` | 110 gtest cases, 0 failures | 110 gtest cases, 0 failures |
| `process has died` | 0 | 0 |
| Node startup | listed as `(Agnocast enabled)`, heaphook loaded | starts normally |
| `~/output/trajectory` | 10.004 Hz | 10.016 Hz |
| `~/debug/inference_time_ms` | 9.987 Hz, 23.19 ms | 9.999 Hz, 22.98 ms |
| `/planning/generator/diffusion_planner/candidate_trajectories` | 9.978 Hz | 10.016 Hz |
| Route reached (`/api/routing/state`) | 3 (ARRIVED) | 3 (ARRIVED) |
| `~/input/traffic_signals` subscription depth | KEEP_LAST(10) | KEEP_LAST(10) |

PSim covers the route path; the traffic signal input is only published in the logging simulator, so the subscription depth was measured there. Both runs use the same binaries, started with the environment variable flipped.

## Notes for reviewers

### Interface changes

None. Topic names, service names, message types and all remaps are unchanged.

### Effects on system behavior

None with `ENABLE_AGNOCAST=0`. With `ENABLE_AGNOCAST=1` the node runs under `AgnocastOnlyCallbackIsolatedExecutor` with the heaphook preloaded. The member declaration order was changed so that the subscriptions outlive `core_`; this only affects construction and destruction order, not runtime behavior.