### PR TITLE
feat(hazard_lights_selector): apply `agnocast_wrapper::Node` to `autoware_hazard_lights_selector` (cherry-pick #12850)

### DIFF
--- a/planning/autoware_hazard_lights_selector/CMakeLists.txt
+++ b/planning/autoware_hazard_lights_selector/CMakeLists.txt
@@ -8,9 +8,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::hazard_lights_selector::HazardLightsSelector"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(

--- a/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
+++ b/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
@@ -5,8 +5,11 @@
   <arg name="input_hazard_lights_cmd_from_mrm_operator" default="/system/hazard_lights_cmd"/>
   <arg name="output_hazard_lights_cmd" default="/planning/hazard_lights_cmd"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_hazard_lights_selector" exec="autoware_hazard_lights_selector_node" name="autoware_hazard_lights_selector" output="screen">
     <param from="$(var hazard_lights_selector_param_path)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
 
     <remap from="input/planning/hazard_lights_command" to="$(var input_hazard_lights_cmd_from_path_planner)"/>
     <remap from="input/system/hazard_lights_command" to="$(var input_hazard_lights_cmd_from_mrm_operator)"/>

--- a/planning/autoware_hazard_lights_selector/package.xml
+++ b/planning/autoware_hazard_lights_selector/package.xml
@@ -13,6 +13,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <!-- depend -->
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/autoware_hazard_lights_selector/src/node.cpp
+++ b/planning/autoware_hazard_lights_selector/src/node.cpp
@@ -14,6 +14,10 @@
 
 #include "node.hpp"
 
+#include <stdexcept>
+#include <string>
+#include <utility>
+
 namespace autoware::hazard_lights_selector
 {
 
@@ -24,6 +28,11 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
 
   // Parameter
   params_.update_rate = static_cast<int>(declare_parameter("update_rate", 10));
+  if (params_.update_rate <= 0) {
+    throw std::invalid_argument(
+      "update_rate must be positive, but got " + std::to_string(params_.update_rate));
+  }
+  const auto period_ms = 1000 / params_.update_rate;
 
   // Subscriber
   sub_hazard_lights_command_from_planning_ =
@@ -41,19 +50,19 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
       "output/hazard_lights_command", 1);
 
   // Timer
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), std::chrono::milliseconds(1000 / params_.update_rate),
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), std::chrono::milliseconds(period_ms),
     std::bind(&HazardLightsSelector::on_timer, this));
 }
 
 void HazardLightsSelector::on_hazard_lights_command_from_planning(
-  const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg)
 {
   hazard_lights_command_from_planning_ = msg;
 }
 
 void HazardLightsSelector::on_hazard_lights_command_from_system(
-  const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg)
 {
   hazard_lights_command_from_system_ = msg;
 }
@@ -61,23 +70,23 @@ void HazardLightsSelector::on_hazard_lights_command_from_system(
 void HazardLightsSelector::on_timer()
 {
   using autoware_vehicle_msgs::msg::HazardLightsCommand;
-  auto hazard_lights_command = HazardLightsCommand();
-  hazard_lights_command.stamp = this->now();
-  hazard_lights_command.command = HazardLightsCommand::DISABLE;
+  auto hazard_lights_command = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_hazard_lights_command_);
+  hazard_lights_command->stamp = this->now();
+  hazard_lights_command->command = HazardLightsCommand::DISABLE;
 
   if (hazard_lights_command_from_planning_) {
     if (hazard_lights_command_from_planning_->command == HazardLightsCommand::ENABLE) {
-      hazard_lights_command.command = HazardLightsCommand::ENABLE;
+      hazard_lights_command->command = HazardLightsCommand::ENABLE;
     }
   }
 
   if (hazard_lights_command_from_system_) {
     if (hazard_lights_command_from_system_->command == HazardLightsCommand::ENABLE) {
-      hazard_lights_command.command = HazardLightsCommand::ENABLE;
+      hazard_lights_command->command = HazardLightsCommand::ENABLE;
     }
   }
 
-  pub_hazard_lights_command_->publish(hazard_lights_command);
+  pub_hazard_lights_command_->publish(std::move(hazard_lights_command));
 }
 
 }  // namespace autoware::hazard_lights_selector

--- a/planning/autoware_hazard_lights_selector/src/node.hpp
+++ b/planning/autoware_hazard_lights_selector/src/node.hpp
@@ -16,6 +16,7 @@
 #define NODE_HPP_
 
 // include
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
@@ -28,7 +29,7 @@ struct Parameters
   int update_rate;  // [Hz]
 };
 
-class HazardLightsSelector : public rclcpp::Node
+class HazardLightsSelector : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit HazardLightsSelector(const rclcpp::NodeOptions & node_options);
@@ -38,30 +39,30 @@ private:
   Parameters params_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    sub_hazard_lights_command_from_planning_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    sub_hazard_lights_command_from_system_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  sub_hazard_lights_command_from_planning_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  sub_hazard_lights_command_from_system_;
 
   void on_hazard_lights_command_from_planning(
-    const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg);
   void on_hazard_lights_command_from_system(
-    const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    pub_hazard_lights_command_;
+  AUTOWARE_PUBLISHER_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  pub_hazard_lights_command_;
 
   // Timer
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   void on_timer();
 
   // State
-  autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr
-    hazard_lights_command_from_planning_;
-  autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr
-    hazard_lights_command_from_system_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  hazard_lights_command_from_planning_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  hazard_lights_command_from_system_;
 };
 }  // namespace autoware::hazard_lights_selector
 


### PR DESCRIPTION
## Description
Cherry-pick of autowarefoundation/autoware_universe#12850 onto `feat/v0.64/e2e_scenario_pass`. Migrates `autoware_hazard_lights_selector` to `agnocast_wrapper::Node`, switches the node registration to `autoware_agnocast_wrapper_register_node`, and launches it with the agnocast environment (`agnocast_env.launch.xml` + `LD_PRELOAD`).

The commit applied cleanly with no conflicts and no manual modification.

## Related links

  **Parent Issue:**

  - autowarefoundation/autoware_universe#12850

 ## How was this PR tested?

Verified upstream in autowarefoundation/autoware_universe#12850.
Since the cherry-pick applied without any modification, the upstream verification carries over as is.

## Notes for reviewers
Requires the `autoware_agnocast_wrapper` package from autoware_core to be available.

## Interface changes
  
## Effects on system behavior
  None when `ENABLE_AGNOCAST` is not enabled; the node falls back to the plain rclcpp path.
