### PR TITLE
feat(planning_validator): apply `agnocast_wrapper::Node` to `planning_validator` (cherry-pick #12964)

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator/CMakeLists.txt
@@ -20,11 +20,14 @@ ament_auto_add_library(autoware_planning_validator_component SHARED
 
 ament_target_dependencies(autoware_planning_validator_component
   autoware_adapi_v1_msgs
+  autoware_agnocast_wrapper
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_component
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::planning_validator::PlanningValidatorNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 # invalid trajectory publisher (for debug)
@@ -52,7 +55,7 @@ else()
     target_link_libraries(${PROJECT_NAME}_component "${cpp_typesupport_target}")
 endif()
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(autoware_planning_validator_test_utils REQUIRED)
   ament_add_ros_isolated_gtest(test_autoware_planning_validator
     test/src/test_main.cpp

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware_planning_validator/msg/planning_validator_status.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -39,7 +40,7 @@ using autoware_planning_validator::msg::PlanningValidatorStatus;
 class PlanningValidatorDebugMarkerPublisher
 {
 public:
-  explicit PlanningValidatorDebugMarkerPublisher(rclcpp::Node * node);
+  explicit PlanningValidatorDebugMarkerPublisher(autoware::agnocast_wrapper::Node * node);
 
   void pushPoseMarker(
     const autoware_planning_msgs::msg::TrajectoryPoint & p, const std::string & ns, int id = 0);
@@ -96,11 +97,11 @@ public:
   void clearMarkers();
 
 private:
-  rclcpp::Node * node_;
+  autoware::agnocast_wrapper::Node * node_;
   visualization_msgs::msg::MarkerArray marker_array_;
   visualization_msgs::msg::MarkerArray marker_array_virtual_wall_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr virtual_wall_pub_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) debug_viz_pub_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) virtual_wall_pub_;
   std::map<std::string, int> marker_id_;
 
   int getMarkerId(const std::string & ns)

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/manager.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/manager.hpp
@@ -34,9 +34,9 @@ class PlanningValidatorManager
 public:
   PlanningValidatorManager();
   void load_plugin(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context);
-  void unload_plugin(rclcpp::Node & node, const std::string & name);
+  void unload_plugin(autoware::agnocast_wrapper::Node & node, const std::string & name);
   void validate();
 
 private:

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
@@ -20,11 +20,12 @@
 #include "autoware/planning_validator/types.hpp"
 #include "autoware_planning_validator/msg/planning_validator_status.hpp"
 
-#include <autoware_utils/ros/logger_level_configure.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware_utils/ros/parameter.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
-#include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -58,13 +59,14 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
 
-class PlanningValidatorNode : public rclcpp::Node
+class PlanningValidatorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PlanningValidatorNode(const rclcpp::NodeOptions & options);
 
 private:
-  void onTrajectory(const Trajectory::ConstSharedPtr & traj_msg);
+  void onTrajectory(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Trajectory) & traj_msg);
+  void onOdometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Odometry) & msg);
   void setupParameters();
   void setData(const Trajectory::ConstSharedPtr & traj_msg);
   bool isDataReady();
@@ -77,29 +79,42 @@ private:
   void displayStatus();
 
   // subscriber
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletRoute, autoware_utils::polling_policy::Newest>
-    sub_route_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletMapBin, autoware_utils::polling_policy::Newest>
-    sub_lanelet_map_bin_{this, "~/input/lanelet_map_bin", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<PointCloud2> sub_pointcloud_{
-    this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos()};
-  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{
-    this, "~/input/kinematics"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> sub_acceleration_{
-    this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operational_state_{
-    this, "~/input/operational_mode_state", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<TrafficLightGroupArray> sub_traffic_signals_{
-    this, "~/input/traffic_signals"};
+  AUTOWARE_SUBSCRIPTION_PTR(Trajectory) sub_trajectory_;
+  AUTOWARE_SUBSCRIPTION_PTR(Odometry) sub_odometry_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr
+    sub_route_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>(
+      this, "~/input/route", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletMapBin, autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr
+    sub_lanelet_map_bin_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletMapBin, autoware::agnocast_wrapper::polling::polling_policy::Newest>(
+      this, "~/input/lanelet_map_bin", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PointCloud2>::SharedPtr sub_pointcloud_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<PointCloud2>(
+      this, "~/input/pointcloud", rclcpp::SensorDataQoS(rclcpp::KeepLast(1)));
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr sub_kinematics_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
+      this, "~/input/kinematics");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+    sub_acceleration_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(
+        this, "~/input/acceleration");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<OperationModeState>::SharedPtr
+    sub_operational_state_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<OperationModeState>(
+        this, "~/input/operational_mode_state", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<TrafficLightGroupArray>::SharedPtr
+    sub_traffic_signals_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<TrafficLightGroupArray>(
+        this, "~/input/traffic_signals");
 
   // publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr pub_traj_;
-  rclcpp::Publisher<PlanningValidatorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<Float64Stamped>::SharedPtr pub_processing_time_ms_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
+  AUTOWARE_PUBLISHER_PTR(Trajectory) pub_traj_;
+  AUTOWARE_PUBLISHER_PTR(PlanningValidatorStatus) pub_status_;
+  AUTOWARE_PUBLISHER_PTR(Float64Stamped) pub_processing_time_ms_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) pub_markers_;
 
   PlanningValidatorManager manager_;
 
@@ -113,9 +128,13 @@ private:
 
   Trajectory::ConstSharedPtr soft_stop_trajectory_;
 
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<
+    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>
+    logger_configure_;
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 
   StopWatch<std::chrono::milliseconds> stop_watch_;
 };

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/plugin_interface.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/plugin_interface.hpp
@@ -18,6 +18,7 @@
 #include "autoware/planning_validator/types.hpp"
 #include "autoware_planning_validator/msg/planning_validator_status.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -34,7 +35,7 @@ class PluginInterface
 public:
   virtual ~PluginInterface() = default;
   virtual void init(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context) = 0;
   virtual void validate() = 0;
   virtual void setup_diag() = 0;
@@ -46,7 +47,8 @@ protected:
   std::shared_ptr<PlanningValidatorContext> context_;
   rclcpp::Clock::SharedPtr clock_{};
 
-  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+  std::unique_ptr<
+    autoware::planning_factor_interface::PlanningFactorInterfaceT<autoware::agnocast_wrapper::Node>>
     planning_factor_interface_;
 };
 

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
@@ -19,6 +19,9 @@
 #include "autoware/planning_validator/utils.hpp"
 #include "autoware_planning_validator/msg/planning_validator_status.hpp"
 
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <autoware/route_handler/route_handler.hpp>
@@ -31,9 +34,6 @@
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <memory>
 #include <string>
@@ -172,17 +172,19 @@ struct PlanningValidatorData
 
 struct PlanningValidatorContext
 {
-  explicit PlanningValidatorContext(rclcpp::Node * node)
+  explicit PlanningValidatorContext(autoware::agnocast_wrapper::Node * node)
   : vehicle_info(autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo()),
     tf_buffer{node->get_clock()},
-    tf_listener{tf_buffer},
+    tf_listener{tf_buffer, *node},
     clock{node->get_clock()}
   {
     debug_pose_publisher = std::make_shared<PlanningValidatorDebugMarkerPublisher>(node);
     data = std::make_shared<PlanningValidatorData>();
     validation_status = std::make_shared<PlanningValidatorStatus>();
-    diag_updater = std::make_shared<Updater>(node);
-    vehicle_stop_checker_ = std::make_shared<autoware::motion_utils::VehicleStopChecker>(node);
+    diag_updater = std::make_shared<autoware::agnocast_wrapper::diagnostic_updater::Updater>(node);
+    constexpr double vehicle_velocity_buffer_time_sec = 10.0;
+    vehicle_stop_checker_ = std::make_shared<autoware::motion_utils::VehicleStopCheckerBase>(
+      node, vehicle_velocity_buffer_time_sec);
     init_validation_status();
   }
 
@@ -191,13 +193,13 @@ struct PlanningValidatorContext
   PlanningValidatorParams params;
 
   std::shared_ptr<PlanningValidatorDebugMarkerPublisher> debug_pose_publisher = nullptr;
-  std::shared_ptr<Updater> diag_updater = nullptr;
+  std::shared_ptr<autoware::agnocast_wrapper::diagnostic_updater::Updater> diag_updater = nullptr;
   std::shared_ptr<PlanningValidatorData> data = nullptr;
   std::shared_ptr<PlanningValidatorStatus> validation_status = nullptr;
-  std::shared_ptr<autoware::motion_utils::VehicleStopChecker> vehicle_stop_checker_ = nullptr;
+  std::shared_ptr<autoware::motion_utils::VehicleStopCheckerBase> vehicle_stop_checker_ = nullptr;
 
-  tf2_ros::Buffer tf_buffer;
-  tf2_ros::TransformListener tf_listener;
+  autoware::agnocast_wrapper::Buffer tf_buffer;
+  autoware::agnocast_wrapper::TransformListener tf_listener;
   rclcpp::Clock::SharedPtr clock{};
 
   auto get_traffic_signal(const int64_t group_id) -> std::optional<std::vector<TrafficLightElement>>

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -1,10 +1,4 @@
 <launch>
-  <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
-  <let name="container_package" value="rclcpp_components" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_package" value="agnocast_components" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_executable" value="$(var container_type)" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_executable" value="agnocast_component_container_cie" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-
   <arg name="launch_latency_checker" default="true"/>
   <arg name="launch_trajectory_checker" default="true"/>
   <arg name="launch_intersection_collision_checker" default="true"/>
@@ -46,28 +40,28 @@
   <arg name="input_vector_map_topic_name" default="/map/vector_map"/>
   <arg name="output_trajectory" default="/planning/trajectory"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <group>
-    <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="planning_validator_container" namespace="" args="" output="both">
-      <composable_node pkg="autoware_planning_validator" plugin="autoware::planning_validator::PlanningValidatorNode" name="planning_validator" namespace="">
-        <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-        <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-        <remap from="~/input/trajectory" to="$(var input_trajectory_topic_name)"/>
-        <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-        <remap from="~/input/lanelet_map_bin" to="$(var input_vector_map_topic_name)"/>
-        <remap from="~/input/route" to="$(var input_route_topic_name)"/>
-        <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
-        <remap from="~/input/acceleration" to="/localization/acceleration"/>
-        <remap from="~/input/operational_mode_state" to="/system/operation_mode/state"/>
-        <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
-        <remap from="~/output/validation_status" to="~/validation_status"/>
-        <param name="launch_modules" value="$(var planning_validator_launch_modules)"/>
-        <param from="$(var planning_validator_param_path)"/>
-        <param from="$(var planning_validator_latency_checker_param_path)"/>
-        <param from="$(var planning_validator_trajectory_checker_param_path)"/>
-        <param from="$(var planning_validator_intersection_collision_checker_param_path)"/>
-        <param from="$(var planning_validator_rear_collision_checker_param_path)"/>
-        <extra_arg name="use_intra_process_comms" value="false"/>
-      </composable_node>
-    </node_container>
+    <node pkg="autoware_planning_validator" exec="autoware_planning_validator_node" name="planning_validator" namespace="" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+      <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+      <remap from="~/input/trajectory" to="$(var input_trajectory_topic_name)"/>
+      <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
+      <remap from="~/input/lanelet_map_bin" to="$(var input_vector_map_topic_name)"/>
+      <remap from="~/input/route" to="$(var input_route_topic_name)"/>
+      <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
+      <remap from="~/input/acceleration" to="/localization/acceleration"/>
+      <remap from="~/input/operational_mode_state" to="/system/operation_mode/state"/>
+      <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
+      <remap from="~/output/validation_status" to="~/validation_status"/>
+      <param name="launch_modules" value="$(var planning_validator_launch_modules)"/>
+      <param from="$(var planning_validator_param_path)"/>
+      <param from="$(var planning_validator_latency_checker_param_path)"/>
+      <param from="$(var planning_validator_trajectory_checker_param_path)"/>
+      <param from="$(var planning_validator_intersection_collision_checker_param_path)"/>
+      <param from="$(var planning_validator_rear_collision_checker_param_path)"/>
+    </node>
   </group>
 </launch>

--- a/planning/planning_validator/autoware_planning_validator/package.xml
+++ b/planning/planning_validator/autoware_planning_validator/package.xml
@@ -20,6 +20,7 @@
 
   <depend>angles</depend>
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
@@ -27,6 +28,8 @@
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_logging</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
@@ -43,7 +46,6 @@
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_planning_validator_test_utils</test_depend>
 
-  <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/planning/planning_validator/autoware_planning_validator/src/debug_marker.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/debug_marker.cpp
@@ -44,14 +44,15 @@ std_msgs::msg::ColorRGBA getColorFromId(int id)
 }
 }  // namespace
 
-PlanningValidatorDebugMarkerPublisher::PlanningValidatorDebugMarkerPublisher(rclcpp::Node * node)
+PlanningValidatorDebugMarkerPublisher::PlanningValidatorDebugMarkerPublisher(
+  autoware::agnocast_wrapper::Node * node)
 : node_(node)
 {
   debug_viz_pub_ =
-    node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/marker", 1);
+    node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/marker", rclcpp::QoS{1});
 
   virtual_wall_pub_ =
-    node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/virtual_wall", 1);
+    node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/virtual_wall", rclcpp::QoS{1});
 }
 
 void PlanningValidatorDebugMarkerPublisher::clearMarkers()

--- a/planning/planning_validator/autoware_planning_validator/src/manager.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/manager.cpp
@@ -29,7 +29,7 @@ PlanningValidatorManager::PlanningValidatorManager()
 }
 
 void PlanningValidatorManager::load_plugin(
-  rclcpp::Node & node, const std::string & name,
+  autoware::agnocast_wrapper::Node & node, const std::string & name,
   const std::shared_ptr<PlanningValidatorContext> & context)
 {
   // Check if the plugin is already loaded.
@@ -49,7 +49,8 @@ void PlanningValidatorManager::load_plugin(
   }
 }
 
-void PlanningValidatorManager::unload_plugin(rclcpp::Node & node, const std::string & name)
+void PlanningValidatorManager::unload_plugin(
+  autoware::agnocast_wrapper::Node & node, const std::string & name)
 {
   auto it = std::remove_if(loaded_plugins_.begin(), loaded_plugins_.end(), [&](const auto plugin) {
     return plugin->get_module_name() == name;

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_validator
 {
@@ -34,6 +35,10 @@ PlanningValidatorNode::PlanningValidatorNode(const rclcpp::NodeOptions & options
   sub_trajectory_ = create_subscription<Trajectory>(
     "~/input/trajectory", rclcpp::QoS{1},
     std::bind(&PlanningValidatorNode::onTrajectory, this, std::placeholders::_1));
+
+  sub_odometry_ = create_subscription<Odometry>(
+    "/localization/kinematic_state", rclcpp::QoS{1},
+    std::bind(&PlanningValidatorNode::onOdometry, this, std::placeholders::_1));
 
   // publishers
   pub_traj_ = create_publisher<Trajectory>("~/output/trajectory", 1);
@@ -55,8 +60,10 @@ PlanningValidatorNode::PlanningValidatorNode(const rclcpp::NodeOptions & options
     manager_.load_plugin(*this, name, context_);
   }
 
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  logger_configure_ = std::make_unique<
+    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>(this);
+  published_time_publisher_ = std::make_unique<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
 }
 
 void PlanningValidatorNode::setupParameters()
@@ -96,25 +103,38 @@ bool PlanningValidatorNode::isDataReady()
 void PlanningValidatorNode::setData(const Trajectory::ConstSharedPtr & traj_msg)
 {
   auto & data = context_->data;
-  data->current_kinematics = sub_kinematics_.take_data();
-  data->current_acceleration = sub_acceleration_.take_data();
-  data->obstacle_pointcloud = sub_pointcloud_.take_data();
-  data->traffic_signals = sub_traffic_signals_.take_data();
+  data->current_kinematics = sub_kinematics_->take_data();
+  data->current_acceleration = sub_acceleration_->take_data();
+  data->obstacle_pointcloud = sub_pointcloud_->take_data();
+  data->traffic_signals = sub_traffic_signals_->take_data();
   data->set_current_trajectory(traj_msg);
-  data->set_route(sub_route_.take_data());
-  data->set_map(sub_lanelet_map_bin_.take_data());
+
+  data->set_route(sub_route_->take_data());
+  data->set_map(sub_lanelet_map_bin_->take_data());
 }
 
-void PlanningValidatorNode::onTrajectory(const Trajectory::ConstSharedPtr & traj_msg)
+void PlanningValidatorNode::onOdometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Odometry) & msg)
+{
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = msg->header;
+  twist.twist = msg->twist.twist;
+  context_->vehicle_stop_checker_->addTwist(twist);
+}
+
+void PlanningValidatorNode::onTrajectory(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Trajectory) & traj_in)
 {
   stop_watch_.tic(__func__);
+
+  const Trajectory::ConstSharedPtr traj_msg =
+    traj_in ? std::make_shared<const Trajectory>(*traj_in) : nullptr;
 
   setData(traj_msg);
 
   if (!isDataReady()) return;
 
   // Check operational mode state
-  OperationModeState::ConstSharedPtr operation_mode_msg = sub_operational_state_.take_data();
+  const OperationModeState::ConstSharedPtr operation_mode_msg = sub_operational_state_->take_data();
   if (operation_mode_msg) {
     flag_autonomous_control_enabled_ = infer_autonomous_control_state(operation_mode_msg);
   }

--- a/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
+++ b/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<PlanningValidatorNode> generateNode()
 
 void publishMandatoryTopics(
   std::shared_ptr<PlanningInterfaceTestManager> test_manager,
-  std::shared_ptr<PlanningValidatorNode> test_target_node)
+  rclcpp::Node::SharedPtr test_target_node)
 {
   // publish necessary topics from test_manager
   test_manager->publishInput(
@@ -81,34 +81,35 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
+  const auto ros_node = test_target_node->get_rclcpp_node();
 
-  publishMandatoryTopics(test_manager, test_target_node);
+  publishMandatoryTopics(test_manager, ros_node);
 
   const std::string input_trajectory_topic = "planning_validator_node/input/trajectory";
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNormalTrajectory(test_target_node, input_trajectory_topic));
+  ASSERT_NO_THROW(test_manager->testWithNormalTrajectory(ros_node, input_trajectory_topic));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test for trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(
-    test_manager->testWithAbnormalTrajectory(test_target_node, input_trajectory_topic));
+  ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(ros_node, input_trajectory_topic));
 }
 
 TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
+  const auto ros_node = test_target_node->get_rclcpp_node();
 
-  publishMandatoryTopics(test_manager, test_target_node);
+  publishMandatoryTopics(test_manager, ros_node);
 
   const std::string input_trajectory_topic = "planning_validator_node/input/trajectory";
   const std::string input_odometry_topic = "planning_validator_node/input/kinematics";
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNormalTrajectory(test_target_node, input_trajectory_topic));
+  ASSERT_NO_THROW(test_manager->testWithNormalTrajectory(ros_node, input_trajectory_topic));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test for trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
+  ASSERT_NO_THROW(test_manager->testWithOffTrackOdometry(ros_node, input_odometry_topic));
 }

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/CMakeLists.txt
@@ -30,4 +30,6 @@ target_link_libraries(${PROJECT_NAME}
   intersection_collision_checker_node_parameters
 )
 
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/intersection_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/intersection_collision_checker.hpp
@@ -40,7 +40,7 @@ class IntersectionCollisionChecker : public PluginInterface
 {
 public:
   void init(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context) override;
   void validate() override;
   void setup_diag() override;
@@ -99,9 +99,9 @@ private:
 
   std::unique_ptr<intersection_collision_checker_node::ParamListener> param_listener_;
 
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_voxel_pointcloud_;
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_cluster_pointcloud_;
-  rclcpp::Publisher<StringStamped>::SharedPtr pub_string_;
+  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_voxel_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_cluster_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(StringStamped) pub_string_;
 
   intersection_collision_checker_node::Params params_;
 

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_validator</depend>

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
@@ -49,7 +49,7 @@ using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_utils::get_or_declare_parameter;
 
 void IntersectionCollisionChecker::init(
-  rclcpp::Node & node, const std::string & name,
+  autoware::agnocast_wrapper::Node & node, const std::string & name,
   const std::shared_ptr<PlanningValidatorContext> & context)
 {
   module_name_ = name;
@@ -74,8 +74,8 @@ void IntersectionCollisionChecker::init(
     node.create_publisher<StringStamped>("~/intersection_collision_checker/debug/state", 1);
 
   planning_factor_interface_ =
-    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      &node, "intersection_collision_checker");
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterfaceT<
+      autoware::agnocast_wrapper::Node>>(&node, "intersection_collision_checker");
 
   setup_diag();
 }

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/CMakeLists.txt
@@ -17,4 +17,6 @@ target_link_libraries(${PROJECT_NAME}
   ${autoware_planning_validator_LIBRARIES}
 )
 
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/include/autoware/planning_validator_latency_checker/latency_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/include/autoware/planning_validator_latency_checker/latency_checker.hpp
@@ -28,7 +28,7 @@ class LatencyChecker : public PluginInterface
 {
 public:
   void init(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context) override;
   void validate() override;
   void setup_diag() override;

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_planning_validator</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils</depend>

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/src/latency_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/src/latency_checker.cpp
@@ -25,7 +25,7 @@ namespace autoware::planning_validator
 using autoware_utils::get_or_declare_parameter;
 
 void LatencyChecker::init(
-  rclcpp::Node & node, const std::string & name,
+  autoware::agnocast_wrapper::Node & node, const std::string & name,
   const std::shared_ptr<PlanningValidatorContext> & context)
 {
   module_name_ = name;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/CMakeLists.txt
@@ -30,4 +30,6 @@ target_link_libraries(${PROJECT_NAME}
   rear_collision_checker_node_parameters
 )
 
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>angles</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -55,7 +55,7 @@ using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_utils::get_or_declare_parameter;
 
 void RearCollisionChecker::init(
-  rclcpp::Node & node, const std::string & name,
+  autoware::agnocast_wrapper::Node & node, const std::string & name,
   const std::shared_ptr<PlanningValidatorContext> & context)
 {
   module_name_ = name;
@@ -87,8 +87,8 @@ void RearCollisionChecker::init(
   time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(pub_debug_processing_time_detail_);
 
   planning_factor_interface_ =
-    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      &node, "rear_collision_checker");
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterfaceT<
+      autoware::agnocast_wrapper::Node>>(&node, "rear_collision_checker");
 
   setup_diag();
 }

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -32,7 +32,7 @@ class RearCollisionChecker : public PluginInterface
 {
 public:
   void init(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context) override;
   void validate() override;
   void setup_diag() override;
@@ -78,14 +78,13 @@ private:
   void set_diag_status(
     DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const;
 
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_voxel_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_voxel_pointcloud_;
 
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_cluster_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_cluster_pointcloud_;
 
-  rclcpp::Publisher<StringStamped>::SharedPtr pub_string_;
+  AUTOWARE_PUBLISHER_PTR(StringStamped) pub_string_;
 
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    pub_debug_processing_time_detail_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) pub_debug_processing_time_detail_;
 
   rclcpp::Time last_safe_time_;
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/CMakeLists.txt
@@ -17,7 +17,9 @@ target_link_libraries(${PROJECT_NAME}
   ${autoware_planning_validator_LIBRARIES}
 )
 
-if(BUILD_TESTING)
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
+if(BUILD_TESTING AND NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(autoware_planning_validator_test_utils REQUIRED)
   ament_add_ros_isolated_gtest(test_autoware_planning_validator
     test/test_main.cpp

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/include/autoware/planning_validator_trajectory_checker/trajectory_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/include/autoware/planning_validator_trajectory_checker/trajectory_checker.hpp
@@ -30,7 +30,7 @@ class TrajectoryChecker : public PluginInterface
 {
 public:
   void init(
-    rclcpp::Node & node, const std::string & name,
+    autoware::agnocast_wrapper::Node & node, const std::string & name,
     const std::shared_ptr<PlanningValidatorContext> & context) override;
   void validate() override;
   void setup_diag() override;
@@ -55,7 +55,7 @@ public:
   bool check_trajectory_shift();
 
 private:
-  void setup_parameters(rclcpp::Node & node);
+  void setup_parameters(autoware::agnocast_wrapper::Node & node);
 
   void set_diag_status(
     DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const;

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>angles</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_validator</depend>
   <depend>autoware_trajectory</depend>

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -34,7 +34,7 @@ namespace autoware::planning_validator
 using autoware_utils::get_or_declare_parameter;
 
 void TrajectoryChecker::init(
-  rclcpp::Node & node, const std::string & name,
+  autoware::agnocast_wrapper::Node & node, const std::string & name,
   const std::shared_ptr<PlanningValidatorContext> & context)
 {
   module_name_ = name;
@@ -49,7 +49,7 @@ void TrajectoryChecker::init(
   setup_diag();
 }
 
-void TrajectoryChecker::setup_parameters(rclcpp::Node & node)
+void TrajectoryChecker::setup_parameters(autoware::agnocast_wrapper::Node & node)
 {
   const int default_handling_value = get_or_declare_parameter<int>(node, "default_handling_type");
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker.cpp
@@ -16,6 +16,7 @@
 #include "autoware/planning_validator_trajectory_checker/utils.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/planning_validator/types.hpp>
 #include <autoware/planning_validator_test_utils/planning_validator_test_utils.hpp>
 #include <autoware/planning_validator_test_utils/test_parameters.hpp>
@@ -58,7 +59,7 @@ protected:
          "/config/test_vehicle_info.param.yaml"});
     options.append_parameter_override("trajectory_checker.interval.threshold", THRESHOLD_INTERVAL);
     options.append_parameter_override("default_handling_type", DEFAULT_HANDLING_TYPE);
-    node_ = std::make_shared<rclcpp::Node>("test_node", options);
+    node_ = std::make_shared<autoware::agnocast_wrapper::Node>("test_node", options);
     context_ = std::make_shared<PlanningValidatorContext>(node_.get());
     trajectory_checker_ = std::make_shared<TrajectoryChecker>();
     trajectory_checker_->init(*node_, "trajectory_checker", context_);
@@ -71,7 +72,7 @@ protected:
     context_.reset();
   }
 
-  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<autoware::agnocast_wrapper::Node> node_;
   std::shared_ptr<TrajectoryChecker> trajectory_checker_;
   std::shared_ptr<PlanningValidatorContext> context_;
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
@@ -98,10 +98,11 @@ public:
   std::vector<DiagnosticArray::ConstSharedPtr> received_diags_;
 };
 
-void spinSome(rclcpp::Node::SharedPtr node_ptr)
+template <class NodeT>
+void spinSome(std::shared_ptr<NodeT> node_ptr)
 {
   for (int i = 0; i < 20; ++i) {
-    rclcpp::spin_some(node_ptr);
+    rclcpp::spin_some(node_ptr->get_node_base_interface());
     rclcpp::WallRate(100).sleep();
   }
 }


### PR DESCRIPTION
## Description
Cherry-pick of autowarefoundation/autoware_universe#12964 onto `feat/v0.64/e2e_scenario_pass`.

Migrates `autoware_planning_validator` and its checker plugins to `agnocast_wrapper::Node`, moves the subscribers to the `agnocast_wrapper::polling::` API, adopts `PlanningFactorInterfaceT<Node>`, and launches the validator as a standalone node under agnocast.

  The commit applied cleanly with no conflicts and no manual modification.

  ## Related links
  
  **Parent Issue:**

  - autowarefoundation/autoware_universe#12964

  ## How was this PR tested?

  Verified upstream in autowarefoundation/autoware_universe#12964.
  Since the cherry-pick applied without any modification, the upstream verification carries over as is.

 I also ran Lsim for 10 minutes with odaiba-rinkai-map + goal pose set to make sure.

  ## Notes for reviewers

  Depends on the autoware_core side being in place: `autoware_agnocast_wrapper` (polling API, `diagnostic_updater`, tf2 wrappers) and `PlanningFactorInterfaceT<Node>`.

  ## Interface changes

  None. 

  ## Effects on system behavior
  
  None when `ENABLE_AGNOCAST` is not enabled; the node falls back to the plain rclcpp path.
