### PR TITLE
feat(autonomous_emergency_braking): apply `agnocast_wrapper::Node` to `autoware_autonomous_emergency_braking` (cherry-pick #12939)

### DIFF
--- a/control/autoware_autonomous_emergency_braking/CMakeLists.txt
+++ b/control/autoware_autonomous_emergency_braking/CMakeLists.txt
@@ -16,6 +16,7 @@ ament_auto_add_library(autoware_autonomous_emergency_braking_helpers SHARED
   include/autoware/autonomous_emergency_braking/utils.hpp
   src/utils.cpp
 )
+autoware_agnocast_wrapper_setup(autoware_autonomous_emergency_braking_helpers)
 
 set(AEB_NODE ${PROJECT_NAME}_node)
 ament_auto_add_library(${AEB_NODE} SHARED
@@ -24,12 +25,14 @@ ament_auto_add_library(${AEB_NODE} SHARED
 )
 
 target_link_libraries(${AEB_NODE} autoware_autonomous_emergency_braking_helpers)
-rclcpp_components_register_node(${AEB_NODE}
+autoware_agnocast_wrapper_register_node(${AEB_NODE}
   PLUGIN "autoware::motion::control::autonomous_emergency_braking::AEB"
   EXECUTABLE ${PROJECT_NAME}
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   ament_add_ros_isolated_gtest(test_aeb
   test/test.cpp)
 

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -17,6 +17,11 @@
 
 #include "autoware_utils/system/time_keeper.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
@@ -46,8 +51,6 @@
 #include <pcl/point_types.h>
 #include <pcl/surface/convex_hull.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <deque>
 #include <limits>
@@ -71,7 +74,7 @@ using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_utils::Polygon2d;
 using autoware_utils::Polygon3d;
 using diagnostic_updater::DiagnosticStatusWrapper;
-using diagnostic_updater::Updater;
+using Updater = autoware::agnocast_wrapper::diagnostic_updater::Updater;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
@@ -321,7 +324,7 @@ private:
 /**
  * @brief Autonomous Emergency Braking (AEB) node
  */
-class AEB : public rclcpp::Node
+class AEB : public autoware::agnocast_wrapper::Node
 {
 public:
   /**
@@ -331,27 +334,35 @@ public:
   explicit AEB(const rclcpp::NodeOptions & node_options);
 
   // subscriber
-  autoware_utils::InterProcessPollingSubscriber<PointCloud2> sub_point_cloud_{
-    this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos()};
-  autoware_utils::InterProcessPollingSubscriber<VelocityReport> sub_velocity_{
-    this, "~/input/velocity"};
-  autoware_utils::InterProcessPollingSubscriber<Imu> sub_imu_{this, "~/input/imu"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_predicted_traj_{
-    this, "~/input/predicted_trajectory"};
-  autoware_utils::InterProcessPollingSubscriber<PredictedObjects> predicted_objects_sub_{
-    this, "~/input/objects"};
-  autoware_utils::InterProcessPollingSubscriber<AutowareState> sub_autoware_state_{
-    this, "/autoware/state"};
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PointCloud2>::SharedPtr sub_point_cloud_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<PointCloud2>(
+      this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<VelocityReport>::SharedPtr sub_velocity_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<VelocityReport>(
+      this, "~/input/velocity");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Imu>::SharedPtr sub_imu_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<Imu>(this, "~/input/imu");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Trajectory>::SharedPtr
+    sub_predicted_traj_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<Trajectory>(
+        this, "~/input/predicted_trajectory");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PredictedObjects>::SharedPtr
+    predicted_objects_sub_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<PredictedObjects>(
+        this, "~/input/objects");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AutowareState>::SharedPtr
+    sub_autoware_state_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<AutowareState>(
+        this, "/autoware/state");
   // publisher
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_obstacle_pointcloud_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr virtual_wall_publisher_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr debug_rss_distance_publisher_;
-  rclcpp::Publisher<MetricArray>::SharedPtr metrics_pub_;
+  AUTOWARE_PUBLISHER_PTR(sensor_msgs::msg::PointCloud2) pub_obstacle_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) debug_marker_publisher_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) virtual_wall_publisher_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) debug_processing_time_detail_pub_;
+  AUTOWARE_PUBLISHER_PTR(tier4_debug_msgs::msg::Float32Stamped) debug_rss_distance_publisher_;
+  AUTOWARE_PUBLISHER_PTR(MetricArray) metrics_pub_;
   // timer
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   // callback
@@ -359,13 +370,13 @@ public:
    * @brief Callback for point cloud messages
    * @param input_msg Shared pointer to the point cloud message
    */
-  void onPointCloud(const PointCloud2::ConstSharedPtr input_msg);
+  void onPointCloud(const std::shared_ptr<const PointCloud2> & input_msg);
 
   /**
    * @brief Callback for IMU messages
    * @param input_msg Shared pointer to the IMU message
    */
-  void onImu(const Imu::ConstSharedPtr input_msg);
+  void onImu(const std::shared_ptr<const Imu> & input_msg);
 
   /**
    * @brief Timer callback function
@@ -535,14 +546,14 @@ public:
 
   // Member variables
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
-  VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
+  std::shared_ptr<const VelocityReport> current_velocity_ptr_{};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};
-  Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};
-  PredictedObjects::ConstSharedPtr predicted_objects_ptr_{nullptr};
-  AutowareState::ConstSharedPtr autoware_state_{nullptr};
+  std::shared_ptr<const Trajectory> predicted_traj_ptr_{};
+  std::shared_ptr<const PredictedObjects> predicted_objects_ptr_{};
+  std::shared_ptr<const AutowareState> autoware_state_{};
 
-  tf2_ros::Buffer tf_buffer_{get_clock()};
-  tf2_ros::TransformListener tf_listener_{tf_buffer_};
+  autoware::agnocast_wrapper::Buffer tf_buffer_{get_clock()};
+  autoware::agnocast_wrapper::TransformListener tf_listener_{tf_buffer_, *this};
 
   // vehicle info
   VehicleInfo vehicle_info_;
@@ -586,7 +597,7 @@ public:
   double mpc_prediction_time_interval_;
   CollisionDataKeeper collision_data_keeper_;
   // Parameter callback
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 };
 }  // namespace autoware::motion::control::autonomous_emergency_braking
 

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -111,7 +111,7 @@ Polygon2d convertObjToPolygon(const PredictedObject & obj);
  */
 std::optional<geometry_msgs::msg::TransformStamped> getTransform(
   const std::string & target_frame, const std::string & source_frame,
-  const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger);
+  const autoware::agnocast_wrapper::Buffer & tf_buffer, const rclcpp::Logger & logger);
 
 /**
  * @brief Get the predicted object's shape as a geometry polygon

--- a/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
+++ b/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
@@ -6,7 +6,10 @@
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <!-- load config files -->
     <param from="$(var param_path)"/>
     <!-- remap topic name -->

--- a/control/autoware_autonomous_emergency_braking/package.xml
+++ b/control/autoware_autonomous_emergency_braking/package.xml
@@ -21,6 +21,7 @@
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -58,6 +58,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -209,7 +210,8 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   // start time
   const double aeb_hz = declare_parameter<double>("aeb_hz");
   const auto period_ns = rclcpp::Rate(aeb_hz).period();
-  timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
 
   debug_processing_time_detail_pub_ =
     create_publisher<autoware_utils::ProcessingTimeDetail>("~/debug/processing_time_detail_ms", 1);
@@ -277,7 +279,7 @@ void AEB::onTimer()
   updater_.force_update();
 }
 
-void AEB::onImu(const Imu::ConstSharedPtr input_msg)
+void AEB::onImu(const std::shared_ptr<const Imu> & input_msg)
 {
   // transform imu
   const auto logger = get_logger();
@@ -289,7 +291,7 @@ void AEB::onImu(const Imu::ConstSharedPtr input_msg)
   tf2::doTransform(input_msg->angular_velocity, *angular_velocity_ptr_, transform_stamped.value());
 }
 
-void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
+void AEB::onPointCloud(const std::shared_ptr<const PointCloud2> & input_msg)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   PointCloud::Ptr pointcloud_ptr(new PointCloud);
@@ -342,13 +344,13 @@ bool AEB::fetchLatestData()
     return false;
   };
 
-  current_velocity_ptr_ = sub_velocity_.take_data();
+  current_velocity_ptr_ = sub_velocity_->take_data();
   if (!current_velocity_ptr_) {
     return missing("ego velocity");
   }
 
   if (use_pointcloud_data_) {
-    const auto pointcloud_ptr = sub_point_cloud_.take_data();
+    const auto pointcloud_ptr = sub_point_cloud_->take_data();
     if (!pointcloud_ptr) {
       return missing("object pointcloud message");
     }
@@ -362,12 +364,12 @@ bool AEB::fetchLatestData()
   }
 
   if (use_predicted_object_data_) {
-    predicted_objects_ptr_ = predicted_objects_sub_.take_data();
+    predicted_objects_ptr_ = predicted_objects_sub_->take_data();
     if (!predicted_objects_ptr_) {
       return missing("predicted objects");
     }
   } else {
-    predicted_objects_ptr_.reset();
+    predicted_objects_ptr_ = {};
   }
 
   if (!obstacle_ros_pointcloud_ptr_ && !predicted_objects_ptr_) {
@@ -376,7 +378,7 @@ bool AEB::fetchLatestData()
 
   const bool has_imu_path = std::invoke([&]() {
     if (!use_imu_path_) return false;
-    const auto imu_ptr = sub_imu_.take_data();
+    const auto imu_ptr = sub_imu_->take_data();
     if (!imu_ptr) {
       return missing("imu message");
     }
@@ -389,7 +391,7 @@ bool AEB::fetchLatestData()
     if (!use_predicted_trajectory_) {
       return false;
     }
-    predicted_traj_ptr_ = sub_predicted_traj_.take_data();
+    predicted_traj_ptr_ = sub_predicted_traj_->take_data();
     return (!predicted_traj_ptr_) ? missing("control predicted trajectory") : true;
   });
 
@@ -400,7 +402,7 @@ bool AEB::fetchLatestData()
     return false;
   }
 
-  autoware_state_ = sub_autoware_state_.take_data();
+  autoware_state_ = sub_autoware_state_->take_data();
   if (check_autoware_state_ && !autoware_state_) {
     return missing("autoware_state");
   }
@@ -616,9 +618,10 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
   // Debug print
   if (!filtered_objects->empty() && publish_debug_pointcloud_) {
-    const auto filtered_objects_ros_pointcloud_ptr = std::make_shared<PointCloud2>();
+    auto filtered_objects_ros_pointcloud_ptr =
+      ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_obstacle_pointcloud_);
     pcl::toROSMsg(*filtered_objects, *filtered_objects_ros_pointcloud_ptr);
-    pub_obstacle_pointcloud_->publish(*filtered_objects_ros_pointcloud_ptr);
+    pub_obstacle_pointcloud_->publish(std::move(filtered_objects_ros_pointcloud_ptr));
   }
   return has_collision;
 }

--- a/control/autoware_autonomous_emergency_braking/src/utils.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/utils.cpp
@@ -207,7 +207,7 @@ Polygon2d convertObjToPolygon(const PredictedObject & obj)
 
 std::optional<geometry_msgs::msg::TransformStamped> getTransform(
   const std::string & target_frame, const std::string & source_frame,
-  const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger)
+  const autoware::agnocast_wrapper::Buffer & tf_buffer, const rclcpp::Logger & logger)
 {
   geometry_msgs::msg::TransformStamped tf_current_pose;
   try {


### PR DESCRIPTION
## Description

  Cherry-pick of autowarefoundation/autoware_universe#12939, which applies `agnocast_wrapper::Node` to `autoware_autonomous_emergency_braking`. Applied with `git cherry-pick -x`; no conflict resolution was needed.

  ## Related links

  **Parent Issue:**

  - https://github.com/autowarefoundation/autoware_universe/pull/12939

  ## How was this PR tested?

  Already tested upstream in autowarefoundation/autoware_universe#12939.

  ## Notes for reviewers

  None.

  ## Interface changes

  None.

  ## Effects on system behavior
None when `ENABLE_AGNOCAST=0`. Will behave as `agnocast::Node` when `ENABLE_AGNOCAST=1`