### PR TITLE
feat(shift_decider): apply `agnocast_wrapper::Node` to `autoware_shift_decider` (cherry-pick #12918, #13015) 

### DIFF
--- a/control/autoware_shift_decider/CMakeLists.txt
+++ b/control/autoware_shift_decider/CMakeLists.txt
@@ -16,9 +16,11 @@ target_link_libraries(${PROJECT_NAME}_node
   shift_decider_parameters
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_node
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_node
   PLUGIN "autoware::shift_decider::ShiftDecider"
   EXECUTABLE ${PROJECT_NAME}
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(

--- a/control/autoware_shift_decider/include/autoware/shift_decider/autoware_shift_decider.hpp
+++ b/control/autoware_shift_decider/include/autoware/shift_decider/autoware_shift_decider.hpp
@@ -15,9 +15,10 @@
 #ifndef AUTOWARE__SHIFT_DECIDER__AUTOWARE_SHIFT_DECIDER_HPP_
 #define AUTOWARE__SHIFT_DECIDER__AUTOWARE_SHIFT_DECIDER_HPP_
 
-#include "autoware_utils/ros/polling_subscriber.hpp"
 #include "shift_decider_parameters.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
@@ -30,28 +31,31 @@
 namespace autoware::shift_decider
 {
 
-class ShiftDecider : public rclcpp::Node
+class ShiftDecider : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit ShiftDecider(const rclcpp::NodeOptions & node_options);
 
 private:
   void onTimer();
-  void onControlCmd(autoware_control_msgs::msg::Control::SharedPtr msg);
-  void onAutowareState(autoware_system_msgs::msg::AutowareState::SharedPtr msg);
-  void onCurrentGear(autoware_vehicle_msgs::msg::GearReport::SharedPtr msg);
   void updateCurrentShiftCmd();
   void initTimer(double period_s);
 
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_cmd_;
-  autoware_utils::InterProcessPollingSubscriber<autoware_control_msgs::msg::Control>
-    sub_control_cmd_{this, "input/control_cmd"};
-  autoware_utils::InterProcessPollingSubscriber<autoware_system_msgs::msg::AutowareState>
-    sub_autoware_state_{this, "input/state"};
-  autoware_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::GearReport>
-    sub_current_gear_{this, "input/current_gear"};
+  AUTOWARE_PUBLISHER_PTR(autoware_vehicle_msgs::msg::GearCommand) pub_shift_cmd_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    autoware_control_msgs::msg::Control>::SharedPtr sub_control_cmd_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      autoware_control_msgs::msg::Control>(this, "input/control_cmd");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    autoware_system_msgs::msg::AutowareState>::SharedPtr sub_autoware_state_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      autoware_system_msgs::msg::AutowareState>(this, "input/state");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    autoware_vehicle_msgs::msg::GearReport>::SharedPtr sub_current_gear_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      autoware_vehicle_msgs::msg::GearReport>(this, "input/current_gear");
 
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   autoware_control_msgs::msg::Control::ConstSharedPtr control_cmd_;
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;

--- a/control/autoware_shift_decider/launch/shift_decider.launch.xml
+++ b/control/autoware_shift_decider/launch/shift_decider.launch.xml
@@ -1,10 +1,14 @@
 <launch>
   <arg name="config_file" default="$(find-pkg-share autoware_shift_decider)/config/shift_decider.param.yaml"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
     <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
     <remap from="input/state" to="/autoware/state"/>
+    <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
     <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
     <param from="$(var config_file)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/control/autoware_shift_decider/package.xml
+++ b/control/autoware_shift_decider/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_utils</depend>

--- a/control/autoware_shift_decider/src/autoware_shift_decider.cpp
+++ b/control/autoware_shift_decider/src/autoware_shift_decider.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <utility>
 
 namespace autoware::shift_decider
 {
@@ -26,8 +27,6 @@ namespace autoware::shift_decider
 ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
 : Node("shift_decider", node_options)
 {
-  using std::placeholders::_1;
-
   static constexpr std::size_t queue_size = 1;
   rclcpp::QoS durable_qos(queue_size);
   durable_qos.transient_local();
@@ -44,9 +43,9 @@ ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
 
 void ShiftDecider::onTimer()
 {
-  control_cmd_ = sub_control_cmd_.take_data();
-  autoware_state_ = sub_autoware_state_.take_data();
-  current_gear_ptr_ = sub_current_gear_.take_data();
+  control_cmd_ = sub_control_cmd_->take_data();
+  autoware_state_ = sub_autoware_state_->take_data();
+  current_gear_ptr_ = sub_current_gear_->take_data();
   if (!autoware_state_ || !control_cmd_ || !current_gear_ptr_) {
     return;
   }
@@ -87,8 +86,8 @@ void ShiftDecider::initTimer(double period_s)
 {
   const auto period_ns =
     std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(period_s));
-  timer_ =
-    rclcpp::create_timer(this, get_clock(), period_ns, std::bind(&ShiftDecider::onTimer, this));
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), period_ns, std::bind(&ShiftDecider::onTimer, this));
 }
 }  // namespace autoware::shift_decider
 

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -165,16 +165,16 @@
         </composable_node>
       </node_container>
 
-      <!-- Load shift decider as composable node -->
-      <load_composable_node target="/e2e_control_container">
-        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-          <param from="$(find-pkg-share $(var launch_config_pkg))/config/control/shift_decider/shift_decider.param.yaml"/>
-          <remap from="input/control_cmd" to="/trajectory_follower/control_cmd"/>
-          <remap from="input/state" to="/autoware/state"/>
-          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-        </composable_node>
-      </load_composable_node>
+      <!-- shift_decider runs as standalone node -->
+      <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+      <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
+        <param from="$(find-pkg-share $(var launch_config_pkg))/config/control/shift_decider/shift_decider.param.yaml"/>
+        <remap from="input/control_cmd" to="/trajectory_follower/control_cmd"/>
+        <remap from="input/state" to="/autoware/state"/>
+        <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+        <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+        <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      </node>
 
       <node pkg="topic_tools" exec="relay" name="trajectory_follower_control_cmd_relay" output="log" args="/trajectory_follower/control_cmd /trajectory_follower_control_cmd"/>
 

--- a/simulator/autoware_carla_interface/package.xml
+++ b/simulator/autoware_carla_interface/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_external_cmd_selector</exec_depend>
   <exec_depend>autoware_twist2accel</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>


### PR DESCRIPTION
 ## Description

  Cherry-pick of the following upstream PRs, which apply `agnocast_wrapper::Node` to `autoware_shift_decider` and launch it as a standalone node under agnocast:

  - autowarefoundation/autoware_universe#12918
  - autowarefoundation/autoware_universe#13015 (carla_interface launch)

  Applied with `git cherry-pick -x`; no conflict resolution was needed.

  ## Related links

  **Parent Issue:**

  - https://github.com/autowarefoundation/autoware_universe/pull/12918
  - https://github.com/autowarefoundation/autoware_universe/pull/13015

  ## How was this PR tested?

  Already tested upstream in the PRs listed above.
 I also ran Lsim for 10 minutes with odaiba-rinkai-map + goal pose set to make sure.


  ## Notes for reviewers

  The autoware_launch counterpart (autowarefoundation/autoware_launch#1921) has to be merged before this PR.

  ## Interface changes

  None.

  ## Effects on system behavior
None when ENABLE_AGNOCAST=0. Will behave as agnocast::Node when ENABLE_AGNOCAST=1