### PR TITLE
feat(collision_detector): apply `agnocast_wrapper::Node` to `autoware_collision_detector` (cherry-pick #12953, #13032)

### DIFF
--- a/control/autoware_collision_detector/CMakeLists.txt
+++ b/control/autoware_collision_detector/CMakeLists.txt
@@ -21,9 +21,11 @@ target_link_libraries(${PROJECT_NAME}
   ${PCL_LIBRARIES}
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::collision_detector::CollisionDetectorNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
@@ -124,16 +125,22 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   // publisher and subscriber
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(nav_msgs::msg::Odometry)
-  sub_odometry_ = create_polling_subscriber<nav_msgs::msg::Odometry>("~/input/odometry");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(sensor_msgs::msg::PointCloud2)
-  sub_pointcloud_ = create_polling_subscriber<sensor_msgs::msg::PointCloud2>(
-    "~/input/pointcloud", autoware_utils::single_depth_sensor_qos());
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
-  sub_dynamic_objects_ = create_polling_subscriber<PredictedObjects>("~/input/objects");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(OperationModeState)
-  sub_operation_mode_ = create_polling_subscriber<OperationModeState>(
-    "/api/operation_mode/state", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<nav_msgs::msg::Odometry>::SharedPtr
+    sub_odometry_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<nav_msgs::msg::Odometry>(
+        this, "~/input/odometry");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<sensor_msgs::msg::PointCloud2>::SharedPtr
+    sub_pointcloud_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<sensor_msgs::msg::PointCloud2>(
+        this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PredictedObjects>::SharedPtr
+    sub_dynamic_objects_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<PredictedObjects>(
+        this, "~/input/objects");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<OperationModeState>::SharedPtr
+    sub_operation_mode_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<OperationModeState>(
+        this, "/api/operation_mode/state", rclcpp::QoS{1}.transient_local());
   AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray)
   pub_debug_ = create_publisher<visualization_msgs::msg::MarkerArray>("~/debug_markers", 1);
 
@@ -142,10 +149,10 @@ private:
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
   // data
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) odometry_ptr_;
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::PointCloud2) pointcloud_ptr_;
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(PredictedObjects) object_ptr_;
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(OperationModeState) operation_mode_ptr_;
+  std::shared_ptr<const nav_msgs::msg::Odometry> odometry_ptr_;
+  std::shared_ptr<const sensor_msgs::msg::PointCloud2> pointcloud_ptr_;
+  std::shared_ptr<const PredictedObjects> object_ptr_;
+  std::shared_ptr<const OperationModeState> operation_mode_ptr_;
   std::optional<rclcpp::Time> start_of_consecutive_collision_stamp_;
   std::optional<rclcpp::Time> most_recent_collision_stamp_;
   bool is_error_diag_ = false;

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -15,12 +15,14 @@
 #ifndef AUTOWARE__COLLISION_DETECTOR__NODE_HPP_
 #define AUTOWARE__COLLISION_DETECTOR__NODE_HPP_
 
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/subscription.hpp>
 #include <tf2/utils.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
@@ -31,9 +33,6 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <boost/optional.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <memory>
 #include <string>
@@ -50,7 +49,7 @@ using autoware_perception_msgs::msg::Shape;
 
 using Obstacle = std::pair<double /* distance */, geometry_msgs::msg::Point>;
 
-class CollisionDetectorNode : public rclcpp::Node
+class CollisionDetectorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit CollisionDetectorNode(const rclcpp::NodeOptions & node_options);
@@ -120,31 +119,33 @@ private:
     double duration_sec) const;
 
   // ros
-  mutable tf2_ros::Buffer tf_buffer_{get_clock()};
-  mutable tf2_ros::TransformListener tf_listener_{tf_buffer_};
+  mutable autoware::agnocast_wrapper::Buffer tf_buffer_{get_clock()};
+  mutable autoware::agnocast_wrapper::TransformListener tf_listener_{tf_buffer_, *this};
   rclcpp::TimerBase::SharedPtr timer_;
 
   // publisher and subscriber
-  autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry> sub_odometry_{
-    this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2> sub_pointcloud_{
-    this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos()};
-  autoware_utils::InterProcessPollingSubscriber<PredictedObjects> sub_dynamic_objects_{
-    this, "~/input/objects"};
-  autoware_utils::InterProcessPollingSubscriber<autoware_adapi_v1_msgs::msg::OperationModeState>
-    sub_operation_mode_{this, "/api/operation_mode/state", rclcpp::QoS{1}.transient_local()};
-  std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> pub_debug_ =
-    create_publisher<visualization_msgs::msg::MarkerArray>("~/debug_markers", 1);
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(nav_msgs::msg::Odometry)
+  sub_odometry_ = create_polling_subscriber<nav_msgs::msg::Odometry>("~/input/odometry");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(sensor_msgs::msg::PointCloud2)
+  sub_pointcloud_ = create_polling_subscriber<sensor_msgs::msg::PointCloud2>(
+    "~/input/pointcloud", autoware_utils::single_depth_sensor_qos());
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
+  sub_dynamic_objects_ = create_polling_subscriber<PredictedObjects>("~/input/objects");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(OperationModeState)
+  sub_operation_mode_ = create_polling_subscriber<OperationModeState>(
+    "/api/operation_mode/state", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray)
+  pub_debug_ = create_publisher<visualization_msgs::msg::MarkerArray>("~/debug_markers", 1);
 
   // parameter
   NodeParam node_param_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
   // data
-  nav_msgs::msg::Odometry::ConstSharedPtr odometry_ptr_;
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_ptr_;
-  PredictedObjects::ConstSharedPtr object_ptr_;
-  OperationModeState::ConstSharedPtr operation_mode_ptr_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) odometry_ptr_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::PointCloud2) pointcloud_ptr_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(PredictedObjects) object_ptr_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(OperationModeState) operation_mode_ptr_;
   std::optional<rclcpp::Time> start_of_consecutive_collision_stamp_;
   std::optional<rclcpp::Time> most_recent_collision_stamp_;
   bool is_error_diag_ = false;
@@ -153,9 +154,9 @@ private:
   std::vector<TimestampedObject> ignored_objects_;
 
   // Diagnostic Updater
-  diagnostic_updater::Updater updater_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
 
-  std::unique_ptr<autoware::motion_utils::VehicleStopChecker> vehicle_stop_checker_;
+  std::unique_ptr<autoware::motion_utils::VehicleStopCheckerBase> vehicle_stop_checker_;
 };
 }  // namespace autoware::collision_detector
 

--- a/control/autoware_collision_detector/launch/collision_detector.launch.xml
+++ b/control/autoware_collision_detector/launch/collision_detector.launch.xml
@@ -3,10 +3,15 @@
 
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
   <node pkg="autoware_collision_detector" exec="autoware_collision_detector_node" name="collision_detector" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var param_path)"/>
     <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
     <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
   </node>
 </launch>

--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -19,6 +19,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -180,7 +180,9 @@ CollisionDetectorNode::CollisionDetectorNode(const rclcpp::NodeOptions & node_op
   updater_.add("collision_detect", this, &CollisionDetectorNode::checkCollision);
   updater_.setPeriod(0.1);
 
-  vehicle_stop_checker_ = std::make_unique<autoware::motion_utils::VehicleStopChecker>(this);
+  constexpr double vehicle_velocity_buffer_time_sec = 10.0;
+  vehicle_stop_checker_ = std::make_unique<autoware::motion_utils::VehicleStopCheckerBase>(
+    this, vehicle_velocity_buffer_time_sec);
 }
 
 PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & input_objects)
@@ -346,7 +348,7 @@ bool CollisionDetectorNode::shouldBeExcluded(
 
 void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  odometry_ptr_ = sub_odometry_.take_data();
+  odometry_ptr_ = sub_odometry_->take_data();
 
   if (!odometry_ptr_) {
     RCLCPP_INFO_THROTTLE(
@@ -354,15 +356,20 @@ void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusW
     return;
   }
 
+  geometry_msgs::msg::TwistStamped current_velocity;
+  current_velocity.header = odometry_ptr_->header;
+  current_velocity.twist = odometry_ptr_->twist.twist;
+  vehicle_stop_checker_->addTwist(current_velocity);
+
   if (vehicle_stop_checker_->isVehicleStopped()) {
     is_error_diag_ = false;
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "vehicle is stopping");
     return;
   }
 
-  pointcloud_ptr_ = sub_pointcloud_.take_data();
-  object_ptr_ = sub_dynamic_objects_.take_data();
-  operation_mode_ptr_ = sub_operation_mode_.take_data();
+  pointcloud_ptr_ = sub_pointcloud_->take_data();
+  object_ptr_ = sub_dynamic_objects_->take_data();
+  operation_mode_ptr_ = sub_operation_mode_->take_data();
 
   if (node_param_.use_pointcloud && !pointcloud_ptr_) {
     RCLCPP_WARN_THROTTLE(
@@ -438,7 +445,9 @@ void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusW
 
   stat.summary(status.level, status.message);
 
-  pub_debug_->publish(generate_debug_markers(ego_polygon, nearest_obstacle, is_error_diag_));
+  auto debug_markers = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_debug_);
+  *debug_markers = generate_debug_markers(ego_polygon, nearest_obstacle, is_error_diag_);
+  pub_debug_->publish(std::move(debug_markers));
 }
 
 std::optional<Obstacle> CollisionDetectorNode::getNearestObstacle(


### PR DESCRIPTION
 ## Description

  Cherry-pick of the following upstream PRs:

  - autowarefoundation/autoware_universe#12953 — apply `agnocast_wrapper::Node` to `autoware_collision_detector`
  - autowarefoundation/autoware_universe#13032 — migrate to the `polling::` API

  Both are needed: #12953 alone uses `AUTOWARE_POLLING_SUBSCRIBER_PTR` and the node member `create_polling_subscriber()`, which no longer exist in the current `autoware_agnocast_wrapper`. #13032 replaces them with `agnocast_wrapper::polling::`.

  Applied with `git cherry-pick -x` in that order; no conflict resolution was needed.


  ## Related links

  **Parent Issue:**

  - https://github.com/autowarefoundation/autoware_universe/pull/12953
  - https://github.com/autowarefoundation/autoware_universe/pull/13032

  ## How was this PR tested?

  Already tested upstream in the PRs listed above.
 I also ran Lsim for 10 minutes with odaiba-rinkai-map + goal pose set to make sure.


  ## Notes for reviewers

  This covers `autoware_collision_detector` only. `autoware_spheric_collision_detector` is untouched.

  ## Interface changes

  None.

  ## Effects on system behavior

None when ENABLE_AGNOCAST=0. Will behave as agnocast::Node when ENABLE_AGNOCAST=1.