### PR TITLE
feat(control_evaluator): apply `agnocast_wrapper::Node` to `autoware_control_evaluator` (cherry-pick #12963, #13033)

### DIFF
--- a/evaluator/autoware_control_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_control_evaluator/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(control_evaluator_node SHARED
   DIRECTORY src
 )
 
-rclcpp_components_register_node(control_evaluator_node
+autoware_agnocast_wrapper_register_node(control_evaluator_node
   PLUGIN "control_diagnostics::ControlEvaluatorNode"
   EXECUTABLE control_evaluator
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -20,6 +20,7 @@
 #include "autoware_utils/math/accumulator.hpp"
 
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -98,27 +99,39 @@ public:
   void onTimer();
 
 private:
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry)
-  odometry_sub_ = create_polling_subscriber<Odometry>("~/input/odometry");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped)
-  accel_sub_ = create_polling_subscriber<AccelWithCovarianceStamped>("~/input/acceleration");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory)
-  traj_sub_ = create_polling_subscriber<Trajectory>("~/input/trajectory");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest)
-  route_subscriber_ =
-    create_polling_subscriber<LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest>(
-      "~/input/route", rclcpp::QoS{1}.transient_local());
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest)
-  vector_map_subscriber_ =
-    create_polling_subscriber<LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest>(
-      "~/input/vector_map", rclcpp::QoS{1}.transient_local());
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId)
-  behavior_path_subscriber_ = create_polling_subscriber<PathWithLaneId>("~/input/behavior_path");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport)
-  steering_sub_ = create_polling_subscriber<SteeringReport>("~/input/steering_status");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
-  objects_sub_ = create_polling_subscriber<PredictedObjects>("~/input/objects");
-  std::unordered_map<std::string, AUTOWARE_POLLING_SUBSCRIBER_PTR(PlanningFactorArray)>
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr odometry_sub_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
+      this, "~/input/odometry");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+    accel_sub_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(
+        this, "~/input/acceleration");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Trajectory>::SharedPtr traj_sub_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<Trajectory>(
+      this, "~/input/trajectory");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr
+    route_subscriber_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>(
+      this, "~/input/route", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletMapBin, autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr
+    vector_map_subscriber_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletMapBin, autoware::agnocast_wrapper::polling::polling_policy::Newest>(
+      this, "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PathWithLaneId>::SharedPtr
+    behavior_path_subscriber_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<PathWithLaneId>(
+        this, "~/input/behavior_path");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<SteeringReport>::SharedPtr steering_sub_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<SteeringReport>(
+      this, "~/input/steering_status");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<PredictedObjects>::SharedPtr objects_sub_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<PredictedObjects>(
+      this, "~/input/objects");
+  std::unordered_map<
+    std::string,
+    autoware::agnocast_wrapper::polling::PollingSubscriber<PlanningFactorArray>::SharedPtr>
     planning_factors_sub_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_abs_accumulators_;

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -19,9 +19,9 @@
 #include "autoware/control_evaluator/metrics/metric.hpp"
 #include "autoware_utils/math/accumulator.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils_math/accumulator.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
@@ -72,7 +72,7 @@ using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 /**
  * @brief Node for control evaluation
  */
-class ControlEvaluatorNode : public rclcpp::Node
+class ControlEvaluatorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
@@ -98,32 +98,34 @@ public:
   void onTimer();
 
 private:
-  autoware_utils::InterProcessPollingSubscriber<Odometry> odometry_sub_{this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
-    this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{this, "~/input/trajectory"};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletRoute, autoware_utils::polling_policy::Newest>
-    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletMapBin, autoware_utils::polling_policy::Newest>
-    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<PathWithLaneId> behavior_path_subscriber_{
-    this, "~/input/behavior_path"};
-  autoware_utils::InterProcessPollingSubscriber<SteeringReport> steering_sub_{
-    this, "~/input/steering_status"};
-  autoware_utils::InterProcessPollingSubscriber<PredictedObjects> objects_sub_{
-    this, "~/input/objects"};
-  std::unordered_map<
-    std::string, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>>
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry)
+  odometry_sub_ = create_polling_subscriber<Odometry>("~/input/odometry");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped)
+  accel_sub_ = create_polling_subscriber<AccelWithCovarianceStamped>("~/input/acceleration");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory)
+  traj_sub_ = create_polling_subscriber<Trajectory>("~/input/trajectory");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest)
+  route_subscriber_ =
+    create_polling_subscriber<LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest>(
+      "~/input/route", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest)
+  vector_map_subscriber_ =
+    create_polling_subscriber<LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest>(
+      "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId)
+  behavior_path_subscriber_ = create_polling_subscriber<PathWithLaneId>("~/input/behavior_path");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport)
+  steering_sub_ = create_polling_subscriber<SteeringReport>("~/input/steering_status");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
+  objects_sub_ = create_polling_subscriber<PredictedObjects>("~/input/objects");
+  std::unordered_map<std::string, AUTOWARE_POLLING_SUBSCRIBER_PTR(PlanningFactorArray)>
     planning_factors_sub_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_abs_accumulators_;
   std::unordered_set<std::string> stop_deviation_modules_;
 
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    processing_time_pub_;
-  rclcpp::Publisher<MetricArrayMsg>::SharedPtr metrics_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped) processing_time_pub_;
+  AUTOWARE_PUBLISHER_PTR(MetricArrayMsg) metrics_pub_;
 
   // update Route Handler
   void getRouteData();
@@ -173,7 +175,7 @@ private:
   MetricArrayMsg metrics_msg_;
   VehicleInfo vehicle_info_;
   autoware::route_handler::RouteHandler route_handler_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
   std::optional<double> prev_steering_angle_{std::nullopt};
   std::optional<double> prev_steering_rate_{std::nullopt};

--- a/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
+++ b/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
@@ -9,9 +9,12 @@
   <arg name="input/steering_status" default="/vehicle/status/steering_status"/>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <!-- control evaluator -->
   <group>
     <node name="control_evaluator" exec="control_evaluator" pkg="autoware_control_evaluator">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <param from="$(find-pkg-share autoware_control_evaluator)/config/control_evaluator.param.yaml"/>
       <param name="output_metrics" value="$(var output_metrics)"/>
       <remap from="~/input/odometry" to="$(var input/odometry)"/>

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_deprecated_boundary_departure_checker</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -94,7 +94,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   for (const auto & module_name : stop_deviation_modules_) {
     planning_factors_sub_.emplace(
       module_name,
-      this->create_polling_subscriber<PlanningFactorArray>(topic_prefix + module_name));
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<PlanningFactorArray>(
+        this, topic_prefix + module_name));
     stop_deviation_accumulators_.emplace(module_name, Accumulator<double>());
     stop_deviation_abs_accumulators_.emplace(module_name, Accumulator<double>());
   }

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -93,8 +93,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
     declare_parameter<std::string>("planning_factor_metrics.topic_prefix");
   for (const auto & module_name : stop_deviation_modules_) {
     planning_factors_sub_.emplace(
-      module_name, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>(
-                     this, topic_prefix + module_name));
+      module_name,
+      this->create_polling_subscriber<PlanningFactorArray>(topic_prefix + module_name));
     stop_deviation_accumulators_.emplace(module_name, Accumulator<double>());
     stop_deviation_abs_accumulators_.emplace(module_name, Accumulator<double>());
   }
@@ -142,8 +142,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
 
   // Timer callback to publish evaluator diagnostics
   using namespace std::literals::chrono_literals;
-  timer_ =
-    rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
 }
 
 ControlEvaluatorNode::~ControlEvaluatorNode()
@@ -231,7 +231,7 @@ void ControlEvaluatorNode::getRouteData()
 {
   // route
   {
-    const auto msg = route_subscriber_.take_data();
+    const auto msg = route_subscriber_->take_data();
     if (msg) {
       if (msg->segments.empty()) {
         RCLCPP_ERROR(get_logger(), "input route is empty. ignored");
@@ -243,7 +243,7 @@ void ControlEvaluatorNode::getRouteData()
 
   // map
   {
-    const auto msg = vector_map_subscriber_.take_data();
+    const auto msg = vector_map_subscriber_->take_data();
     if (msg) {
       route_handler_.setMap(*msg);
     }
@@ -546,8 +546,7 @@ void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 
 void ControlEvaluatorNode::AddStopDeviationMetricMsg()
 {
-  const auto get_min_distance_signed =
-    [](const PlanningFactorArray::ConstSharedPtr & planning_factors) -> std::optional<double> {
+  const auto get_min_distance_signed = [](const auto & planning_factors) -> std::optional<double> {
     std::optional<double> min_distance = std::nullopt;
     for (const auto & factor : planning_factors->factors) {
       if (factor.behavior == PlanningFactor::STOP) {
@@ -565,7 +564,7 @@ void ControlEvaluatorNode::AddStopDeviationMetricMsg()
   // get min_distance from each module
   std::vector<std::pair<std::string, double>> min_distances;
   for (auto & [module_name, planning_factor_sub_] : planning_factors_sub_) {
-    const auto planning_factors = planning_factor_sub_.take_data();
+    const auto planning_factors = planning_factor_sub_->take_data();
     if (
       !planning_factors || planning_factors->factors.empty() ||
       stop_deviation_modules_.count(module_name) == 0) {
@@ -666,7 +665,7 @@ void ControlEvaluatorNode::onTimer()
 {
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
-  const auto odom = odometry_sub_.take_data();
+  const auto odom = odometry_sub_->take_data();
   if (odom) {
     const Pose ego_pose = odom->pose.pose;
     ego_speed_ = std::abs(odom->twist.twist.linear.x);
@@ -675,19 +674,19 @@ void ControlEvaluatorNode::onTimer()
     AddStopDeviationMetricMsg();
 
     // add object related metrics
-    const auto objects = objects_sub_.take_data();
+    const auto objects = objects_sub_->take_data();
     if (objects) {
       AddObjectMetricMsg(*odom, *objects);
     }
 
     // add kinematic info
-    const auto acc = accel_sub_.take_data();
+    const auto acc = accel_sub_->take_data();
     if (acc) {
       AddKinematicStateMetricMsg(*odom, *acc);
     }
 
     // add deviation metrics
-    const auto traj = traj_sub_.take_data();
+    const auto traj = traj_sub_->take_data();
     if (traj && !traj->points.empty()) {
       AddLateralDeviationMetricMsg(*traj, ego_pose.position);
       AddYawDeviationMetricMsg(*traj, ego_pose);
@@ -702,7 +701,7 @@ void ControlEvaluatorNode::onTimer()
       AddGoalDeviationMetricMsg(*odom);
 
       // add boundary distance metrics
-      const auto behavior_path = behavior_path_subscriber_.take_data();
+      const auto behavior_path = behavior_path_subscriber_->take_data();
       if (behavior_path) {
         AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
       }
@@ -711,7 +710,7 @@ void ControlEvaluatorNode::onTimer()
   }
 
   // add steering metrics
-  const auto steering_status = steering_sub_.take_data();
+  const auto steering_status = steering_sub_->take_data();
   if (steering_status) {
     AddSteeringMetricMsg(*steering_status);
   }

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -57,6 +57,11 @@ class EvalTest : public ::testing::Test
 protected:
   void SetUp() override
   {
+    const auto * const enable_agnocast = std::getenv("ENABLE_AGNOCAST");
+    if (enable_agnocast != nullptr && std::string(enable_agnocast) == "1") {
+      GTEST_SKIP() << "This test launches a node and is skipped under ENABLE_AGNOCAST=1";
+    }
+
     rclcpp::init(0, nullptr);
 
     rclcpp::NodeOptions options;
@@ -236,7 +241,7 @@ protected:
 
   void spin_some()
   {
-    rclcpp::spin_some(eval_node);
+    rclcpp::spin_some(eval_node->get_node_base_interface());
     rclcpp::spin_some(dummy_node);
     rclcpp::sleep_for(std::chrono::milliseconds(100));
   }


### PR DESCRIPTION
  ## Description

  Cherry-pick of the following upstream PRs:

  - autowarefoundation/autoware_universe#12963 — apply `agnocast_wrapper::Node` to `autoware_control_evaluator`
  - autowarefoundation/autoware_universe#13033 — migrate to the `polling::` API

  Both are needed: #12963 alone uses `AUTOWARE_POLLING_SUBSCRIBER_PTR`, the node member `create_polling_subscriber()`, and `agnocast_wrapper::polling_policy`, none of which exist in the current `autoware_agnocast_wrapper`. #13033 replaces them with `agnocast_wrapper::polling::`.
  Applied with `git cherry-pick -x` in that order; no conflict resolution was needed.


  ## Related links

  **Parent Issue:**

  - https://github.com/autowarefoundation/autoware_universe/pull/12963
  - https://github.com/autowarefoundation/autoware_universe/pull/13033

  ## How was this PR tested?

  Already tested upstream in the PRs listed above.
 I also ran Lsim for 10 minutes with odaiba-rinkai-map + goal pose set to make sure.


  ## Notes for reviewers

  None.

  ## Interface changes

  None.

  ## Effects on system behavior


None when ENABLE_AGNOCAST=0. Will behave as agnocast::Node when ENABLE_AGNOCAST=1